### PR TITLE
Idempotent instructions - set position

### DIFF
--- a/programs/margin-pool/src/instructions/deposit.rs
+++ b/programs/margin-pool/src/instructions/deposit.rs
@@ -79,7 +79,7 @@ impl<'info> Deposit<'info> {
     }
 }
 
-pub fn deposit_handler(ctx: Context<Deposit>, token_amount: u64) -> Result<()> {
+pub fn deposit_handler(ctx: Context<Deposit>, amount: Amount) -> Result<()> {
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/margin_borrow.rs
+++ b/programs/margin-pool/src/instructions/margin_borrow.rs
@@ -89,7 +89,7 @@ impl<'info> MarginBorrow<'info> {
     }
 }
 
-pub fn margin_borrow_handler(ctx: Context<MarginBorrow>, token_amount: u64) -> Result<()> {
+pub fn margin_borrow_handler(ctx: Context<MarginBorrow>, amount: Amount) -> Result<()> {
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/margin_repay.rs
+++ b/programs/margin-pool/src/instructions/margin_repay.rs
@@ -80,7 +80,7 @@ impl<'info> MarginRepay<'info> {
     }
 }
 
-pub fn margin_repay_handler(ctx: Context<MarginRepay>, max_amount: Amount) -> Result<()> {
+pub fn margin_repay_handler(ctx: Context<MarginRepay>, amount: Amount) -> Result<()> {
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -92,11 +92,11 @@ mod jet_margin_pool {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy)]
 pub enum AmountKind {
-    Tokens,
-    Notes,
+    ShiftBalance,
+    SetBalance,
 }
 
-/// Represent an amount of some value (like tokens, or notes)
+/// Represent an amount of tokens
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy)]
 pub struct Amount {
     pub kind: AmountKind,
@@ -104,16 +104,16 @@ pub struct Amount {
 }
 
 impl Amount {
-    pub const fn tokens(value: u64) -> Self {
+    pub const fn shift(value: u64) -> Self {
         Self {
-            kind: AmountKind::Tokens,
+            kind: AmountKind::ShiftBalance,
             value,
         }
     }
 
     pub const fn notes(value: u64) -> Self {
         Self {
-            kind: AmountKind::Notes,
+            kind: AmountKind::SetBalance,
             value,
         }
     }


### PR DESCRIPTION
This PR proposes removing the ability to specify notes.
The position can still be added/subtracted from. A new parameter is added to set position to an exact amount.

### When setting the position
Deposit, Borrow
- If the token value of position is already >= value, the instruction is a no-op
- The token value of position is set to value
- Token value of position is guaranteed to be >= value

Withdraw, Repay
- If the token value of position is already <= value, the instruction is a no-op
- The token value of position is set to value
- Token value of position is guaranteed to be <= value

### When shifting the position
This is the same as the current implementation
Deposit, Borrow
- token value of position += value

Withdraw, Repay
- token value of position -= value

### Simplifying clients
This would greatly simplify client libraries because it wouldn't need to expose notes in its api. Integrators wouldn't need to know to pay all notes to close a position, nor would note balances be found in the typescript classes