### PR TITLE
Make precommit hooks opt-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ target
 **/*.rs.bk
 node_modules
 lcov.info
-.husky/pre-commit
+.husky

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 **/*.rs.bk
 node_modules
 lcov.info
+.husky/pre-commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run precommit
+# Personalize precommit hooks in this file. For example:
+# npm run precommit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-# Personalize precommit hooks in this file. For example:
-# npm run precommit


### PR DESCRIPTION
This change makes husky precommit hooks opt-in rather than enabled by default. To opt-in, you can execute:
```bash
npx husky add .husky/pre-commit 'npm run precommit'
```
Any precommit checks you add to this file will be local and not propagate to anyone else.

There is another question about whether the precommit script should be changed but that can be negotiated by the users of precommit checks in another PR.

### Justification
Pre-commit hooks are run locally on the developer's machine and can be skipped already. It's an individual developer's decision whether to use them, and which hooks to use, so we should enable that decision rather than imposing the same hooks on everyone. It's easier to opt-in than it is to opt-out.
- `git add .` is problematic because it makes you blindly commit changes you may have been careful to avoid adding.
- `npm run fmt:fix` is not very useful without `git add .`
- `npm run compile && npm run lint` does not make any guarantees about the integrity of the code on github because it can be easily skipped locally