### PR TITLE
fix issues with running on 1.10.x

### DIFF
--- a/libraries/ts/src/margin/pool/marginPool.ts
+++ b/libraries/ts/src/margin/pool/marginPool.ts
@@ -449,13 +449,7 @@ export class MarginPool {
 
     const tokenMetadata = await marginAccount.getTokenMetadata(this.addresses.tokenMint)
 
-    const data = Buffer.from(Uint8Array.of(0, ...new BN(500000).toArray("le", 4)))
-    const additionalComputeBudgetInstruction = new TransactionInstruction({
-      keys: [],
-      programId: new PublicKey("ComputeBudget111111111111111111111111111111"),
-      data
-    })
-    const ix: TransactionInstruction[] = [additionalComputeBudgetInstruction]
+    const ix: TransactionInstruction[] = []
     await this.withAdapterInvoke(
       ix,
       marginAccount.owner,

--- a/programs/control/src/instructions/configure_token.rs
+++ b/programs/control/src/instructions/configure_token.rs
@@ -105,6 +105,7 @@ impl<'info> ConfigureToken<'info> {
     }
 }
 
+#[inline(never)]
 pub fn configure_token_handler(
     ctx: Context<ConfigureToken>,
     metadata: Option<TokenMetadataParams>,

--- a/programs/control/src/instructions/register_token.rs
+++ b/programs/control/src/instructions/register_token.rs
@@ -160,6 +160,7 @@ impl<'info> RegisterToken<'info> {
     }
 }
 
+#[inline(never)]
 pub fn register_token_handler(ctx: Context<RegisterToken>) -> Result<()> {
     let authority = [&ctx.accounts.authority.seed[..]];
 

--- a/programs/margin-pool/src/instructions/margin_borrow.rs
+++ b/programs/margin-pool/src/instructions/margin_borrow.rs
@@ -58,9 +58,6 @@ pub struct MarginBorrow<'info> {
 
 impl<'info> MarginBorrow<'info> {
     fn mint_loan_context(&self) -> CpiContext<'_, '_, '_, 'info, MintTo<'info>> {
-        msg!("loan_mint = {:?}", self.loan_note_mint.to_account_info());
-        msg!("loan_to = {:?}", self.loan_account.to_account_info());
-        msg!("loan_authority = {:?}", self.margin_pool.to_account_info());
         CpiContext::new(
             self.token_program.to_account_info(),
             MintTo {
@@ -72,12 +69,6 @@ impl<'info> MarginBorrow<'info> {
     }
 
     fn mint_deposit_context(&self) -> CpiContext<'_, '_, '_, 'info, MintTo<'info>> {
-        msg!("deposit_mint = {:?}", self.loan_note_mint.to_account_info());
-        msg!("deposit_to = {:?}", self.loan_account.to_account_info());
-        msg!(
-            "deposit_authority = {:?}",
-            self.margin_pool.to_account_info()
-        );
         CpiContext::new(
             self.token_program.to_account_info(),
             MintTo {
@@ -114,8 +105,6 @@ pub fn margin_borrow_handler(ctx: Context<MarginBorrow>, token_amount: u64) -> R
     let pool = &ctx.accounts.margin_pool;
     let signer = [&pool.signer_seeds()?[..]];
 
-    msg!("borrow_amount.notes =  {}", borrow_amount.notes);
-    msg!("deposit_amount.notes =  {}\n", deposit_amount.notes);
     token::mint_to(
         ctx.accounts.mint_loan_context().with_signer(&signer),
         borrow_amount.notes,


### PR DESCRIPTION
- add hint for compiler to stop inlining
- remove unnecessary logs from `margin_borrow` to fit in compute limit
- remove use of unstable feature in ts lib to raise compute limits for
  `margin_borrow`