### PR TITLE
update/remove-dgraph

### DIFF
--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -53,15 +53,6 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     needs: [build-cli-deps]
-    services:
-      dgraph:
-        image: dgraph/standalone:v21.12.0
-        ports:
-          - "15080:5080"
-          - "16080:6080"
-          - "18080:8080"
-          - "19080:9080"
-          - "18000:8000"
     steps:
       - id: cache-cli-deps
         uses: actions/cache@v3


### PR DESCRIPTION
removes the `dgraph` docker service from the `rust_coverage` workflow since the liquidator is no longer in this repository.