### PR TITLE
Addresses repayment edge case

### DIFF
--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -148,4 +148,7 @@ pub enum ErrorCode {
 
     /// 141106 - The oracle account is not valid
     InvalidOracle,
+
+    /// 141107 - Attempt repayment of more tokens than total outstanding
+    RepaymentExceedsTotalOutstanding,
 }

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -166,7 +166,18 @@ impl MarginPool {
             .checked_sub(amount.notes)
             .ok_or(ErrorCode::InsufficientLiquidity)?;
 
-        *self.total_borrowed_mut() -= Number::from(amount.tokens);
+        // Due to defensive rounding, and probably only when the final outstanding loan in a pool
+        // is being repaid, it is possible that the integer number of tokens being repaid exceeds
+        // the precise number of total borrowed tokens. To cover this case, we guard against any
+        // difference beyond the rounding effect, and use a saturating sub to update the total borrowed.
+
+        if self.total_borrowed().as_u64_ceil(0) < amount.tokens {
+            return Err(ErrorCode::RepaymentExceedsTotalOutstanding.into());
+        }
+
+        *self.total_borrowed_mut() = self
+            .total_borrowed()
+            .saturating_sub(Number::from(amount.tokens));
 
         Ok(())
     }


### PR DESCRIPTION
Defensive rounding for repayment can cause an underflow when paying off
the final loan notes in a pool. See MarginPool::repay() for details.