### PR TITLE
feature: max leverage configured per pool/token

### DIFF
--- a/libraries/rust/src/instructions/control.rs
+++ b/libraries/rust/src/instructions/control.rs
@@ -116,6 +116,7 @@ pub fn configure_token(
         margin_pool: pool.address,
         token_metadata: get_metadata_address(&pool.token_mint),
         deposit_metadata: get_metadata_address(&pool.deposit_note_mint),
+        loan_metadata: get_metadata_address(&pool.loan_note_mint),
 
         pyth_product: config.pyth_product.unwrap_or_default(),
         pyth_price: config.pyth_price.unwrap_or_default(),

--- a/libraries/ts/src/types/jetControl.ts
+++ b/libraries/ts/src/types/jetControl.ts
@@ -1,253 +1,341 @@
 export type JetControl = {
-  version: "0.1.0"
-  name: "jet_control"
-  instructions: [
+  "version": "0.1.0",
+  "name": "jet_control",
+  "instructions": [
     {
-      name: "createAuthority"
-      accounts: [
+      "name": "createAuthority",
+      "accounts": [
         {
-          name: "authority"
-          isMut: true
-          isSigner: false
+          "name": "authority",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "payer"
-          isMut: true
-          isSigner: true
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "systemProgram"
-          isMut: false
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
-      ]
-      args: []
+      ],
+      "args": []
     },
     {
-      name: "registerToken"
-      accounts: [
+      "name": "registerToken",
+      "accounts": [
         {
-          name: "requester"
-          isMut: true
-          isSigner: true
+          "name": "requester",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "authority"
-          isMut: false
-          isSigner: false
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "marginPool"
-          isMut: true
-          isSigner: false
+          "name": "marginPool",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "vault"
-          isMut: true
-          isSigner: false
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "depositNoteMint"
-          isMut: true
-          isSigner: false
+          "name": "depositNoteMint",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "loanNoteMint"
-          isMut: true
-          isSigner: false
+          "name": "loanNoteMint",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "tokenMint"
-          isMut: false
-          isSigner: false
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "tokenMetadata"
-          isMut: true
-          isSigner: false
+          "name": "tokenMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "depositNoteMetadata"
-          isMut: true
-          isSigner: false
+          "name": "depositNoteMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "loanNoteMetadata"
-          isMut: true
-          isSigner: false
+          "name": "loanNoteMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "marginPoolProgram"
-          isMut: false
-          isSigner: false
+          "name": "marginPoolProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "metadataProgram"
-          isMut: false
-          isSigner: false
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "tokenProgram"
-          isMut: false
-          isSigner: false
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "systemProgram"
-          isMut: false
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "rent"
-          isMut: false
-          isSigner: false
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
         }
-      ]
-      args: []
+      ],
+      "args": []
     },
     {
-      name: "registerAdapter"
-      accounts: [
+      "name": "registerAdapter",
+      "accounts": [
         {
-          name: "requester"
-          isMut: false
-          isSigner: true
+          "name": "requester",
+          "isMut": false,
+          "isSigner": true
         },
         {
-          name: "authority"
-          isMut: false
-          isSigner: false
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "adapter"
-          isMut: false
-          isSigner: false
+          "name": "adapter",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "metadataAccount"
-          isMut: true
-          isSigner: false
+          "name": "metadataAccount",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "payer"
-          isMut: true
-          isSigner: true
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "metadataProgram"
-          isMut: false
-          isSigner: false
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "systemProgram"
-          isMut: false
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
-      ]
-      args: []
+      ],
+      "args": []
     },
     {
-      name: "configureToken"
-      accounts: [
+      "name": "configureToken",
+      "accounts": [
         {
-          name: "requester"
-          isMut: false
-          isSigner: true
+          "name": "requester",
+          "isMut": false,
+          "isSigner": true
         },
         {
-          name: "authority"
-          isMut: false
-          isSigner: false
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "tokenMint"
-          isMut: false
-          isSigner: false
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "marginPool"
-          isMut: true
-          isSigner: false
+          "name": "marginPool",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "tokenMetadata"
-          isMut: true
-          isSigner: false
+          "name": "tokenMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "depositMetadata"
-          isMut: true
-          isSigner: false
+          "name": "depositMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "pythProduct"
-          isMut: false
-          isSigner: false
+          "name": "loanMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "pythPrice"
-          isMut: false
-          isSigner: false
+          "name": "pythProduct",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "marginPoolProgram"
-          isMut: false
-          isSigner: false
+          "name": "pythPrice",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "metadataProgram"
-          isMut: false
-          isSigner: false
+          "name": "marginPoolProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         }
-      ]
-      args: [
+      ],
+      "args": [
         {
-          name: "metadata"
-          type: {
-            option: {
-              defined: "TokenMetadataParams"
+          "name": "metadata",
+          "type": {
+            "option": {
+              "defined": "TokenMetadataParams"
             }
           }
         },
         {
-          name: "poolParam"
-          type: {
-            option: {
-              defined: "MarginPoolParams"
+          "name": "poolParam",
+          "type": {
+            "option": {
+              "defined": "MarginPoolParams"
             }
           }
         },
         {
-          name: "poolConfig"
-          type: {
-            option: {
-              defined: "MarginPoolConfig"
+          "name": "poolConfig",
+          "type": {
+            "option": {
+              "defined": "MarginPoolConfig"
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "setLiquidator",
+      "accounts": [
+        {
+          "name": "requester",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "liquidator",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "metadataAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "isLiquidator",
+          "type": "bool"
         }
       ]
     }
-  ]
-  accounts: [
+  ],
+  "accounts": [
     {
-      name: "authority"
-      type: {
-        kind: "struct"
-        fields: [
+      "name": "authority",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
-            name: "seed"
-            type: {
-              array: ["u8", 1]
+            "name": "seed",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
             }
           }
         ]
       }
     }
-  ]
-  types: [
+  ],
+  "types": [
     {
-      name: "TokenKind"
+      "name": "TokenMetadataParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenKind",
+            "type": {
+              "defined": "TokenKind"
+            }
+          },
+          {
+            "name": "collateralWeight",
+            "type": "u16"
+          },
+          {
+            "name": "maxLeverage",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginPoolParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "feeDestination",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      name: "TokenKind",
       type: {
-        kind: "enum"
+        kind: "enum",
         variants: [
           {
             name: "NonCollateral"
@@ -257,28 +345,6 @@ export type JetControl = {
           },
           {
             name: "Claim"
-          }
-        ]
-      }
-    },
-    {
-      name: "TokenMetadataParams"
-      type: {
-        kind: "struct"
-        fields: [
-          {
-            name: "tokenKind"
-            type: {
-              defined: "TokenKind"
-            }
-          },
-          {
-            name: "collateralWeight"
-            type: "u16"
-          },
-          {
-            name: "collateralMaxStaleness"
-            type: "u64"
           }
         ]
       }
@@ -327,267 +393,343 @@ export type JetControl = {
         ]
       }
     },
-    {
-      name: "MarginPoolParams"
-      type: {
-        kind: "struct"
-        fields: [
-          {
-            name: "feeDestination"
-            type: "publicKey"
-          }
-        ]
-      }
-    }
   ]
-}
+};
 
 export const IDL: JetControl = {
-  version: "0.1.0",
-  name: "jet_control",
-  instructions: [
+  "version": "0.1.0",
+  "name": "jet_control",
+  "instructions": [
     {
-      name: "createAuthority",
-      accounts: [
+      "name": "createAuthority",
+      "accounts": [
         {
-          name: "authority",
-          isMut: true,
-          isSigner: false
+          "name": "authority",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "payer",
-          isMut: true,
-          isSigner: true
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "systemProgram",
-          isMut: false,
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
-      args: []
+      "args": []
     },
     {
-      name: "registerToken",
-      accounts: [
+      "name": "registerToken",
+      "accounts": [
         {
-          name: "requester",
-          isMut: true,
-          isSigner: true
+          "name": "requester",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "authority",
-          isMut: false,
-          isSigner: false
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "marginPool",
-          isMut: true,
-          isSigner: false
+          "name": "marginPool",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "vault",
-          isMut: true,
-          isSigner: false
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "depositNoteMint",
-          isMut: true,
-          isSigner: false
+          "name": "depositNoteMint",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "loanNoteMint",
-          isMut: true,
-          isSigner: false
+          "name": "loanNoteMint",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "tokenMint",
-          isMut: false,
-          isSigner: false
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "tokenMetadata",
-          isMut: true,
-          isSigner: false
+          "name": "tokenMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "depositNoteMetadata",
-          isMut: true,
-          isSigner: false
+          "name": "depositNoteMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "loanNoteMetadata",
-          isMut: true,
-          isSigner: false
+          "name": "loanNoteMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "marginPoolProgram",
-          isMut: false,
-          isSigner: false
+          "name": "marginPoolProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "metadataProgram",
-          isMut: false,
-          isSigner: false
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "tokenProgram",
-          isMut: false,
-          isSigner: false
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "systemProgram",
-          isMut: false,
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "rent",
-          isMut: false,
-          isSigner: false
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
         }
       ],
-      args: []
+      "args": []
     },
     {
-      name: "registerAdapter",
-      accounts: [
+      "name": "registerAdapter",
+      "accounts": [
         {
-          name: "requester",
-          isMut: false,
-          isSigner: true
+          "name": "requester",
+          "isMut": false,
+          "isSigner": true
         },
         {
-          name: "authority",
-          isMut: false,
-          isSigner: false
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "adapter",
-          isMut: false,
-          isSigner: false
+          "name": "adapter",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "metadataAccount",
-          isMut: true,
-          isSigner: false
+          "name": "metadataAccount",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "payer",
-          isMut: true,
-          isSigner: true
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
         },
         {
-          name: "metadataProgram",
-          isMut: false,
-          isSigner: false
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "systemProgram",
-          isMut: false,
-          isSigner: false
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
-      args: []
+      "args": []
     },
     {
-      name: "configureToken",
-      accounts: [
+      "name": "configureToken",
+      "accounts": [
         {
-          name: "requester",
-          isMut: false,
-          isSigner: true
+          "name": "requester",
+          "isMut": false,
+          "isSigner": true
         },
         {
-          name: "authority",
-          isMut: false,
-          isSigner: false
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "tokenMint",
-          isMut: false,
-          isSigner: false
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "marginPool",
-          isMut: true,
-          isSigner: false
+          "name": "marginPool",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "tokenMetadata",
-          isMut: true,
-          isSigner: false
+          "name": "tokenMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "depositMetadata",
-          isMut: true,
-          isSigner: false
+          "name": "depositMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "pythProduct",
-          isMut: false,
-          isSigner: false
+          "name": "loanMetadata",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "pythPrice",
-          isMut: false,
-          isSigner: false
+          "name": "pythProduct",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "marginPoolProgram",
-          isMut: false,
-          isSigner: false
+          "name": "pythPrice",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          name: "metadataProgram",
-          isMut: false,
-          isSigner: false
+          "name": "marginPoolProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
-      args: [
+      "args": [
         {
-          name: "metadata",
-          type: {
-            option: {
-              defined: "TokenMetadataParams"
+          "name": "metadata",
+          "type": {
+            "option": {
+              "defined": "TokenMetadataParams"
             }
           }
         },
         {
-          name: "poolParam",
-          type: {
-            option: {
-              defined: "MarginPoolParams"
+          "name": "poolParam",
+          "type": {
+            "option": {
+              "defined": "MarginPoolParams"
             }
           }
         },
         {
-          name: "poolConfig",
-          type: {
-            option: {
-              defined: "MarginPoolConfig"
+          "name": "poolConfig",
+          "type": {
+            "option": {
+              "defined": "MarginPoolConfig"
             }
           }
         }
       ]
+    },
+    {
+      "name": "setLiquidator",
+      "accounts": [
+        {
+          "name": "requester",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "liquidator",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "metadataAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "isLiquidator",
+          "type": "bool"
+        }
+      ]
     }
   ],
-  accounts: [
+  "accounts": [
     {
-      name: "authority",
-      type: {
-        kind: "struct",
-        fields: [
+      "name": "authority",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
-            name: "seed",
-            type: {
-              array: ["u8", 1]
+            "name": "seed",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
             }
           }
         ]
       }
     }
   ],
-  types: [
+  "types": [
+    {
+      "name": "TokenMetadataParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenKind",
+            "type": {
+              "defined": "TokenKind"
+            }
+          },
+          {
+            "name": "collateralWeight",
+            "type": "u16"
+          },
+          {
+            "name": "maxLeverage",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginPoolParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "feeDestination",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
     {
       name: "TokenKind",
       type: {
@@ -601,28 +743,6 @@ export const IDL: JetControl = {
           },
           {
             name: "Claim"
-          }
-        ]
-      }
-    },
-    {
-      name: "TokenMetadataParams",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "tokenKind",
-            type: {
-              defined: "TokenKind"
-            }
-          },
-          {
-            name: "collateralWeight",
-            type: "u16"
-          },
-          {
-            name: "collateralMaxStaleness",
-            type: "u64"
           }
         ]
       }
@@ -671,17 +791,5 @@ export const IDL: JetControl = {
         ]
       }
     },
-    {
-      name: "MarginPoolParams",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "feeDestination",
-            type: "publicKey"
-          }
-        ]
-      }
-    }
   ]
-}
+};

--- a/programs/control/src/instructions/configure_token.rs
+++ b/programs/control/src/instructions/configure_token.rs
@@ -47,22 +47,22 @@ pub struct MarginPoolParams {
 pub struct ConfigureToken<'info> {
     #[cfg_attr(not(feature = "testing"), account(address = crate::ROOT_AUTHORITY))]
     pub requester: Signer<'info>,
-    pub authority: Account<'info, Authority>,
+    pub authority: Box<Account<'info, Authority>>,
 
     /// CHECK:
     pub token_mint: UncheckedAccount<'info>,
 
     #[account(mut, has_one = token_mint)]
-    pub margin_pool: Account<'info, MarginPool>,
+    pub margin_pool: Box<Account<'info, MarginPool>>,
 
     #[account(mut, has_one = token_mint)]
-    pub token_metadata: Account<'info, TokenMetadata>,
+    pub token_metadata: Box<Account<'info, TokenMetadata>>,
 
     #[account(mut, constraint = deposit_metadata.underlying_token_mint == token_mint.key())]
-    pub deposit_metadata: Account<'info, PositionTokenMetadata>,
+    pub deposit_metadata: Box<Account<'info, PositionTokenMetadata>>,
 
     #[account(mut, constraint = loan_metadata.underlying_token_mint == token_mint.key())]
-    pub loan_metadata: Account<'info, PositionTokenMetadata>,
+    pub loan_metadata: Box<Account<'info, PositionTokenMetadata>>,
 
     /// CHECK:
     pub pyth_product: UncheckedAccount<'info>,

--- a/programs/control/src/instructions/configure_token.rs
+++ b/programs/control/src/instructions/configure_token.rs
@@ -34,8 +34,8 @@ pub struct TokenMetadataParams {
     /// The weight of the asset's value relative to other tokens when used as collateral.
     pub collateral_weight: u16,
 
-    /// The maximum staleness (seconds) that's acceptable for this token when used as collateral.
-    pub collateral_max_staleness: u64,
+    /// The maximum leverage allowed on loans for the token
+    pub max_leverage: u16,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
@@ -60,6 +60,9 @@ pub struct ConfigureToken<'info> {
 
     #[account(mut, constraint = deposit_metadata.underlying_token_mint == token_mint.key())]
     pub deposit_metadata: Account<'info, PositionTokenMetadata>,
+
+    #[account(mut, constraint = loan_metadata.underlying_token_mint == token_mint.key())]
+    pub loan_metadata: Account<'info, PositionTokenMetadata>,
 
     /// CHECK:
     pub pyth_product: UncheckedAccount<'info>,
@@ -99,6 +102,16 @@ impl<'info> ConfigureToken<'info> {
             self.metadata_program.to_account_info(),
             SetEntry {
                 metadata_account: self.deposit_metadata.to_account_info(),
+                authority: self.authority.to_account_info(),
+            },
+        )
+    }
+
+    fn set_loan_metadata_context(&self) -> CpiContext<'_, '_, '_, 'info, SetEntry<'info>> {
+        CpiContext::new(
+            self.metadata_program.to_account_info(),
+            SetEntry {
+                metadata_account: self.loan_metadata.to_account_info(),
                 authority: self.authority.to_account_info(),
             },
         )
@@ -152,14 +165,31 @@ pub fn configure_token_handler(
         let mut data = vec![];
 
         metadata.token_kind = params.token_kind;
-        metadata.collateral_weight = params.collateral_weight;
-        metadata.collateral_max_staleness = params.collateral_max_staleness;
+        metadata.value_modifier = params.collateral_weight;
+        metadata.max_staleness = 0;
 
         metadata.try_serialize(&mut data)?;
 
         jet_metadata::cpi::set_entry(
             ctx.accounts
                 .set_deposit_metadata_context()
+                .with_signer(&[&authority]),
+            0,
+            data,
+        )?;
+
+        metadata = ctx.accounts.loan_metadata.clone();
+        let mut data = vec![];
+
+        metadata.token_kind = TokenKind::Claim;
+        metadata.value_modifier = params.max_leverage;
+        metadata.max_staleness = 0;
+
+        metadata.try_serialize(&mut data)?;
+
+        jet_metadata::cpi::set_entry(
+            ctx.accounts
+                .set_loan_metadata_context()
                 .with_signer(&[&authority]),
             0,
             data,

--- a/programs/control/src/instructions/register_token.rs
+++ b/programs/control/src/instructions/register_token.rs
@@ -177,8 +177,8 @@ pub fn register_token_handler(ctx: Context<RegisterToken>) -> Result<()> {
         position_token_mint: ctx.accounts.deposit_note_mint.key(),
         adapter_program: ctx.accounts.margin_pool_program.key(),
         token_kind: TokenKind::NonCollateral,
-        collateral_weight: 0,
-        collateral_max_staleness: 0,
+        value_modifier: 0,
+        max_staleness: 0,
     };
 
     let loan_note_metadata = PositionTokenMetadata {
@@ -186,8 +186,8 @@ pub fn register_token_handler(ctx: Context<RegisterToken>) -> Result<()> {
         position_token_mint: ctx.accounts.loan_note_mint.key(),
         adapter_program: ctx.accounts.margin_pool_program.key(),
         token_kind: TokenKind::Claim,
-        collateral_weight: 0,
-        collateral_max_staleness: 0,
+        value_modifier: 0,
+        max_staleness: 0,
     };
 
     let token_metadata = TokenMetadata {

--- a/programs/margin-pool/src/instructions/configure.rs
+++ b/programs/margin-pool/src/instructions/configure.rs
@@ -65,8 +65,6 @@ pub fn configure_handler(
             return err!(ErrorCode::InvalidOracle);
         }
 
-        //TODO JV2M-359
-        //TODO this needs to be set in the product account.
         let quote_currency = product_account
             .iter()
             .find_map(|(k, v)| match k {

--- a/programs/margin/src/instructions/liquidate_begin.rs
+++ b/programs/margin/src/instructions/liquidate_begin.rs
@@ -85,8 +85,8 @@ pub fn liquidate_begin_handler(ctx: Context<LiquidateBegin>) -> Result<()> {
 
     let valuation = account.valuation()?;
 
-    let min_value_change =
-        valuation.net_collateral() * Number128::from_bps(LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN);
+    let min_value_change = valuation.available_collateral()
+        * Number128::from_bps(LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN);
 
     *ctx.accounts.liquidation.load_init()? =
         Liquidation::new(Clock::get()?.unix_timestamp, min_value_change);

--- a/programs/margin/src/instructions/liquidate_begin.rs
+++ b/programs/margin/src/instructions/liquidate_begin.rs
@@ -19,10 +19,7 @@ use anchor_lang::prelude::*;
 
 use jet_proto_math::Number128;
 
-use crate::{
-    ErrorCode, Liquidation, MarginAccount, IDEAL_LIQUIDATION_COLLATERAL_RATIO,
-    MAX_LIQUIDATION_VALUE_SLIPPAGE,
-};
+use crate::{ErrorCode, Liquidation, MarginAccount, LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN};
 use jet_metadata::LiquidatorMetadata;
 
 #[derive(Accounts)]
@@ -87,17 +84,13 @@ pub fn liquidate_begin_handler(ctx: Context<LiquidateBegin>) -> Result<()> {
     }
 
     let valuation = account.valuation()?;
-    let ideal_c_ratio = Number128::from_bps(IDEAL_LIQUIDATION_COLLATERAL_RATIO);
-    let ideal_value_liquidated =
-        valuation.claims() - valuation.net() / (ideal_c_ratio - Number128::ONE);
 
-    let min_value_change = Number128::ZERO
-        - Number128::from_bps(MAX_LIQUIDATION_VALUE_SLIPPAGE) * ideal_value_liquidated;
+    let min_value_change =
+        valuation.net() * Number128::from_bps(LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN);
 
     *ctx.accounts.liquidation.load_init()? = Liquidation {
         start_time: Clock::get()?.unix_timestamp,
         value_change: Number128::ZERO,
-        c_ratio_change: Number128::ZERO,
         min_value_change,
     };
 

--- a/programs/margin/src/instructions/liquidate_begin.rs
+++ b/programs/margin/src/instructions/liquidate_begin.rs
@@ -86,13 +86,10 @@ pub fn liquidate_begin_handler(ctx: Context<LiquidateBegin>) -> Result<()> {
     let valuation = account.valuation()?;
 
     let min_value_change =
-        valuation.net() * Number128::from_bps(LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN);
+        valuation.net_collateral() * Number128::from_bps(LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN);
 
-    *ctx.accounts.liquidation.load_init()? = Liquidation {
-        start_time: Clock::get()?.unix_timestamp,
-        value_change: Number128::ZERO,
-        min_value_change,
-    };
+    *ctx.accounts.liquidation.load_init()? =
+        Liquidation::new(Clock::get()?.unix_timestamp, min_value_change);
 
     Ok(())
 }

--- a/programs/margin/src/instructions/liquidate_end.rs
+++ b/programs/margin/src/instructions/liquidate_end.rs
@@ -37,7 +37,7 @@ pub struct LiquidateEnd<'info> {
 
 pub fn liquidate_end_handler(ctx: Context<LiquidateEnd>) -> Result<()> {
     let mut account = ctx.accounts.margin_account.load_mut()?;
-    let start_time = ctx.accounts.liquidation.load()?.start_time;
+    let start_time = ctx.accounts.liquidation.load()?.start_time();
 
     if (account.liquidator != ctx.accounts.authority.key())
         && Clock::get()?.unix_timestamp - start_time < LIQUIDATION_TIMEOUT

--- a/programs/margin/src/instructions/liquidator_invoke.rs
+++ b/programs/margin/src/instructions/liquidator_invoke.rs
@@ -18,13 +18,9 @@
 use anchor_lang::prelude::*;
 
 use jet_metadata::MarginAdapterMetadata;
-use jet_proto_math::Number128;
 
 use crate::adapter::{self, CompactAccountMeta, InvokeAdapter};
-use crate::{
-    ErrorCode, Liquidation, MarginAccount, Valuation, LIQUIDATION_CLOSE_THRESHOLD_USD,
-    LIQUIDATION_MAX_COLLATERAL_RATIO,
-};
+use crate::{ErrorCode, Liquidation, MarginAccount, Valuation};
 
 #[derive(Accounts)]
 pub struct LiquidatorInvoke<'info> {
@@ -82,25 +78,13 @@ fn update_and_verify_liquidation(
 ) -> Result<()> {
     let end_value = margin_account.valuation()?;
 
-    *liquidation.value_change_mut() += end_value.net_collateral() - start_value.net_collateral(); // side effects
-    let end_c_ratio = end_value
-        .c_ratio()
-        .unwrap_or_else(|| Number128::from_i128(i128::MAX));
+    *liquidation.value_change_mut() +=
+        end_value.available_collateral() - start_value.available_collateral(); // side effects
 
-    verify_liquidation_step_is_allowed(liquidation, start_value.exposure, end_c_ratio)
+    verify_liquidation_step_is_allowed(liquidation)
 }
 
-fn verify_liquidation_step_is_allowed(
-    liquidation: &Liquidation,
-    start_exposure: Number128,
-    end_c_ratio: Number128,
-) -> Result<()> {
-    let close_threshold = Number128::from_decimal(LIQUIDATION_CLOSE_THRESHOLD_USD, 0);
-    let max_c_ratio = match start_exposure {
-        exposure if exposure < close_threshold => Number128::from_i128(i128::MAX),
-        _ => Number128::from_bps(LIQUIDATION_MAX_COLLATERAL_RATIO),
-    };
-
+fn verify_liquidation_step_is_allowed(liquidation: &Liquidation) -> Result<()> {
     if *liquidation.value_change() < liquidation.min_value_change() {
         msg!(
             "Illegal liquidation: net loss of {} value which exceeds the min value change of {}",
@@ -108,13 +92,6 @@ fn verify_liquidation_step_is_allowed(
             liquidation.min_value_change()
         );
         err!(ErrorCode::LiquidationLostValue)
-    } else if end_c_ratio > max_c_ratio {
-        msg!(
-            "Illegal liquidation: causes the c-ratio to increase to {} above the maximum of {}",
-            end_c_ratio,
-            max_c_ratio
-        );
-        err!(ErrorCode::LiquidationTooHealthy)
     } else {
         Ok(())
     }

--- a/programs/margin/src/instructions/register_position.rs
+++ b/programs/margin/src/instructions/register_position.rs
@@ -73,8 +73,8 @@ pub fn register_position_handler(ctx: Context<RegisterPosition>) -> Result<()> {
         address,
         metadata.adapter_program,
         metadata.token_kind.into(),
-        metadata.collateral_weight,
-        metadata.collateral_max_staleness,
+        metadata.value_modifier,
+        metadata.max_staleness,
     )?;
 
     Ok(())

--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -55,8 +55,12 @@ pub const LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN: u16 = 10_00;
 /// The maximum c-ratio that an account can end a liquidation with.
 ///
 /// Note: This is not a traditional c-ratio, because it's based on the ratio of
-///       the collateral / required_collateral.
-pub const LIQUIDATION_MAX_COLLATERAL_RATIO: u16 = 120_00;
+///       the effective_collateral / required_collateral.
+pub const LIQUIDATION_MAX_COLLATERAL_RATIO: u16 = 125_00;
+
+/// The threshold at which accounts can have all their debts closed. Accounts with
+/// total exposure below this value can have their exposure reduced to zero.
+pub const LIQUIDATION_CLOSE_THRESHOLD_USD: u64 = 100;
 
 /// The maximum duration in seconds of a liquidation before another user may cancel it
 #[constant]

--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -14,6 +14,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#![allow(clippy::inconsistent_digit_grouping)]
 
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::clock::UnixTimestamp;
@@ -31,26 +32,13 @@ pub use state::*;
 
 pub use adapter::{AdapterResult, CompactAccountMeta, PositionChange, PriceChangeInfo};
 
-/// The minimum collateral ratio that a margin account must maintain before
-/// being subject to liquidation
-#[constant]
-pub const MIN_COLLATERAL_RATIO: u16 = 12_500;
-
-/// The target c-ratio for a liquidation
-#[constant]
-pub const IDEAL_LIQUIDATION_COLLATERAL_RATIO: u16 = 13_000;
-
-/// The maximum c-ratio that a liquidator is allowed to increase a margin account to
-#[constant]
-pub const MAX_LIQUIDATION_COLLATERAL_RATIO: u16 = 15_000;
-
 /// The maximum confidence deviation allowed for an oracle price.
 ///
 /// The confidence is measured as the percent of the confidence interval
 /// value provided by the oracle as compared to the weighted average value
 /// of the price.
 #[constant]
-pub const MAX_ORACLE_CONFIDENCE: u16 = 500;
+pub const MAX_ORACLE_CONFIDENCE: u16 = 5_00;
 
 /// The maximum number of seconds since the last price was by an oracle, before
 /// rejecting the price as too stale.
@@ -60,17 +48,15 @@ pub const MAX_ORACLE_STALENESS: i64 = 10;
 #[constant]
 pub const MAX_PRICE_QUOTE_AGE: u64 = 10;
 
-/// The maximum loss of value to a margin account allowed during a liquidation.
-/// This is the ratio of value lost to the value that should be liquidated,
-/// represented in basis points
-/// This applies to the arbitrary liquidate_invoke steps executed by a liquidator.
-/// This does not include the liquidation fees, which would result in additional value extracted
-#[constant]
-pub const MAX_LIQUIDATION_VALUE_SLIPPAGE: u16 = 500;
+/// The maximum amount that the amount of missing collateral can be increased,
+/// expressed as a percentage of the current missing collateral.
+pub const LIQUIDATION_MAX_UNDERCOLLATERAL_GAIN: u16 = 10_00;
 
-/// The maximum reduction in c-ratio allowed during a liquidation, in bps
-#[constant]
-pub const MAX_LIQUIDATION_C_RATIO_SLIPPAGE: u16 = 500;
+/// The maximum c-ratio that an account can end a liquidation with.
+///
+/// Note: This is not a traditional c-ratio, because it's based on the ratio of
+///       the collateral / required_collateral.
+pub const LIQUIDATION_MAX_COLLATERAL_RATIO: u16 = 120_00;
 
 /// The maximum duration in seconds of a liquidation before another user may cancel it
 #[constant]
@@ -232,7 +218,7 @@ pub enum ErrorCode {
 
     /// 141040 - No permission to perform a liquidation action
     #[msg("the liquidator does not have permission to do this")]
-    UnauthorizedLiquidator,
+    UnauthorizedLiquidator = 135_040,
 
     /// 141041
     #[msg("attempted to extract too much value during liquidation")]

--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -227,14 +227,6 @@ pub enum ErrorCode {
     /// 141041
     #[msg("attempted to extract too much value during liquidation")]
     LiquidationLostValue,
-
-    /// 141042
-    #[msg("reduced the c-ratio too far during liquidation")]
-    LiquidationUnhealthy,
-
-    /// 141043
-    #[msg("increased the c-ratio too high during liquidation")]
-    LiquidationTooHealthy,
 }
 
 pub fn write_adapter_result(result: &AdapterResult) -> Result<()> {

--- a/programs/margin/src/state.rs
+++ b/programs/margin/src/state.rs
@@ -802,15 +802,7 @@ pub struct Valuation {
 }
 
 impl Valuation {
-    pub fn c_ratio(&self) -> Option<Number128> {
-        if self.required_collateral == Number128::ZERO {
-            return None;
-        }
-
-        Some(self.effective_collateral / self.required_collateral)
-    }
-
-    pub fn net_collateral(&self) -> Number128 {
+    pub fn available_collateral(&self) -> Number128 {
         self.effective_collateral - self.required_collateral
     }
 

--- a/programs/metadata/src/lib.rs
+++ b/programs/metadata/src/lib.rs
@@ -154,11 +154,11 @@ pub struct PositionTokenMetadata {
     /// Description of this token
     pub token_kind: TokenKind,
 
-    /// The weight of the asset's value relative to other tokens when used as collateral.
-    pub collateral_weight: u16,
+    /// A modifier to adjust the token value, based on the kind of token
+    pub value_modifier: u16,
 
-    /// The maximum staleness (seconds) that's acceptable for this token when used as collateral.
-    pub collateral_max_staleness: u64,
+    /// The maximum staleness (seconds) that's acceptable for balances of this token
+    pub max_staleness: u64,
 }
 
 /// An account that references information about a token's price oracle

--- a/tests/hosted/src/setup_helper.rs
+++ b/tests/hosted/src/setup_helper.rs
@@ -1,7 +1,5 @@
 use anyhow::{Error, Result};
 
-use jet_control::TokenMetadataParams;
-use jet_margin_sdk::instructions::control::TokenConfiguration;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
@@ -43,6 +41,7 @@ pub async fn setup_token(
     ctx: &MarginTestContext,
     decimals: u8,
     collateral_weight: u16,
+    leverage_max: u16,
     price: i64,
 ) -> Result<Pubkey, Error> {
     let token = ctx.tokens.create_token(decimals, None, None).await?;
@@ -55,29 +54,13 @@ pub async fn setup_token(
     ctx.margin
         .create_pool(&MarginPoolSetupInfo {
             token,
+            collateral_weight,
+            max_leverage: leverage_max,
             fee_destination: token_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight,
             config: DEFAULT_POOL_CONFIG,
             oracle: token_oracle,
         })
-        .await?;
-
-    ctx.margin
-        .configure_token(
-            &token,
-            &TokenConfiguration {
-                pyth_price: Some(token_oracle.price),
-                pyth_product: Some(token_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
         .await?;
 
     // set price to $1
@@ -148,7 +131,7 @@ pub async fn build_environment_with_no_balances(
     let liquidator = ctx.create_liquidator(100).await?;
     let mut mints: Vec<Pubkey> = Vec::new();
     for _ in 0..number_of_mints {
-        let mint = setup_token(ctx, 6, 10_000, 1).await?;
+        let mint = setup_token(ctx, 6, 1_00, 10_00, 1).await?;
         mints.push(mint);
     }
     let mut users: Vec<TestUser> = Vec::new();
@@ -176,7 +159,7 @@ pub async fn build_environment_with_raw_token_balances(
     let mut mints: Vec<Pubkey> = Vec::new();
     let mut wallets: Vec<(Pubkey, u64, u64)> = Vec::new();
     for _ in 0..number_of_mints {
-        let mint = setup_token(ctx, 6, 10_000, 1).await?;
+        let mint = setup_token(ctx, 6, 1_00, 10_00, 1).await?;
         mints.push(mint);
         wallets.push((mint, 100, 0));
     }

--- a/tests/hosted/tests/liquidate.rs
+++ b/tests/hosted/tests/liquidate.rs
@@ -135,27 +135,6 @@ async fn cannot_transact_when_being_liquidated() -> Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn liquidator_cannot_over_repay() -> Result<()> {
-    let scen = scenario1().await?;
-
-    scen.user_b_liq.liquidate_begin().await?;
-
-    // Fail a repayment on behalf of the user because it repays too much
-    // User B would have
-    // Collateral (800'000 * 0.95) + 500'000 = 1'260'000
-    // Claim 500'000
-    // C ratio = 2.52
-    let result = scen
-        .user_b_liq
-        .repay(&scen.usdc, Amount::tokens(3_000_000 * ONE_USDC))
-        .await;
-    assert_program_error!(ErrorCode::LiquidationTooHealthy, result);
-
-    Ok(())
-}
-
-#[tokio::test]
-#[serial]
 async fn liquidator_can_repay_from_unhealthy_to_healthy_state() -> Result<()> {
     let scen = scenario1().await?;
 

--- a/tests/hosted/tests/liquidate.rs
+++ b/tests/hosted/tests/liquidate.rs
@@ -35,8 +35,8 @@ struct Scenario1 {
 #[allow(clippy::erasing_op)]
 async fn scenario1() -> Result<Scenario1> {
     let ctx = test_context().await;
-    let usdc = setup_token(ctx, 6, 10_000, 1).await?;
-    let tsol = setup_token(ctx, 9, 9_500, 100).await?;
+    let usdc = setup_token(ctx, 6, 1_00, 4_00, 1).await?;
+    let tsol = setup_token(ctx, 9, 95, 4_00, 100).await?;
 
     // Create wallet for the liquidator
     let liquidator_wallet = ctx.create_liquidator(100).await?;
@@ -279,7 +279,7 @@ async fn can_withdraw_some_during_liquidation() -> Result<()> {
         .withdraw(
             &scen.usdc,
             &liquidator_usdc_account,
-            Amount::tokens(40000 * ONE_USDC),
+            Amount::tokens(40 * ONE_USDC),
         )
         .await?;
 
@@ -293,11 +293,8 @@ async fn cannot_borrow_too_much_during_liquidation() -> Result<()> {
 
     scen.user_b_liq.liquidate_begin().await?;
 
-    let result = scen
-        .user_b_liq
-        .borrow(&scen.usdc, 5_000_000 * ONE_USDC)
-        .await;
-    assert_program_error!(ErrorCode::LiquidationUnhealthy, result);
+    let result = scen.user_b_liq.borrow(&scen.usdc, 500_000 * ONE_USDC).await;
+    assert_program_error!(ErrorCode::LiquidationLostValue, result);
 
     Ok(())
 }
@@ -308,9 +305,7 @@ async fn can_borrow_some_during_liquidation() -> Result<()> {
     let scen = scenario1().await?;
 
     scen.user_b_liq.liquidate_begin().await?;
-    scen.user_b_liq
-        .borrow(&scen.usdc, 500_000 * ONE_USDC)
-        .await?;
+    scen.user_b_liq.borrow(&scen.usdc, 5_000 * ONE_USDC).await?;
 
     Ok(())
 }

--- a/tests/hosted/tests/pool_overpayment.rs
+++ b/tests/hosted/tests/pool_overpayment.rs
@@ -1,7 +1,5 @@
 use anyhow::Error;
 
-use jet_control::TokenMetadataParams;
-use jet_margin_sdk::instructions::control::TokenConfiguration;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
@@ -63,7 +61,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: usdc,
             fee_destination: usdc_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 10_000,
+            collateral_weight: 1_00,
+            max_leverage: 4_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: usdc_oracle,
         },
@@ -71,7 +70,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: usdt,
             fee_destination: usdt_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 10_000,
+            collateral_weight: 1_00,
+            max_leverage: 4_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: usdt_oracle,
         },
@@ -79,7 +79,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: tsol,
             fee_destination: tsol_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 9_500,
+            collateral_weight: 95,
+            max_leverage: 4_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: tsol_oracle,
         },
@@ -88,57 +89,6 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
     for pool_info in pools {
         ctx.margin.create_pool(&pool_info).await?;
     }
-
-    ctx.margin
-        .configure_token(
-            &usdc,
-            &TokenConfiguration {
-                pyth_price: Some(usdc_oracle.price),
-                pyth_product: Some(usdc_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 10_000,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    ctx.margin
-        .configure_token(
-            &usdt,
-            &TokenConfiguration {
-                pyth_price: Some(usdt_oracle.price),
-                pyth_product: Some(usdt_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 10_000,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    ctx.margin
-        .configure_token(
-            &tsol,
-            &TokenConfiguration {
-                pyth_price: Some(tsol_oracle.price),
-                pyth_product: Some(tsol_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 9_500,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
 
     Ok(TestEnv { usdc, usdt, tsol })
 }

--- a/tests/hosted/tests/rounding.rs
+++ b/tests/hosted/tests/rounding.rs
@@ -1,7 +1,5 @@
 use anyhow::{Error, Result};
 
-use jet_control::TokenMetadataParams;
-use jet_margin_sdk::instructions::control::TokenConfiguration;
 use solana_sdk::clock::Clock;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::pubkey::Pubkey;
@@ -56,7 +54,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: usdc,
             fee_destination: usdc_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 10_000,
+            collateral_weight: 1_00,
+            max_leverage: 10_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: usdc_oracle,
         },
@@ -64,7 +63,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: tsol,
             fee_destination: tsol_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 9_500,
+            collateral_weight: 95,
+            max_leverage: 4_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: tsol_oracle,
         },
@@ -73,40 +73,6 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
     for pool_info in pools {
         ctx.margin.create_pool(&pool_info).await?;
     }
-
-    ctx.margin
-        .configure_token(
-            &usdc,
-            &TokenConfiguration {
-                pyth_price: Some(usdc_oracle.price),
-                pyth_product: Some(usdc_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 10_000,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    ctx.margin
-        .configure_token(
-            &tsol,
-            &TokenConfiguration {
-                pyth_price: Some(tsol_oracle.price),
-                pyth_product: Some(tsol_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 9_500,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
 
     Ok(TestEnv { usdc, tsol })
 }

--- a/tests/hosted/tests/sanity.rs
+++ b/tests/hosted/tests/sanity.rs
@@ -1,9 +1,7 @@
 use anyhow::Error;
 
-use jet_control::TokenMetadataParams;
 use jet_margin::PositionKind;
 use jet_margin_pool::{Amount, MarginPoolConfig, PoolFlags};
-use jet_margin_sdk::instructions::control::TokenConfiguration;
 use jet_metadata::TokenKind;
 use jet_simulation::{assert_program_error_code, create_wallet};
 
@@ -56,7 +54,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: usdc,
             fee_destination: usdc_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 10_000,
+            collateral_weight: 1_00,
+            max_leverage: 10_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: usdc_oracle,
         },
@@ -64,7 +63,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: tsol,
             fee_destination: tsol_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 9_500,
+            collateral_weight: 95,
+            max_leverage: 4_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: tsol_oracle,
         },
@@ -73,40 +73,6 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
     for pool_info in pools {
         ctx.margin.create_pool(&pool_info).await?;
     }
-
-    ctx.margin
-        .configure_token(
-            &usdc,
-            &TokenConfiguration {
-                pyth_price: Some(usdc_oracle.price),
-                pyth_product: Some(usdc_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 10_000,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    ctx.margin
-        .configure_token(
-            &tsol,
-            &TokenConfiguration {
-                pyth_price: Some(tsol_oracle.price),
-                pyth_product: Some(tsol_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 9_500,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
 
     Ok(TestEnv { usdc, tsol })
 }

--- a/tests/hosted/tests/swap.rs
+++ b/tests/hosted/tests/swap.rs
@@ -1,7 +1,5 @@
 use anyhow::Error;
 
-use jet_control::TokenMetadataParams;
-use jet_margin_sdk::instructions::control::TokenConfiguration;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
@@ -56,7 +54,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: usdc,
             fee_destination: usdc_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 10_000,
+            collateral_weight: 1_00,
+            max_leverage: 10_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: usdc_oracle,
         },
@@ -64,7 +63,8 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
             token: tsol,
             fee_destination: tsol_fees,
             token_kind: TokenKind::Collateral,
-            collateral_weight: 9_500,
+            collateral_weight: 95,
+            max_leverage: 4_00,
             config: DEFAULT_POOL_CONFIG,
             oracle: tsol_oracle,
         },
@@ -73,40 +73,6 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
     for pool_info in pools {
         ctx.margin.create_pool(&pool_info).await?;
     }
-
-    ctx.margin
-        .configure_token(
-            &usdc,
-            &TokenConfiguration {
-                pyth_price: Some(usdc_oracle.price),
-                pyth_product: Some(usdc_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 10_000,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    ctx.margin
-        .configure_token(
-            &tsol,
-            &TokenConfiguration {
-                pyth_price: Some(tsol_oracle.price),
-                pyth_product: Some(tsol_oracle.product),
-                pool_config: Some(DEFAULT_POOL_CONFIG),
-                metadata: Some(TokenMetadataParams {
-                    token_kind: TokenKind::Collateral,
-                    collateral_weight: 9_500,
-                    collateral_max_staleness: 0,
-                }),
-                ..Default::default()
-            },
-        )
-        .await?;
 
     Ok(TestEnv { usdc, tsol })
 }

--- a/tests/integration/pool/marginPool.test.ts
+++ b/tests/integration/pool/marginPool.test.ts
@@ -128,8 +128,8 @@ describe("margin pool", () => {
   it("Create margin pools", async () => {
     await manager.create({
       tokenMint: USDC[0],
-      collateralWeight: 10_000,
-      collateralMaxStaleness: new BN(0),
+      collateralWeight: 1_00,
+      maxLeverage: 4_00,
       feeDestination: FEE_VAULT_USDC,
       pythProduct: USDC_oracle[0].publicKey,
       pythPrice: USDC_oracle[1].publicKey,
@@ -137,8 +137,8 @@ describe("margin pool", () => {
     })
     await manager.create({
       tokenMint: SOL[0],
-      collateralWeight: 9_500,
-      collateralMaxStaleness: new BN(0),
+      collateralWeight: 95,
+      maxLeverage: 4_00,
       feeDestination: FEE_VAULT_SOL,
       pythProduct: SOL_oracle[0].publicKey,
       pythPrice: SOL_oracle[1].publicKey,

--- a/tests/mock-adapter/src/lib.rs
+++ b/tests/mock-adapter/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::single_component_path_imports)]
 use anchor_lang::prelude::*;
 use anchor_spl::token::{burn, mint_to, Burn, Mint, MintTo, Token, TokenAccount};
 use jet_margin::{write_adapter_result, AdapterResult};


### PR DESCRIPTION
This replaces the c-ratio health check with one based on looking at the required collateral an account should have. This allows for configuring each token with it's own max leverage, which then is used to determine the collateral requirements for debts in that token type.

The collateral weight and new max leverage configuration are now both specified in terms of percentages instead of basis points.