### PR TITLE
remove chai from bundle and a few unused imports

### DIFF
--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -127,10 +127,9 @@ export class Pool {
       )
       const tokenMint = AssociatedToken.decodeMint(poolTokenMintInfo, this.addresses.tokenMint)
       const oracleInfo = await this.programs.marginPool.provider.connection.getAccountInfo(marginPool.tokenPriceOracle)
-      assert(
-        oracleInfo,
-        "Pyth oracle does not exist but a margin pool does. The margin pool is incorrectly configured."
-      )
+      if (!oracleInfo) {
+        throw "Pyth oracle does not exist but a margin pool does. The margin pool is incorrectly configured."
+      }
       this.info = {
         marginPool,
         tokenMint,

--- a/libraries/ts/src/margin/pool/poolManager.ts
+++ b/libraries/ts/src/margin/pool/poolManager.ts
@@ -1,10 +1,10 @@
-import { Address, AnchorProvider, BN, translateAddress } from "@project-serum/anchor"
+import { Address, AnchorProvider, translateAddress } from "@project-serum/anchor"
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token"
 import { PublicKey, SystemProgram, SYSVAR_RENT_PUBKEY, Transaction, TransactionInstruction } from "@solana/web3.js"
 import { findDerivedAccount } from "../../utils/pda"
 import { MarginPoolConfig, MarginPools, MarginTokenConfig } from "../config"
 import { MarginPrograms } from "../marginClient"
-import { MarginPoolAddresses, Pool, TokenKind } from "./pool"
+import { MarginPoolAddresses, Pool } from "./pool"
 import { MarginPoolConfigData } from "./state"
 
 interface MarginPoolParams {

--- a/libraries/ts/src/margin/serum/market.ts
+++ b/libraries/ts/src/margin/serum/market.ts
@@ -1,6 +1,6 @@
 import assert from "assert"
 import { blob, struct, u8 } from "buffer-layout"
-import { AnchorProvider, BN, InstructionNamespace } from "@project-serum/anchor"
+import { BN, InstructionNamespace } from "@project-serum/anchor"
 import {
   decodeEventQueue,
   decodeRequestQueue,

--- a/libraries/ts/src/types/jetControl.ts
+++ b/libraries/ts/src/types/jetControl.ts
@@ -1,341 +1,338 @@
 export type JetControl = {
-  "version": "0.1.0",
-  "name": "jet_control",
-  "instructions": [
+  version: "0.1.0"
+  name: "jet_control"
+  instructions: [
     {
-      "name": "createAuthority",
-      "accounts": [
+      name: "createAuthority"
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": false
+          name: "authority"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: "payer"
+          isMut: true
+          isSigner: true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram"
+          isMut: false
+          isSigner: false
         }
-      ],
-      "args": []
+      ]
+      args: []
     },
     {
-      "name": "registerToken",
-      "accounts": [
+      name: "registerToken"
+      accounts: [
         {
-          "name": "requester",
-          "isMut": true,
-          "isSigner": true
+          name: "requester"
+          isMut: true
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "marginPool",
-          "isMut": true,
-          "isSigner": false
+          name: "marginPool"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: "vault"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "depositNoteMint",
-          "isMut": true,
-          "isSigner": false
+          name: "depositNoteMint"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "loanNoteMint",
-          "isMut": true,
-          "isSigner": false
+          name: "loanNoteMint"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
+          name: "tokenMint"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "tokenMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "tokenMetadata"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "depositNoteMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "depositNoteMetadata"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "loanNoteMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "loanNoteMetadata"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "marginPoolProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "marginPoolProgram"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "tokenProgram"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: "rent"
+          isMut: false
+          isSigner: false
         }
-      ],
-      "args": []
+      ]
+      args: []
     },
     {
-      "name": "registerAdapter",
-      "accounts": [
+      name: "registerAdapter"
+      accounts: [
         {
-          "name": "requester",
-          "isMut": false,
-          "isSigner": true
+          name: "requester"
+          isMut: false
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "adapter",
-          "isMut": false,
-          "isSigner": false
+          name: "adapter"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "metadataAccount",
-          "isMut": true,
-          "isSigner": false
+          name: "metadataAccount"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: "payer"
+          isMut: true
+          isSigner: true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram"
+          isMut: false
+          isSigner: false
         }
-      ],
-      "args": []
+      ]
+      args: []
     },
     {
-      "name": "configureToken",
-      "accounts": [
+      name: "configureToken"
+      accounts: [
         {
-          "name": "requester",
-          "isMut": false,
-          "isSigner": true
+          name: "requester"
+          isMut: false
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
+          name: "tokenMint"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "marginPool",
-          "isMut": true,
-          "isSigner": false
+          name: "marginPool"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "tokenMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "tokenMetadata"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "depositMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "depositMetadata"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "loanMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "loanMetadata"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "pythProduct",
-          "isMut": false,
-          "isSigner": false
+          name: "pythProduct"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "pythPrice",
-          "isMut": false,
-          "isSigner": false
+          name: "pythPrice"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "marginPoolProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "marginPoolProgram"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram"
+          isMut: false
+          isSigner: false
         }
-      ],
-      "args": [
+      ]
+      args: [
         {
-          "name": "metadata",
-          "type": {
-            "option": {
-              "defined": "TokenMetadataParams"
+          name: "metadata"
+          type: {
+            option: {
+              defined: "TokenMetadataParams"
             }
           }
         },
         {
-          "name": "poolParam",
-          "type": {
-            "option": {
-              "defined": "MarginPoolParams"
+          name: "poolParam"
+          type: {
+            option: {
+              defined: "MarginPoolParams"
             }
           }
         },
         {
-          "name": "poolConfig",
-          "type": {
-            "option": {
-              "defined": "MarginPoolConfig"
+          name: "poolConfig"
+          type: {
+            option: {
+              defined: "MarginPoolConfig"
             }
           }
         }
       ]
     },
     {
-      "name": "setLiquidator",
-      "accounts": [
+      name: "setLiquidator"
+      accounts: [
         {
-          "name": "requester",
-          "isMut": false,
-          "isSigner": true
+          name: "requester"
+          isMut: false
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "liquidator",
-          "isMut": false,
-          "isSigner": false
+          name: "liquidator"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "metadataAccount",
-          "isMut": true,
-          "isSigner": false
+          name: "metadataAccount"
+          isMut: true
+          isSigner: false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: "payer"
+          isMut: true
+          isSigner: true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram"
+          isMut: false
+          isSigner: false
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram"
+          isMut: false
+          isSigner: false
         }
-      ],
-      "args": [
+      ]
+      args: [
         {
-          "name": "isLiquidator",
-          "type": "bool"
+          name: "isLiquidator"
+          type: "bool"
         }
       ]
     }
-  ],
-  "accounts": [
+  ]
+  accounts: [
     {
-      "name": "authority",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "seed",
-            "type": {
-              "array": [
-                "u8",
-                1
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "TokenMetadataParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenKind",
-            "type": {
-              "defined": "TokenKind"
-            }
-          },
-          {
-            "name": "collateralWeight",
-            "type": "u16"
-          },
-          {
-            "name": "maxLeverage",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "MarginPoolParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeDestination",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      name: "TokenKind",
+      name: "authority"
       type: {
-        kind: "enum",
+        kind: "struct"
+        fields: [
+          {
+            name: "seed"
+            type: {
+              array: ["u8", 1]
+            }
+          }
+        ]
+      }
+    }
+  ]
+  types: [
+    {
+      name: "TokenMetadataParams"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "tokenKind"
+            type: {
+              defined: "TokenKind"
+            }
+          },
+          {
+            name: "collateralWeight"
+            type: "u16"
+          },
+          {
+            name: "maxLeverage"
+            type: "u16"
+          }
+        ]
+      }
+    },
+    {
+      name: "MarginPoolParams"
+      type: {
+        kind: "struct"
+        fields: [
+          {
+            name: "feeDestination"
+            type: "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      name: "TokenKind"
+      type: {
+        kind: "enum"
         variants: [
           {
             name: "NonCollateral"
@@ -392,340 +389,337 @@ export type JetControl = {
           }
         ]
       }
-    },
+    }
   ]
-};
+}
 
 export const IDL: JetControl = {
-  "version": "0.1.0",
-  "name": "jet_control",
-  "instructions": [
+  version: "0.1.0",
+  name: "jet_control",
+  instructions: [
     {
-      "name": "createAuthority",
-      "accounts": [
+      name: "createAuthority",
+      accounts: [
         {
-          "name": "authority",
-          "isMut": true,
-          "isSigner": false
+          name: "authority",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: "payer",
+          isMut: true,
+          isSigner: true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false
         }
       ],
-      "args": []
+      args: []
     },
     {
-      "name": "registerToken",
-      "accounts": [
+      name: "registerToken",
+      accounts: [
         {
-          "name": "requester",
-          "isMut": true,
-          "isSigner": true
+          name: "requester",
+          isMut: true,
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "marginPool",
-          "isMut": true,
-          "isSigner": false
+          name: "marginPool",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "vault",
-          "isMut": true,
-          "isSigner": false
+          name: "vault",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "depositNoteMint",
-          "isMut": true,
-          "isSigner": false
+          name: "depositNoteMint",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "loanNoteMint",
-          "isMut": true,
-          "isSigner": false
+          name: "loanNoteMint",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
+          name: "tokenMint",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "tokenMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "tokenMetadata",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "depositNoteMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "depositNoteMetadata",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "loanNoteMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "loanNoteMetadata",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "marginPoolProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "marginPoolProgram",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "tokenProgram",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          name: "rent",
+          isMut: false,
+          isSigner: false
         }
       ],
-      "args": []
+      args: []
     },
     {
-      "name": "registerAdapter",
-      "accounts": [
+      name: "registerAdapter",
+      accounts: [
         {
-          "name": "requester",
-          "isMut": false,
-          "isSigner": true
+          name: "requester",
+          isMut: false,
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "adapter",
-          "isMut": false,
-          "isSigner": false
+          name: "adapter",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "metadataAccount",
-          "isMut": true,
-          "isSigner": false
+          name: "metadataAccount",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: "payer",
+          isMut: true,
+          isSigner: true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false
         }
       ],
-      "args": []
+      args: []
     },
     {
-      "name": "configureToken",
-      "accounts": [
+      name: "configureToken",
+      accounts: [
         {
-          "name": "requester",
-          "isMut": false,
-          "isSigner": true
+          name: "requester",
+          isMut: false,
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
+          name: "tokenMint",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "marginPool",
-          "isMut": true,
-          "isSigner": false
+          name: "marginPool",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "tokenMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "tokenMetadata",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "depositMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "depositMetadata",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "loanMetadata",
-          "isMut": true,
-          "isSigner": false
+          name: "loanMetadata",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "pythProduct",
-          "isMut": false,
-          "isSigner": false
+          name: "pythProduct",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "pythPrice",
-          "isMut": false,
-          "isSigner": false
+          name: "pythPrice",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "marginPoolProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "marginPoolProgram",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram",
+          isMut: false,
+          isSigner: false
         }
       ],
-      "args": [
+      args: [
         {
-          "name": "metadata",
-          "type": {
-            "option": {
-              "defined": "TokenMetadataParams"
+          name: "metadata",
+          type: {
+            option: {
+              defined: "TokenMetadataParams"
             }
           }
         },
         {
-          "name": "poolParam",
-          "type": {
-            "option": {
-              "defined": "MarginPoolParams"
+          name: "poolParam",
+          type: {
+            option: {
+              defined: "MarginPoolParams"
             }
           }
         },
         {
-          "name": "poolConfig",
-          "type": {
-            "option": {
-              "defined": "MarginPoolConfig"
+          name: "poolConfig",
+          type: {
+            option: {
+              defined: "MarginPoolConfig"
             }
           }
         }
       ]
     },
     {
-      "name": "setLiquidator",
-      "accounts": [
+      name: "setLiquidator",
+      accounts: [
         {
-          "name": "requester",
-          "isMut": false,
-          "isSigner": true
+          name: "requester",
+          isMut: false,
+          isSigner: true
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": false
+          name: "authority",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "liquidator",
-          "isMut": false,
-          "isSigner": false
+          name: "liquidator",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "metadataAccount",
-          "isMut": true,
-          "isSigner": false
+          name: "metadataAccount",
+          isMut: true,
+          isSigner: false
         },
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          name: "payer",
+          isMut: true,
+          isSigner: true
         },
         {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "metadataProgram",
+          isMut: false,
+          isSigner: false
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false
         }
       ],
-      "args": [
+      args: [
         {
-          "name": "isLiquidator",
-          "type": "bool"
+          name: "isLiquidator",
+          type: "bool"
         }
       ]
     }
   ],
-  "accounts": [
+  accounts: [
     {
-      "name": "authority",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "authority",
+      type: {
+        kind: "struct",
+        fields: [
           {
-            "name": "seed",
-            "type": {
-              "array": [
-                "u8",
-                1
-              ]
+            name: "seed",
+            type: {
+              array: ["u8", 1]
             }
           }
         ]
       }
     }
   ],
-  "types": [
+  types: [
     {
-      "name": "TokenMetadataParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "TokenMetadataParams",
+      type: {
+        kind: "struct",
+        fields: [
           {
-            "name": "tokenKind",
-            "type": {
-              "defined": "TokenKind"
+            name: "tokenKind",
+            type: {
+              defined: "TokenKind"
             }
           },
           {
-            "name": "collateralWeight",
-            "type": "u16"
+            name: "collateralWeight",
+            type: "u16"
           },
           {
-            "name": "maxLeverage",
-            "type": "u16"
+            name: "maxLeverage",
+            type: "u16"
           }
         ]
       }
     },
     {
-      "name": "MarginPoolParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "MarginPoolParams",
+      type: {
+        kind: "struct",
+        fields: [
           {
-            "name": "feeDestination",
-            "type": "publicKey"
+            name: "feeDestination",
+            type: "publicKey"
           }
         ]
       }
@@ -790,6 +784,6 @@ export const IDL: JetControl = {
           }
         ]
       }
-    },
+    }
   ]
-};
+}


### PR DESCRIPTION
Removed the need to require Chai in the bundle that gets packaged in the client library.
Also removed a couple of unused imports.

Master seems to be on 0.1.11 but the published version on npm is 0.1.17 so a bit unsure on what version number to use here.
@Tristyn can you clarify? :)