### PR TITLE
get localnet tests to pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "jet-simulation"
 version = "0.1.0"
-source = "git+https://github.com/jet-lab/jet-simulation?branch=master#a3ddc9b0cec7f944ded5e6b4ce538d88f3bcd9ef"
+source = "git+https://github.com/jet-lab/jet-simulation?branch=airdrop-more#803b6de2e043038a58569c090ad842fd1b4454b7"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/libraries/rust/Cargo.toml
+++ b/libraries/rust/Cargo.toml
@@ -24,7 +24,7 @@ anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 anchor-client = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 
-jet-simulation = { git = "https://github.com/jet-lab/jet-simulation", branch = "master" }
+jet-simulation = { git = "https://github.com/jet-lab/jet-simulation", branch = "airdrop-more" }
 jet-control = { path = "../../programs/control", features = ["no-entrypoint"] }
 jet-margin = { path = "../../programs/margin", features = ["no-entrypoint"] }
 jet-metadata = { path = "../../programs/metadata", features = ["no-entrypoint"] }

--- a/libraries/rust/src/tx_builder/user.rs
+++ b/libraries/rust/src/tx_builder/user.rs
@@ -350,9 +350,8 @@ impl MarginTxBuilder {
 
     /// Verify that the margin account is healthy
     pub async fn verify_healthy(&self) -> Result<Transaction> {
-        let ix = self.ix.verify_healthy();
-
-        Ok(Transaction::new_with_payer(&[ix], None))
+        self.create_unsigned_transaction(&[self.ix.verify_healthy()])
+            .await
     }
 
     /// Refresh a user's position in a margin pool

--- a/programs/margin/src/instructions/liquidate_end.rs
+++ b/programs/margin/src/instructions/liquidate_end.rs
@@ -25,6 +25,7 @@ use crate::{ErrorCode, Liquidation, MarginAccount, LIQUIDATION_TIMEOUT};
 pub struct LiquidateEnd<'info> {
     /// If the liquidation is timed out, this can be any account
     /// If the liquidation is not timed out, this must be the liquidator, and it must be a signer
+    #[account(mut)]
     pub authority: Signer<'info>,
 
     /// The account in need of liquidation

--- a/tests/hosted/Cargo.toml
+++ b/tests/hosted/Cargo.toml
@@ -39,5 +39,5 @@ jet-margin-sdk = { path = "../../libraries/rust", features = ["testing"] }
 
 mock-adapter = { path = "../mock-adapter", features = ["no-entrypoint"] }
 
-jet-simulation = { git = "https://github.com/jet-lab/jet-simulation", branch = "master" }
+jet-simulation = { git = "https://github.com/jet-lab/jet-simulation", branch = "airdrop-more" }
 jet-proto-math = "1"


### PR DESCRIPTION
Our tests are not running successfully on localnet because of various bugs in the programs an the surrounding code. I fixed several of these with the orca PR but there were still several remaining issues. This PR intends to get every test passing on localnet and running in github actions. this is a work in progress

program bugs fixed in this pr:
- margin: liquidate_end needs to pay the liquidator but the account was not mutable, so the ix fails
