### PR TITLE
reduce logs from return data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "jet-simulation"
 version = "0.1.0"
-source = "git+https://github.com/jet-lab/jet-simulation?branch=airdrop-more#803b6de2e043038a58569c090ad842fd1b4454b7"
+source = "git+https://github.com/jet-lab/jet-simulation?branch=master#9d453043acebbccb1e71f21016c9814a8e4ad089"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/programs/margin/src/adapter.rs
+++ b/programs/margin/src/adapter.rs
@@ -160,6 +160,9 @@ fn handle_adapter_result(ctx: &InvokeAdapter) -> Result<BTreeMap<Pubkey, Account
         }
     };
 
+    // clear return data after reading it
+    program::set_return_data(&[]);
+
     Ok(touched_positions)
 }
 

--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -245,8 +245,8 @@ pub enum ErrorCode {
 }
 
 pub fn write_adapter_result(margin_account: &MarginAccount, result: &AdapterResult) -> Result<()> {
-    let mut adapter_result_data = vec![0u8; 512];
-    result.serialize(&mut &mut adapter_result_data[..])?;
+    let mut adapter_result_data = vec![];
+    result.serialize(&mut adapter_result_data)?;
     margin_account.invocation.verify_directly_invoked()?;
     anchor_lang::solana_program::program::set_return_data(&adapter_result_data);
     Ok(())


### PR DESCRIPTION
- remove return data after reading it, so it doesn't get logged twice
- use dynamic size for buffer the serialized form is written to, to avoid logging unnecessary zero bytes