### PR TITLE
Margin account version bump

### DIFF
--- a/libraries/rust/src/ix_builder/margin.rs
+++ b/libraries/rust/src/ix_builder/margin.rs
@@ -54,7 +54,7 @@ impl MarginIxBuilder {
 
     pub fn new_with_payer(owner: Pubkey, seed: u16, payer: Pubkey) -> Self {
         let (address, _) = Pubkey::find_program_address(
-            &[owner.as_ref(), 0u16.to_le_bytes().as_ref()],
+            &[owner.as_ref(), seed.to_le_bytes().as_ref()],
             &jet_margin::ID,
         );
         Self {

--- a/libraries/rust/src/tx_builder/user.rs
+++ b/libraries/rust/src/tx_builder/user.rs
@@ -405,6 +405,22 @@ impl MarginTxBuilder {
         self.get_chunk_transactions(12, instructions).await
     }
 
+    /// Get the latest [MarginAccount] state
+    pub async fn get_account_state(&self) -> Result<Box<MarginAccount>> {
+        let account_data = self.rpc.get_account(&self.ix.address).await?;
+
+        match account_data {
+            None => bail!(
+                "no account state found for account {} belonging to {}",
+                self.ix.owner,
+                self.ix.address
+            ),
+            Some(account) => Ok(Box::new(MarginAccount::try_deserialize(
+                &mut &account.data[..],
+            )?)),
+        }
+    }
+
     async fn get_chunk_transactions(
         &self,
         chunk_size: usize,
@@ -506,21 +522,6 @@ impl MarginTxBuilder {
 
             loan_note_token_account
         })
-    }
-
-    async fn get_account_state(&self) -> Result<Box<MarginAccount>> {
-        let account_data = self.rpc.get_account(&self.ix.address).await?;
-
-        match account_data {
-            None => bail!(
-                "no account state found for account {} belonging to {}",
-                self.ix.owner,
-                self.ix.address
-            ),
-            Some(account) => Ok(Box::new(MarginAccount::try_deserialize(
-                &mut &account.data[..],
-            )?)),
-        }
     }
 
     fn adapter_invoke_ix(&self, inner: Instruction) -> Instruction {

--- a/programs/margin/src/state.rs
+++ b/programs/margin/src/state.rs
@@ -34,6 +34,13 @@ use crate::{
 
 const POS_PRICE_VALID: u8 = 1;
 
+/// The current margin version.
+///
+/// Version history:
+/// - 0: The margin account owns all positions
+/// - 1: Adapters own claims, from 08 July 2022
+pub const MARGIN_ACCOUNT_VERSION: u8 = 1;
+
 #[account(zero_copy)]
 #[repr(C)]
 // bytemuck requires a higher alignment than 1 for unit tests to run.
@@ -149,6 +156,7 @@ impl MarginAccount {
     }
 
     pub fn initialize(&mut self, owner: Pubkey, seed: u16, bump_seed: u8) {
+        self.version = MARGIN_ACCOUNT_VERSION;
         self.owner = owner;
         self.bump_seed = [bump_seed];
         self.user_seed = seed.to_le_bytes();

--- a/programs/margin/src/state.rs
+++ b/programs/margin/src/state.rs
@@ -34,11 +34,7 @@ use crate::{
 
 const POS_PRICE_VALID: u8 = 1;
 
-/// The current margin version.
-///
-/// Version history:
-/// - 0: The margin account owns all positions
-/// - 1: Adapters own claims, from 08 July 2022
+/// The current version for the margin account state
 pub const MARGIN_ACCOUNT_VERSION: u8 = 1;
 
 #[account(zero_copy)]


### PR DESCRIPTION
This bumps the margin account version to 1 from 0. This will help differentiate between accounts that were created before adapters owned claims.

We also start using the account seed, and expose the helper to get the margin account state.