### PR TITLE
Use `with` type functions that return ix over tx

### DIFF
--- a/libraries/ts/src/margin/marginAccount.ts
+++ b/libraries/ts/src/margin/marginAccount.ts
@@ -723,14 +723,14 @@ export class MarginAccount {
     }
   }
 
-  async getOrCreatePosition(tokenMint: Address) {
+  async withGetOrCreatePosition(tokenMint: Address) {
     assert(this.info)
     const tokenMintAddress = translateAddress(tokenMint)
 
     for (let i = 0; i < this.positions.length; i++) {
       const position = this.positions[i]
       if (position.token.equals(tokenMintAddress)) {
-        return position
+        return position.address
       }
     }
 
@@ -740,7 +740,7 @@ export class MarginAccount {
     for (let i = 0; i < this.positions.length; i++) {
       const position = this.positions[i]
       if (position.token.equals(tokenMintAddress)) {
-        return position
+        return position.address
       }
     }
 
@@ -755,13 +755,13 @@ export class MarginAccount {
 
   async withUpdateAllPositionBalances({ instructions }: { instructions: TransactionInstruction[] }) {
     for (const position of this.positions) {
-      await this.withUpdatePositionBalance({ instructions, position })
+      await this.withUpdatePositionBalance({ instructions, position: position.address })
     }
   }
 
   async updatePositionBalance({ position }: { position: AccountPosition }) {
     const instructions: TransactionInstruction[] = []
-    await this.withUpdatePositionBalance({ instructions, position })
+    await this.withUpdatePositionBalance({ instructions, position: position.address })
     return await this.provider.sendAndConfirm(new Transaction().add(...instructions))
   }
 
@@ -776,13 +776,13 @@ export class MarginAccount {
     position
   }: {
     instructions: TransactionInstruction[]
-    position: AccountPosition
+    position: Address
   }): Promise<void> {
     const instruction = await this.programs.margin.methods
       .updatePositionBalance()
       .accounts({
         marginAccount: this.address,
-        tokenAccount: position.address
+        tokenAccount: position
       })
       .instruction()
     instructions.push(instruction)

--- a/libraries/ts/src/utils/sendAll.ts
+++ b/libraries/ts/src/utils/sendAll.ts
@@ -29,7 +29,7 @@ export async function sendAll(
           })
           .filter(tx => !!tx) as Transaction[]
       } else {
-        let ixs = tx as any as TransactionInstruction[]
+        const ixs = tx as any as TransactionInstruction[]
         if (ixs.length > 0) {
           return [new Transaction({ feePayer: provider.wallet.publicKey, blockhash, lastValidBlockHeight }).add(...ixs)]
         }
@@ -39,7 +39,7 @@ export async function sendAll(
 
   let start = 0
   const slices = txs.map(tx => {
-    let length = Array.isArray(tx) ? tx.length : 1
+    const length = Array.isArray(tx) ? tx.length : 1
     const end = start + length
     const slice = [start, end]
     start = end


### PR DESCRIPTION
This PR minimises the number of transactions that are being called in the process of creating a position by adding the relevant instructions to existing tx calls.

- Create `withGetOrCreateDepositNotePosition` function
- Prefer `withCreateAccount` instead of `createAccount`