### PR TITLE
fix devnet deploy github action

### DIFF
--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  ANCHOR_CLI_VERSION: 0.25
+  ANCHOR_CLI_VERSION: 0.25.0
   SOLANA_CLI_VERSION: 1.10.24
   VALIDATOR_IMG: jet-v2-test-validator
 


### PR DESCRIPTION
How do we test this? I guess merging is the only option?

implementation: specify the full version of anchor in the devnet deploy github action

Not sure why this is necessary because the ts tests work fine without the patch number. But maybe there's something unique about the commands run here? Anyway the logs say it can't figure out the version, and my recent change changed it from 0.23.0 to 0.25. So changing it to 0.25.0 is my best guess.