### PR TITLE
Wrap `marginBorrow` instructions in one tx only

### DIFF
--- a/libraries/ts/src/margin/marginAccount.ts
+++ b/libraries/ts/src/margin/marginAccount.ts
@@ -725,7 +725,7 @@ export class MarginAccount {
     }
   }
 
-  async withGetOrCreatePosition(tokenMint: Address) {
+  async withGetOrCreatePosition(tokenMint: Address, instructions: TransactionInstruction[]) {
     assert(this.info)
     const tokenMintAddress = translateAddress(tokenMint)
 
@@ -736,17 +736,7 @@ export class MarginAccount {
       }
     }
 
-    await this.registerPosition(tokenMintAddress)
-    await this.refresh()
-
-    for (let i = 0; i < this.positions.length; i++) {
-      const position = this.positions[i]
-      if (position.token.equals(tokenMintAddress)) {
-        return position.address
-      }
-    }
-
-    throw new Error("Unable to register position.")
+    return await this.withRegisterPosition(instructions, tokenMintAddress)
   }
 
   async updateAllPositionBalances() {
@@ -930,8 +920,8 @@ export class MarginAccount {
 
   // prepares arguments for adapterInvoke, accountInvoke, or liquidatorInvoke
   invokeAccounts(adapterInstruction: TransactionInstruction): AccountMeta[] {
-    let accounts: AccountMeta[] = []
-    for (let acc of adapterInstruction.keys) {
+    const accounts: AccountMeta[] = []
+    for (const acc of adapterInstruction.keys) {
       let isSigner = false
       if (acc.pubkey != this.address) {
         isSigner = acc.isSigner

--- a/libraries/ts/src/margin/marginAccount.ts
+++ b/libraries/ts/src/margin/marginAccount.ts
@@ -725,9 +725,35 @@ export class MarginAccount {
     }
   }
 
-  async withGetOrCreatePosition(tokenMint: Address, instructions: TransactionInstruction[]) {
+  async getOrCreatePosition(tokenMint: Address) {
     assert(this.info)
     const tokenMintAddress = translateAddress(tokenMint)
+    for (let i = 0; i < this.positions.length; i++) {
+      const position = this.positions[i]
+      if (position.token.equals(tokenMintAddress)) {
+        return position.address
+      }
+    }
+    await this.registerPosition(tokenMintAddress)
+    await this.refresh()
+    for (let i = 0; i < this.positions.length; i++) {
+      const position = this.positions[i]
+      if (position.token.equals(tokenMintAddress)) {
+        return position.address
+      }
+    }
+    throw new Error("Unable to register position.")
+  }
+
+  async withGetOrCreatePosition({
+    positionTokenMint,
+    instructions
+  }: {
+    positionTokenMint: Address,
+    instructions: TransactionInstruction[]
+  }) {
+    assert(this.info)
+    const tokenMintAddress = translateAddress(positionTokenMint)
 
     for (let i = 0; i < this.positions.length; i++) {
       const position = this.positions[i]

--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -443,10 +443,8 @@ export class Pool {
     assert(marginAccount)
     assert(change)
 
-    await marginAccount.createAccount()
-    await sleep(2000)
-    await marginAccount.refresh()
     const instructions: TransactionInstruction[] = []
+    await marginAccount.withCreateAccount(instructions)
     const position = await marginAccount.withGetOrCreatePosition({
       positionTokenMint: this.addresses.depositNoteMint,
       instructions

--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -443,12 +443,12 @@ export class Pool {
     assert(marginAccount)
     assert(change)
 
+    await marginAccount.createAccount()
+    await sleep(2000)
+    await marginAccount.refresh()
+
     const instructions: TransactionInstruction[] = []
-    await marginAccount.withCreateAccount(instructions)
-    const position = await marginAccount.withGetOrCreatePosition({
-      positionTokenMint: this.addresses.depositNoteMint,
-      instructions
-    })
+    const position = await marginAccount.getOrCreatePosition(this.addresses.depositNoteMint)
     assert(position)
 
     await this.withDeposit({

--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -470,7 +470,10 @@ export class Pool {
     await sleep(2000)
     await marginAccount.refresh()
     const instructions: TransactionInstruction[] = []
-    const position = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, instructions)
+    const position = await marginAccount.withGetOrCreatePosition({
+      positionTokenMint: this.addresses.depositNoteMint,
+      instructions
+    })
     assert(position)
 
     await this.withDeposit({
@@ -545,7 +548,10 @@ export class Pool {
     const refreshInstructions: TransactionInstruction[] = []
     const instructionsInstructions: TransactionInstruction[] = []
 
-    const depositPosition = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, refreshInstructions)
+    const depositPosition = await marginAccount.withGetOrCreatePosition({
+      positionTokenMint: this.addresses.depositNoteMint,
+      instructions: refreshInstructions
+    })
     assert(depositPosition)
 
     await this.withMarginRefreshAllPositionPrices({ instructions: refreshInstructions, pools, marginAccount })
@@ -668,7 +674,10 @@ export class Pool {
     await marginAccount.refresh()
     const refreshInstructions: TransactionInstruction[] = []
     const instructions: TransactionInstruction[] = []
-    const depositPosition = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, refreshInstructions)
+    const depositPosition = await marginAccount.withGetOrCreatePosition({
+      positionTokenMint: this.addresses.depositNoteMint,
+      instructions: refreshInstructions
+    })
     assert(depositPosition)
 
     await this.withMarginRefreshAllPositionPrices({ instructions: refreshInstructions, pools, marginAccount })
@@ -807,11 +816,11 @@ export class Pool {
     destination?: TokenAddress
   }) {
     // FIXME: can source be calculated in withdraw?
+    const source = await marginAccount.getOrCreatePosition(this.addresses.depositNoteMint)
+
     const preInstructions: TransactionInstruction[] = []
     const refreshInstructions: TransactionInstruction[] = []
     const instructions: TransactionInstruction[] = []
-
-    const source = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, refreshInstructions)
 
     await this.withMarginRefreshAllPositionPrices({ instructions: refreshInstructions, pools, marginAccount })
     await marginAccount.withUpdateAllPositionBalances({ instructions: refreshInstructions })

--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -470,7 +470,7 @@ export class Pool {
     await sleep(2000)
     await marginAccount.refresh()
     const instructions: TransactionInstruction[] = []
-    const position = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint)
+    const position = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, instructions)
     assert(position)
 
     await this.withDeposit({
@@ -545,7 +545,7 @@ export class Pool {
     const refreshInstructions: TransactionInstruction[] = []
     const instructionsInstructions: TransactionInstruction[] = []
 
-    const depositPosition = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint)
+    const depositPosition = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, refreshInstructions)
     assert(depositPosition)
 
     await this.withMarginRefreshAllPositionPrices({ instructions: refreshInstructions, pools, marginAccount })
@@ -666,11 +666,10 @@ export class Pool {
     change: PoolTokenChange
   }) {
     await marginAccount.refresh()
-    const depositPosition = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint)
-    assert(depositPosition)
-
     const refreshInstructions: TransactionInstruction[] = []
     const instructions: TransactionInstruction[] = []
+    const depositPosition = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, refreshInstructions)
+    assert(depositPosition)
 
     await this.withMarginRefreshAllPositionPrices({ instructions: refreshInstructions, pools, marginAccount })
 
@@ -808,11 +807,11 @@ export class Pool {
     destination?: TokenAddress
   }) {
     // FIXME: can source be calculated in withdraw?
-    const source = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint)
-
     const preInstructions: TransactionInstruction[] = []
     const refreshInstructions: TransactionInstruction[] = []
     const instructions: TransactionInstruction[] = []
+
+    const source = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint, refreshInstructions)
 
     await this.withMarginRefreshAllPositionPrices({ instructions: refreshInstructions, pools, marginAccount })
     await marginAccount.withUpdateAllPositionBalances({ instructions: refreshInstructions })


### PR DESCRIPTION
- `Pool.marginBorrow` instructions are added to part of an transaction instead of being called as separate txns, minimising the number of transactions that are called and thus the number of transactions that need to be approved by the end user.