### PR TITLE
Fix incorrect flight logs

### DIFF
--- a/libraries/ts/package.json
+++ b/libraries/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jet-lab/margin",
-  "version": "0.1.42",
+  "version": "0.1.46",
   "description": "Library for interacting with the Jet margin on-chain programs",
   "keywords": [
     "solana",

--- a/libraries/ts/src/margin/marginClient.ts
+++ b/libraries/ts/src/margin/marginClient.ts
@@ -142,13 +142,6 @@ export class MarginClient {
       }
     }
 
-    if (
-      txAndSig.sig.signature ===
-      "3qRRjLtXNPtUGXS7tkEtm3pFe13jp11WzbF9FPuA7oV9GEnYJGBFiNwwfCfAtm9YEuszUPBdT7Bg65GFFXG3Hj3t"
-    ) {
-      console.log(txAndSig)
-    }
-
     // Check each logMessage string for instruction
     // Break after finding the first logMessage for which above is true
     for (let i = 0; i < transaction.meta.logMessages.length; i++) {

--- a/libraries/ts/src/margin/marginClient.ts
+++ b/libraries/ts/src/margin/marginClient.ts
@@ -123,11 +123,11 @@ export class MarginClient {
     }
 
     const instructions = {
-      "deposit": "Instruction: Deposit",
-      "withdraw": "Instruction: Withdraw",
-      "borrow": "Instruction: MarginBorrow",
+      deposit: "Instruction: Deposit",
+      withdraw: "Instruction: Withdraw",
+      borrow: "Instruction: MarginBorrow",
       "margin repay": "Instruction: MarginRepay",
-      "repay": "Instruction: Repay"
+      repay: "Instruction: Repay"
     }
     let tradeAction = ""
 
@@ -137,9 +137,16 @@ export class MarginClient {
       for (const action of Object.keys(instructions)) {
         if (logLine.includes(instructions[action])) {
           tradeAction = action
-          return true;
+          return true
         }
       }
+    }
+
+    if (
+      txAndSig.sig.signature ===
+      "3qRRjLtXNPtUGXS7tkEtm3pFe13jp11WzbF9FPuA7oV9GEnYJGBFiNwwfCfAtm9YEuszUPBdT7Bg65GFFXG3Hj3t"
+    ) {
+      console.log(txAndSig)
     }
 
     // Check each logMessage string for instruction
@@ -159,7 +166,9 @@ export class MarginClient {
     } as { tradeAction: TradeAction }
     for (let i = 0; i < transaction.meta.preTokenBalances?.length; i++) {
       const pre = transaction.meta.preTokenBalances[i]
-      const matchingPost = transaction.meta.postTokenBalances?.find(post => post.mint === pre.mint)
+      const matchingPost = transaction.meta.postTokenBalances?.find(
+        post => post.mint === pre.mint && post.owner === pre.owner
+      )
       if (matchingPost && matchingPost.uiTokenAmount.amount !== pre.uiTokenAmount.amount) {
         let token: MarginTokenConfig | null = null
         for (let j = 0; j < Object.entries(mints).length; j++) {


### PR DESCRIPTION
Under specific circumstances, the flight logs parsing function was matching token balances with the same mint but not checking that the owner was actually the same, occasionally creating logs which would show the balance of the pool instead of the user / margin account