### PR TITLE
Wrap deposit instructions in one tx only

### DIFF
--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -443,10 +443,8 @@ export class Pool {
     assert(marginAccount)
     assert(change)
 
-    await marginAccount.createAccount()
-    await sleep(2000)
-    await marginAccount.refresh()
     const instructions: TransactionInstruction[] = []
+    await marginAccount.withCreateAccount(instructions)
     const position = await marginAccount.withGetOrCreatePosition(this.addresses.depositNoteMint)
     assert(position)
 


### PR DESCRIPTION
- `Pool.deposit` instructions are added to part of a transaction instead of being called as separate txns, minimising the number of transactions that are called and thus the number of transactions that need to be approved by the end user.