### PR TITLE
Removes fee collection threshold

### DIFF
--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -573,7 +573,8 @@ pub struct MarginPoolConfig {
     /// The fee rate applied to interest payments collected
     pub management_fee_rate: u16,
 
-    _reserved: u64
+    /// Unused
+    pub reserved: u64
 }
 
 bitflags::bitflags! {

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -574,7 +574,7 @@ pub struct MarginPoolConfig {
     pub management_fee_rate: u16,
 
     /// Unused
-    pub reserved: u64
+    pub reserved: u64,
 }
 
 bitflags::bitflags! {

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -572,6 +572,8 @@ pub struct MarginPoolConfig {
 
     /// The fee rate applied to interest payments collected
     pub management_fee_rate: u16,
+
+    _reserved: u64
 }
 
 bitflags::bitflags! {

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -262,18 +262,20 @@ impl MarginPool {
     ///
     /// Returns the number of notes to mint to represent the collected fees
     pub fn collect_accrued_fees(&mut self) -> u64 {
-        let threshold = Number::from(self.config.management_fee_collect_threshold);
         let uncollected = *self.total_uncollected_fees();
-
-        if uncollected < threshold {
-            // not enough accumulated to be worth minting new notes
-            return 0;
-        }
 
         let fee_notes = (uncollected / self.deposit_note_exchange_rate()).as_u64(0);
 
-        *self.total_uncollected_fees_mut() = Number::ZERO;
-        self.deposit_notes = self.deposit_notes.checked_add(fee_notes).unwrap();
+        // Collect fees, preserving the remainder token amount.
+
+        if fee_notes > 0 {
+            let collected_tokens =
+                Number::from_decimal(fee_notes, 0) * self.deposit_note_exchange_rate();
+            let remainder = uncollected - collected_tokens;
+
+            *self.total_uncollected_fees_mut() = remainder;
+            self.deposit_notes = self.deposit_notes.checked_add(fee_notes).unwrap();
+        }
 
         fee_notes
     }
@@ -570,9 +572,6 @@ pub struct MarginPoolConfig {
 
     /// The fee rate applied to interest payments collected
     pub management_fee_rate: u16,
-
-    /// The threshold for fee collection
-    pub management_fee_collect_threshold: u64,
 }
 
 bitflags::bitflags! {

--- a/tests/hosted/src/setup_helper.rs
+++ b/tests/hosted/src/setup_helper.rs
@@ -23,6 +23,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
+    reserved: 0
 };
 
 pub struct TestEnvironment {

--- a/tests/hosted/src/setup_helper.rs
+++ b/tests/hosted/src/setup_helper.rs
@@ -22,7 +22,6 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_1: 10,
     utilization_rate_2: 20,
     management_fee_rate: 10,
-    management_fee_collect_threshold: 100,
     flags: PoolFlags::ALLOW_LENDING.bits(),
 };
 

--- a/tests/hosted/src/setup_helper.rs
+++ b/tests/hosted/src/setup_helper.rs
@@ -23,7 +23,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
-    reserved: 0
+    reserved: 0,
 };
 
 pub struct TestEnvironment {

--- a/tests/hosted/tests/pool_overpayment.rs
+++ b/tests/hosted/tests/pool_overpayment.rs
@@ -26,7 +26,6 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_1: 10,
     utilization_rate_2: 20,
     management_fee_rate: 10,
-    management_fee_collect_threshold: 100,
     flags: PoolFlags::ALLOW_LENDING.bits(),
 };
 

--- a/tests/hosted/tests/pool_overpayment.rs
+++ b/tests/hosted/tests/pool_overpayment.rs
@@ -27,6 +27,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
+    reserved: 0
 };
 
 struct TestEnv {

--- a/tests/hosted/tests/pool_overpayment.rs
+++ b/tests/hosted/tests/pool_overpayment.rs
@@ -27,7 +27,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
-    reserved: 0
+    reserved: 0,
 };
 
 struct TestEnv {

--- a/tests/hosted/tests/rounding.rs
+++ b/tests/hosted/tests/rounding.rs
@@ -26,7 +26,6 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_1: 10,
     utilization_rate_2: 20,
     management_fee_rate: 10,
-    management_fee_collect_threshold: 100,
     flags: PoolFlags::ALLOW_LENDING.bits(),
 };
 

--- a/tests/hosted/tests/rounding.rs
+++ b/tests/hosted/tests/rounding.rs
@@ -27,6 +27,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
+    reserved: 0
 };
 
 struct TestEnv {

--- a/tests/hosted/tests/rounding.rs
+++ b/tests/hosted/tests/rounding.rs
@@ -27,7 +27,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
-    reserved: 0
+    reserved: 0,
 };
 
 struct TestEnv {

--- a/tests/hosted/tests/sanity.rs
+++ b/tests/hosted/tests/sanity.rs
@@ -30,7 +30,6 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_1: 10,
     utilization_rate_2: 20,
     management_fee_rate: 10,
-    management_fee_collect_threshold: 100,
     flags: PoolFlags::ALLOW_LENDING.bits(),
 };
 

--- a/tests/hosted/tests/sanity.rs
+++ b/tests/hosted/tests/sanity.rs
@@ -31,6 +31,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
+    reserved: 0
 };
 
 struct TestEnv {

--- a/tests/hosted/tests/sanity.rs
+++ b/tests/hosted/tests/sanity.rs
@@ -31,7 +31,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
-    reserved: 0
+    reserved: 0,
 };
 
 struct TestEnv {

--- a/tests/hosted/tests/swap.rs
+++ b/tests/hosted/tests/swap.rs
@@ -28,7 +28,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
-    reserved: 0
+    reserved: 0,
 };
 
 /// Test token swaps for the official SPL token swap

--- a/tests/hosted/tests/swap.rs
+++ b/tests/hosted/tests/swap.rs
@@ -28,6 +28,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_2: 20,
     management_fee_rate: 10,
     flags: PoolFlags::ALLOW_LENDING.bits(),
+    reserved: 0
 };
 
 /// Test token swaps for the official SPL token swap

--- a/tests/hosted/tests/swap.rs
+++ b/tests/hosted/tests/swap.rs
@@ -27,7 +27,6 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
     utilization_rate_1: 10,
     utilization_rate_2: 20,
     management_fee_rate: 10,
-    management_fee_collect_threshold: 100,
     flags: PoolFlags::ALLOW_LENDING.bits(),
 };
 

--- a/tests/integration/pool/marginPoolBorrow.test.ts
+++ b/tests/integration/pool/marginPoolBorrow.test.ts
@@ -102,7 +102,6 @@ describe("margin pool borrow", () => {
     utilizationRate1: 10,
     utilizationRate2: 20,
     managementFeeRate: 10,
-    managementFeeCollectThreshold: new BN(100),
     flags: new BN(2) // ALLOW_LENDING
   }
 

--- a/tests/integration/pool/marginPoolDeposit.test.ts
+++ b/tests/integration/pool/marginPoolDeposit.test.ts
@@ -100,7 +100,6 @@ describe("margin pool deposit", () => {
     utilizationRate1: 10,
     utilizationRate2: 20,
     managementFeeRate: 10,
-    managementFeeCollectThreshold: new BN(100),
     flags: new BN(2) // ALLOW_LENDING
   }
 


### PR DESCRIPTION
We have been using a fee collection threshold to ensure that rounding does not cost us an appreciable fraction of fees collected. We can instead forgo the threshold and explicitly track the remainder as we collect fees.

This removes one parameter per pool for us to manage.