### PR TITLE
Restrict SetTo behaviour to set-to-zero

### DIFF
--- a/libraries/rust/src/ix_builder/margin_pool.rs
+++ b/libraries/rust/src/ix_builder/margin_pool.rs
@@ -133,12 +133,11 @@ impl MarginPoolIxBuilder {
         }
         .to_account_metas(None);
 
-        let TokenChange { kind, tokens } = change;
         Instruction {
             program_id: jet_margin_pool::ID,
             data: ix_data::Deposit {
-                change_kind: kind,
-                amount: tokens,
+                change_kind: change.get_kind(),
+                amount: change.get_tokens(),
             }
             .data(),
             accounts,
@@ -171,12 +170,11 @@ impl MarginPoolIxBuilder {
         }
         .to_account_metas(None);
 
-        let TokenChange { kind, tokens } = change;
         Instruction {
             program_id: jet_margin_pool::ID,
             data: ix_data::Withdraw {
-                change_kind: kind,
-                amount: tokens,
+                change_kind: change.get_kind(),
+                amount: change.get_tokens(),
             }
             .data(),
             accounts,
@@ -209,12 +207,11 @@ impl MarginPoolIxBuilder {
         }
         .to_account_metas(None);
 
-        let TokenChange { kind, tokens } = change;
         Instruction {
             program_id: jet_margin_pool::ID,
             data: ix_data::MarginBorrow {
-                change_kind: kind,
-                amount: tokens,
+                change_kind: change.get_kind(),
+                amount: change.get_tokens(),
             }
             .data(),
             accounts,
@@ -247,12 +244,11 @@ impl MarginPoolIxBuilder {
         }
         .to_account_metas(None);
 
-        let TokenChange { kind, tokens } = change;
         Instruction {
             program_id: jet_margin_pool::ID,
             data: ix_data::MarginRepay {
-                change_kind: kind,
-                amount: tokens,
+                change_kind: change.get_kind(),
+                amount: change.get_tokens(),
             }
             .data(),
             accounts,
@@ -286,12 +282,11 @@ impl MarginPoolIxBuilder {
         }
         .to_account_metas(None);
 
-        let TokenChange { kind, tokens } = change;
         Instruction {
             program_id: jet_margin_pool::ID,
             data: ix_data::Repay {
-                change_kind: kind,
-                amount: tokens,
+                change_kind: change.get_kind(),
+                amount: change.get_tokens(),
             }
             .data(),
             accounts,

--- a/programs/margin-pool/src/instructions/deposit.rs
+++ b/programs/margin-pool/src/instructions/deposit.rs
@@ -82,7 +82,7 @@ impl<'info> Deposit<'info> {
 }
 
 pub fn deposit_handler(ctx: Context<Deposit>, change_kind: ChangeKind, amount: u64) -> Result<()> {
-    let change = TokenChange::new(change_kind, amount);
+    let change = TokenChange::new(change_kind, amount)?;
 
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;

--- a/programs/margin-pool/src/instructions/deposit.rs
+++ b/programs/margin-pool/src/instructions/deposit.rs
@@ -82,10 +82,7 @@ impl<'info> Deposit<'info> {
 }
 
 pub fn deposit_handler(ctx: Context<Deposit>, change_kind: ChangeKind, amount: u64) -> Result<()> {
-    let change = TokenChange {
-        kind: change_kind,
-        tokens: amount,
-    };
+    let change = TokenChange::new(change_kind, amount);
 
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;

--- a/programs/margin-pool/src/instructions/margin_borrow.rs
+++ b/programs/margin-pool/src/instructions/margin_borrow.rs
@@ -92,7 +92,7 @@ pub fn margin_borrow_handler(
     change_kind: ChangeKind,
     amount: u64,
 ) -> Result<()> {
-    let change = TokenChange::new(change_kind, amount);
+    let change = TokenChange::new(change_kind, amount)?;
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/margin_borrow.rs
+++ b/programs/margin-pool/src/instructions/margin_borrow.rs
@@ -92,10 +92,7 @@ pub fn margin_borrow_handler(
     change_kind: ChangeKind,
     amount: u64,
 ) -> Result<()> {
-    let change = TokenChange {
-        kind: change_kind,
-        tokens: amount,
-    };
+    let change = TokenChange::new(change_kind, amount);
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/margin_repay.rs
+++ b/programs/margin-pool/src/instructions/margin_repay.rs
@@ -87,7 +87,7 @@ pub fn margin_repay_handler(
     change_kind: ChangeKind,
     amount: u64,
 ) -> Result<()> {
-    let change = TokenChange::new(change_kind, amount);
+    let change = TokenChange::new(change_kind, amount)?;
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/margin_repay.rs
+++ b/programs/margin-pool/src/instructions/margin_repay.rs
@@ -87,10 +87,7 @@ pub fn margin_repay_handler(
     change_kind: ChangeKind,
     amount: u64,
 ) -> Result<()> {
-    let change = TokenChange {
-        kind: change_kind,
-        tokens: amount,
-    };
+    let change = TokenChange::new(change_kind, amount);
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/repay.rs
+++ b/programs/margin-pool/src/instructions/repay.rs
@@ -78,10 +78,7 @@ impl<'info> Repay<'info> {
 }
 
 pub fn repay_handler(ctx: Context<Repay>, change_kind: ChangeKind, amount: u64) -> Result<()> {
-    let change = TokenChange {
-        kind: change_kind,
-        tokens: amount,
-    };
+    let change = TokenChange::new(change_kind, amount);
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/repay.rs
+++ b/programs/margin-pool/src/instructions/repay.rs
@@ -78,7 +78,7 @@ impl<'info> Repay<'info> {
 }
 
 pub fn repay_handler(ctx: Context<Repay>, change_kind: ChangeKind, amount: u64) -> Result<()> {
-    let change = TokenChange::new(change_kind, amount);
+    let change = TokenChange::new(change_kind, amount)?;
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/withdraw.rs
+++ b/programs/margin-pool/src/instructions/withdraw.rs
@@ -86,10 +86,7 @@ pub fn withdraw_handler(
     change_kind: ChangeKind,
     amount: u64,
 ) -> Result<()> {
-    let change = TokenChange {
-        kind: change_kind,
-        tokens: amount,
-    };
+    let change = TokenChange::new(change_kind, amount);
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/instructions/withdraw.rs
+++ b/programs/margin-pool/src/instructions/withdraw.rs
@@ -86,7 +86,7 @@ pub fn withdraw_handler(
     change_kind: ChangeKind,
     amount: u64,
 ) -> Result<()> {
-    let change = TokenChange::new(change_kind, amount);
+    let change = TokenChange::new(change_kind, amount)?;
     let pool = &mut ctx.accounts.margin_pool;
     let clock = Clock::get()?;
 

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -109,7 +109,7 @@ pub use detail::TokenChange;
 mod detail {
     use anchor_lang::prelude::*;
 
-    use crate::{ChangeKind, Amount, ErrorCode};
+    use crate::{Amount, ChangeKind, ErrorCode};
 
     /// Interface for changing the token value of an account through pool instructions
     #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy)]

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -105,41 +105,48 @@ mod jet_margin_pool {
     }
 }
 
-/// Interface for changing the token value of an account through pool instructions
-#[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy)]
-pub struct TokenChange {
-    kind: ChangeKind,
-    tokens: u64,
-}
+pub use detail::TokenChange;
+mod detail {
+    use anchor_lang::prelude::*;
 
-impl TokenChange {
-    pub fn new(kind: ChangeKind, tokens: u64) -> Self {
-        Self { kind, tokens }
+    use crate::{ChangeKind, Amount};
+
+    /// Interface for changing the token value of an account through pool instructions
+    #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy)]
+    pub struct TokenChange {
+        kind: ChangeKind,
+        tokens: u64,
     }
 
-    pub const fn set(value: u64) -> Self {
-        Self {
-            kind: ChangeKind::SetTo,
-            tokens: value,
+    impl TokenChange {
+        pub fn new(kind: ChangeKind, tokens: u64) -> Self {
+            Self { kind, tokens }
         }
-    }
-    pub const fn shift(value: u64) -> Self {
-        Self {
-            kind: ChangeKind::ShiftBy,
-            tokens: value,
+
+        pub const fn set(value: u64) -> Self {
+            Self {
+                kind: ChangeKind::SetTo,
+                tokens: value,
+            }
         }
-    }
+        pub const fn shift(value: u64) -> Self {
+            Self {
+                kind: ChangeKind::ShiftBy,
+                tokens: value,
+            }
+        }
 
-    pub fn amount(&self) -> Amount {
-        Amount::tokens(self.tokens)
-    }
+        pub fn amount(&self) -> Amount {
+            Amount::tokens(self.tokens)
+        }
 
-    pub fn get_kind(&self) -> ChangeKind {
-        self.kind
-    }
+        pub fn get_kind(&self) -> ChangeKind {
+            self.kind
+        }
 
-    pub fn get_tokens(&self) -> u64 {
-        self.tokens
+        pub fn get_tokens(&self) -> u64 {
+            self.tokens
+        }
     }
 }
 

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -108,11 +108,15 @@ mod jet_margin_pool {
 /// Interface for changing the token value of an account through pool instructions
 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy)]
 pub struct TokenChange {
-    pub kind: ChangeKind,
-    pub tokens: u64,
+    kind: ChangeKind,
+    tokens: u64,
 }
 
 impl TokenChange {
+    pub fn new(kind: ChangeKind, tokens: u64) -> Self {
+        Self { kind, tokens }
+    }
+
     pub const fn set(value: u64) -> Self {
         Self {
             kind: ChangeKind::SetTo,
@@ -128,6 +132,14 @@ impl TokenChange {
 
     pub fn amount(&self) -> Amount {
         Amount::tokens(self.tokens)
+    }
+
+    pub fn get_kind(&self) -> ChangeKind {
+        self.kind
+    }
+
+    pub fn get_tokens(&self) -> u64 {
+        self.tokens
     }
 }
 

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -230,3 +230,21 @@ pub enum ErrorCode {
     /// 141108 - Attempt repayment of more tokens than total outstanding
     RepaymentExceedsTotalOutstanding,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_set_to_guard() {
+        TokenChange::new(ChangeKind::SetTo, 1).unwrap();
+    }
+
+    #[test]
+    fn test_set_to_guard_pass() {
+        TokenChange::new(ChangeKind::SetTo, 0).unwrap();
+        TokenChange::new(ChangeKind::ShiftBy, 0).unwrap();
+        TokenChange::new(ChangeKind::ShiftBy, 1).unwrap();
+    }
+}

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -109,7 +109,7 @@ pub use detail::TokenChange;
 mod detail {
     use anchor_lang::prelude::*;
 
-    use crate::{ChangeKind, Amount};
+    use crate::{ChangeKind, Amount, ErrorCode};
 
     /// Interface for changing the token value of an account through pool instructions
     #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy)]
@@ -119,8 +119,11 @@ mod detail {
     }
 
     impl TokenChange {
-        pub fn new(kind: ChangeKind, tokens: u64) -> Self {
-            Self { kind, tokens }
+        pub fn new(kind: ChangeKind, tokens: u64) -> Result<Self> {
+            match kind {
+                ChangeKind::SetTo if tokens > 0 => Err(ErrorCode::InvalidSetTo.into()),
+                _ => Ok(Self { kind, tokens }),
+            }
         }
 
         pub const fn set(value: u64) -> Self {
@@ -221,7 +224,7 @@ pub enum ErrorCode {
     InvalidOracle,
 
     /// 141107 - Tried to set an invalid token value
-    #[msg("An invalid `SetTo` value was given for a `TokenChange`")]
+    #[msg("`value` must be zero for a `TokenChange` with kind `SetTo`")]
     InvalidSetTo,
 
     /// 141108 - Attempt repayment of more tokens than total outstanding

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -331,9 +331,11 @@ impl MarginPool {
     ) -> Result<FullAmount> {
         match change.get_kind() {
             ChangeKind::ShiftBy => self.convert_amount(Amount::tokens(change.get_tokens()), action),
-            ChangeKind::SetTo => {
-                self.calculate_set_amount(current_notes, Amount::tokens(change.get_tokens()), action)
-            }
+            ChangeKind::SetTo => self.calculate_set_amount(
+                current_notes,
+                Amount::tokens(change.get_tokens()),
+                action,
+            ),
         }
     }
 

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -329,10 +329,10 @@ impl MarginPool {
         change: TokenChange,
         action: PoolAction,
     ) -> Result<FullAmount> {
-        match change.kind {
-            ChangeKind::ShiftBy => self.convert_amount(Amount::tokens(change.tokens), action),
+        match change.get_kind() {
+            ChangeKind::ShiftBy => self.convert_amount(Amount::tokens(change.get_tokens()), action),
             ChangeKind::SetTo => {
-                self.calculate_set_amount(current_notes, Amount::tokens(change.tokens), action)
+                self.calculate_set_amount(current_notes, Amount::tokens(change.get_tokens()), action)
             }
         }
     }


### PR DESCRIPTION
SetTo with non-zero token values is problematic. We have modified the front end to use only set-to-zero behaviour and now want to enforce this in the margin pool program.

JV15-276

We would ideally refactor the program api further.