### PR TITLE
JV15-277 Set signer if sourceAuthority is undefined

### DIFF
--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -647,13 +647,15 @@ export class Pool {
     pools,
     source,
     change,
-    closeLoan
+    closeLoan,
+    signer
   }: {
     marginAccount: MarginAccount
     pools: Pool[]
     source?: TokenAddress
     change: PoolTokenChange
     closeLoan?: boolean
+    signer?: Address
   }): Promise<string> {
     await marginAccount.refresh()
     const refreshInstructions: TransactionInstruction[] = []
@@ -684,7 +686,8 @@ export class Pool {
         loanPosition: loanNoteAccount,
         source,
         change,
-        feesBuffer
+        feesBuffer,
+        sourceAuthority: signer
       })
     }
 
@@ -762,7 +765,7 @@ export class Pool {
         vault: this.addresses.vault,
         loanAccount: loanPosition,
         repaymentTokenAccount: wrappedSource,
-        repaymentAccountAuthority: sourceAuthority,
+        repaymentAccountAuthority: sourceAuthority ?? marginAccount.provider.wallet.publicKey,
         tokenProgram: TOKEN_PROGRAM_ID
       })
       .instruction()


### PR DESCRIPTION
This fixes https://jetprotocol.atlassian.net/browse/JV15-277 by setting a fallback value for `sourceAuthority` if one has not been provided in previous calls, such as in `marginRepay`.