### PR TITLE
Improved risk indicator

### DIFF
--- a/libraries/ts/src/margin/marginAccount.ts
+++ b/libraries/ts/src/margin/marginAccount.ts
@@ -90,8 +90,7 @@ export class MarginAccount {
   static readonly RISK_WARNING_LEVEL = 0.9
   static readonly RISK_CRITICAL_LEVEL = 0.95
   static readonly RISK_LIQUIDATION_LEVEL = 1
-  // TODO: Change to 0.5, or new BN(50) for mainnet deployment
-  static readonly SETUP_LEVERAGE_FRACTION = Number128.fromDecimal(new BN(100), -2)
+  static readonly SETUP_LEVERAGE_FRACTION = Number128.fromDecimal(new BN(50), -2)
 
   info?: {
     marginAccount: MarginAccountData

--- a/libraries/ts/src/margin/marginAccount.ts
+++ b/libraries/ts/src/margin/marginAccount.ts
@@ -87,8 +87,8 @@ export interface MarginWalletTokens {
 
 export class MarginAccount {
   static readonly SEED_MAX_VALUE = 65535
-  static readonly RISK_WARNING_LEVEL = 0.8
-  static readonly RISK_CRITICAL_LEVEL = 0.9
+  static readonly RISK_WARNING_LEVEL = 0.9
+  static readonly RISK_CRITICAL_LEVEL = 0.95
   static readonly RISK_LIQUIDATION_LEVEL = 1
   // TODO: Change to 0.5, or new BN(50) for mainnet deployment
   static readonly SETUP_LEVERAGE_FRACTION = Number128.fromDecimal(new BN(100), -2)
@@ -145,13 +145,12 @@ export class MarginAccount {
     if (weightedCollateral < 0) throw Error("weightedCollateral must be non-negative")
     if (liabilities < 0) throw Error("liabilities must be non-negative")
 
-    if (requiredCollateral === 0) return 0
-
-    const effectiveCollateral = weightedCollateral - liabilities
-
-    if (effectiveCollateral <= 0) return Infinity
-
-    return requiredCollateral / effectiveCollateral
+    if (weightedCollateral > 0)
+      return (requiredCollateral + liabilities) / weightedCollateral
+    else if (requiredCollateral + liabilities > 0)
+      return Infinity
+    else
+      return 0
   }
 
   /**


### PR DESCRIPTION
This risk indicator is a bit nicer than the one we've been using. It is defined as

`indicator = (liabilities + required_collateral) / weighted_collateral`

which is a leverage-like quantity but in the weighted space. The threshold for liquidation is `indicator > 1.0`.

This indicator has the nice property that `1.0 - indicator` is the return on collateral that will push an account to the liquidation threshold.

E.g. If I have SOL collateral and a USDC loan, and my risk indicator is 0.88, that means a 12% decline in the SOL price will bring  my account to the liquidation threshold.

----

This PR also enables the setup limit on the UI, preventing users from setting up to the liquidation threshold.