### PR TITLE
update package version, enable cjs, expect token config on pool creation

### DIFF
--- a/libraries/ts/package.json
+++ b/libraries/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jet-lab/margin",
-  "version": "0.1.67",
+  "version": "0.2.0",
   "description": "Library for interacting with the Jet margin on-chain programs",
   "keywords": [
     "solana",
@@ -8,9 +8,8 @@
     "protocol",
     "blockchain"
   ],
-  "module": "./dist/index.js",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.js",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://github.com/jet-lab/jet-v2/tree/master/libraries/ts/#readme",
   "bugs": {
@@ -28,7 +27,7 @@
   },
   "scripts": {
     "clean": "rimraf dist/",
-    "compile": "tsc",
+    "compile": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
     "docs": "typedoc --excludePrivate --includeVersion ./src/index.ts",
     "fmt": "prettier src/ tests/ types/ --check",
     "fmt:fix": "prettier src/ tests/ types/ --write",
@@ -49,6 +48,5 @@
     "rimraf": "^3.0.2",
     "typedoc": "^0.22.6",
     "typescript": "^4.5.4"
-  },
-  "type": "module"
+  }
 }

--- a/libraries/ts/src/margin/pool/pool.ts
+++ b/libraries/ts/src/margin/pool/pool.ts
@@ -1,13 +1,6 @@
 import { Address, BN, translateAddress } from "@project-serum/anchor"
 import { parsePriceData, PriceData, PriceStatus } from "@pythnetwork/client"
-import {
-  createAssociatedTokenAccountInstruction,
-  getAssociatedTokenAddress,
-  Mint,
-  TOKEN_PROGRAM_ID,
-  ASSOCIATED_TOKEN_PROGRAM_ID
-} from "@solana/spl-token"
-import { closeAccount } from "@project-serum/serum/lib/token-instructions"
+import { Mint, TOKEN_PROGRAM_ID } from "@solana/spl-token"
 import {
   PublicKey,
   SystemProgram,
@@ -73,8 +66,8 @@ export class Pool {
   get name(): string | undefined {
     return this.tokenConfig?.name
   }
-  get symbol(): string | undefined {
-    return this.tokenConfig?.symbol
+  get symbol(): string {
+    return this.tokenConfig.symbol
   }
   get vaultRaw(): Number192 {
     return Number192.fromDecimal(this.info?.vault.amount.lamports ?? new BN(0), 0)
@@ -168,7 +161,7 @@ export class Pool {
   constructor(
     public programs: MarginPrograms,
     public addresses: MarginPoolAddresses,
-    public tokenConfig?: MarginTokenConfig
+    public tokenConfig: MarginTokenConfig
   ) {
     this.address = addresses.marginPool
     this.tokenMint = addresses.tokenMint

--- a/libraries/ts/src/margin/pool/poolManager.ts
+++ b/libraries/ts/src/margin/pool/poolManager.ts
@@ -14,10 +14,6 @@ interface TokenMetadataParams {
   maxLeverage: number
 }
 
-interface MarginPoolParams {
-  feeDestination: PublicKey
-}
-
 interface IPoolCreationParams {
   tokenMint: Address
   collateralWeight: number
@@ -57,7 +53,7 @@ export class PoolManager {
     programs = this.programs
   }: {
     tokenMint: Address
-    tokenConfig?: MarginTokenConfig
+    tokenConfig: MarginTokenConfig
     programs?: MarginPrograms
   }): Promise<Pool> {
     const addresses = this._derive({ programs, tokenMint })

--- a/libraries/ts/tsconfig-cjs.json
+++ b/libraries/ts/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/libraries/ts/tsconfig.json
+++ b/libraries/ts/tsconfig.json
@@ -15,9 +15,11 @@
     "baseUrl": ".",
     "typeRoots": ["node_modules/@types"],
     "moduleResolution": "node",
-    "module": "es2022",
-    "target": "es2019",
-    "outDir": "dist",
-    "rootDir": "./src"
+    "target": "ES2015",
+    "module": "ES2020",
+    "outDir": "dist/esm",
+    "rootDir": "./src",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
   }
 }

--- a/tests/integration/pool/marginPoolBorrow.test.ts
+++ b/tests/integration/pool/marginPoolBorrow.test.ts
@@ -11,7 +11,6 @@ import {
   Pool,
   MarginPoolConfigData,
   PoolManager,
-  Number128,
   TokenAmount
 } from "../../../libraries/ts/src"
 
@@ -63,9 +62,6 @@ describe("margin pool borrow", async () => {
     expect(sol_supply).to.eq(10_000)
     expect(sol_balance).to.eq(10_000)
   })
-
-  const FEE_VAULT_USDC: PublicKey = new PublicKey("FEEVAULTUSDC1111111111111111111111111111111")
-  const FEE_VAULT_SOL: PublicKey = new PublicKey("FEEVAULTTSoL1111111111111111111111111111111")
 
   let USDC_oracle: Keypair[]
   let SOL_oracle: Keypair[]
@@ -123,9 +119,29 @@ describe("margin pool borrow", async () => {
   let pools: Pool[]
 
   it("Load Pools", async () => {
-    marginPool_SOL = await manager.load({ tokenMint: SOL[0] })
-    marginPool_USDC = await manager.load({ tokenMint: USDC[0] })
+    marginPool_SOL = await manager.load({
+      tokenMint: SOL[0],
+      tokenConfig: {
+        symbol: "SOL",
+        name: "Solana",
+        decimals: 9,
+        precision: 2,
+        mint: SOL[0]
+      }
+    })
+    marginPool_USDC = await manager.load({
+      tokenMint: USDC[0],
+      tokenConfig: {
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6,
+        precision: 2,
+        mint: USDC[0]
+      }
+    })
     pools = [marginPool_SOL, marginPool_USDC]
+    expect(marginPool_USDC.symbol).to.eq("USDC")
+    expect(marginPool_SOL.symbol).to.eq("SOL")
   })
 
   it("Create margin pools", async () => {
@@ -345,7 +361,6 @@ describe("margin pool borrow", async () => {
   it("User A repays his SOL loan", async () => {
     //SETUP
     await marginPool_SOL.refresh()
-    const owedSOL = new BN(Number(marginPool_SOL.info?.loanNoteMint.supply))
 
     // ACT
     await marginPool_SOL.marginRepay({
@@ -365,7 +380,6 @@ describe("margin pool borrow", async () => {
   it("User B repays his USDC loan", async () => {
     // SETUP
     await marginPool_USDC.refresh()
-    const owedUSDC = new BN(Number(marginPool_USDC.info?.loanNoteMint.supply))
 
     // ACT
     await marginPool_USDC.marginRepay({
@@ -484,27 +498,27 @@ describe("margin pool borrow", async () => {
 
       expect(transactions[2].tradeAction).to.equals("withdraw")
       expect(transactions[2].tokenSymbol).to.equals("USDC")
-      expect(transactions[2].tradeAmount.uiTokens).to.approximately(400000, 0.0001)
+      expect(transactions[2].tradeAmount.tokens).to.approximately(400000, 0.0001)
       expect(transactions[2].signature).to.be.a("string")
 
       expect(transactions[3].tradeAction).to.equals("margin repay")
       expect(transactions[3].tokenSymbol).to.equals("SOL")
-      expect(transactions[3].tradeAmount.uiTokens).to.approximately(10, 0.0001)
+      expect(transactions[3].tradeAmount.tokens).to.approximately(10, 0.0001)
       expect(transactions[3].signature).to.be.a("string")
 
       expect(transactions[4].tradeAction).to.equals("borrow")
       expect(transactions[4].tokenSymbol).to.equals("SOL")
-      expect(transactions[4].tradeAmount.uiTokens).to.approximately(10, 0.0001)
+      expect(transactions[4].tradeAmount.tokens).to.approximately(10, 0.0001)
       expect(transactions[4].signature).to.be.a("string")
 
       expect(transactions[5].tradeAction).to.equals("deposit")
       expect(transactions[5].tokenSymbol).to.equals("SOL")
-      expect(transactions[5].tradeAmount.uiTokens).to.approximately(50, 0.0001)
+      expect(transactions[5].tradeAmount.tokens).to.approximately(50, 0.0001)
       expect(transactions[5].signature).to.be.a("string")
 
       expect(transactions[6].tradeAction).to.equals("deposit")
       expect(transactions[6].tokenSymbol).to.equals("USDC")
-      expect(transactions[6].tradeAmount.uiTokens).to.approximately(500000, 0.0001)
+      expect(transactions[6].tradeAmount.tokens).to.approximately(500000, 0.0001)
       expect(transactions[6].signature).to.be.a("string")
     })
   })


### PR DESCRIPTION
- Re-enable cjs for usage within a node environment
- Require tokenConfig on pool load (simplifies typing in application code)
- Maintain compatibility for esm imports
- verified it's non breaking with v2-beta and v2
- update package version to 0.2.0