### PR TITLE
better logging for invalid pool price during refresh position

### DIFF
--- a/programs/margin-pool/src/instructions/margin_refresh_position.rs
+++ b/programs/margin-pool/src/instructions/margin_refresh_position.rs
@@ -44,8 +44,8 @@ pub fn margin_refresh_position_handler(ctx: Context<MarginRefreshPosition>) -> R
         &ctx.accounts.token_price_oracle,
     ) {
         Ok(pf) => pf,
-        Err(_) => {
-            msg!("the oracle account is not valid");
+        Err(e) => {
+            msg!("the oracle account is not valid: {:?}", e);
             return err!(ErrorCode::InvalidPoolOracle);
         }
     };


### PR DESCRIPTION
prints the specific pyth error message before swallowing it and replacing it with a generic one