### PR TITLE
Get swap tx in flight logs

### DIFF
--- a/libraries/ts/src/margin/marginClient.ts
+++ b/libraries/ts/src/margin/marginClient.ts
@@ -224,11 +224,11 @@ export class MarginClient {
             })
           })
           const finalTransferIxSource: string = transferIxs[transferIxs.length - 1].parsed.info.source
-          const accountMint = await getAccount(provider.connection, new PublicKey(finalTransferIxSource))
-          const configArray = Object.values(config.tokens).find(config =>
-            accountMint.mint.equals(new PublicKey(config.mint))
+          const sourceAccountMint = await getAccount(provider.connection, new PublicKey(finalTransferIxSource))
+          const tokenConfig = Object.values(config.tokens).find(config =>
+            sourceAccountMint.mint.equals(new PublicKey(config.mint))
           )
-          token = configArray as MarginTokenConfig
+          token = tokenConfig as MarginTokenConfig
           return setupAccountTx(token, amount, parsedTx)
         } else {
           // if trade action is any other type,

--- a/libraries/ts/src/margin/marginClient.ts
+++ b/libraries/ts/src/margin/marginClient.ts
@@ -134,7 +134,8 @@ export class MarginClient {
       withdraw: "Instruction: Withdraw",
       borrow: "Instruction: MarginBorrow",
       "margin repay": "Instruction: MarginRepay",
-      repay: "Instruction: Repay"
+      repay: "Instruction: Repay",
+      swap: "Instruction: MarginSwap"
     }
     let tradeAction = ""
 


### PR DESCRIPTION
- Sets up `MarginSwap` as a recognised instruction
- If trade action is MarginSwap, set up target mint by iterating through parsed instructions to find correct source account mint