### PR TITLE
fixes getMaxTradeAmounts.repay

### DIFF
--- a/libraries/ts/package.json
+++ b/libraries/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jet-lab/margin",
-  "version": "0.2.16",
+  "version": "0.2.19",
   "description": "Library for interacting with the Jet margin on-chain programs",
   "keywords": [
     "solana",

--- a/libraries/ts/src/margin/marginAccount.ts
+++ b/libraries/ts/src/margin/marginAccount.ts
@@ -521,7 +521,7 @@ export class MarginAccount {
     borrow = TokenAmount.max(borrow, zero)
 
     // Max repay
-    const repay = TokenAmount.min(loanBalance, walletAmount)
+    const repay = TokenAmount.min(loanBalance, withdraw)
     const repayFromDeposit = TokenAmount.min(TokenAmount.min(loanBalance, walletAmount), depositBalance)
 
     // Max swap

--- a/libraries/ts/src/margin/marginAccount.ts
+++ b/libraries/ts/src/margin/marginAccount.ts
@@ -521,8 +521,8 @@ export class MarginAccount {
     borrow = TokenAmount.max(borrow, zero)
 
     // Max repay
-    const repay = TokenAmount.min(loanBalance, withdraw)
-    const repayFromDeposit = TokenAmount.min(TokenAmount.min(loanBalance, walletAmount), depositBalance)
+    const repay = TokenAmount.min(loanBalance, walletAmount)
+    const repayFromDeposit = TokenAmount.min(loanBalance, depositBalance)
 
     // Max swap
     const swap = TokenAmount.min(depositBalance.add(borrow), pool.vault)


### PR DESCRIPTION
fixes the logic in `getMaxTradeAmounts.repay` for jet-ui repay modal slider
   - return the lower of the two, loan balance or max withdraw amount 
   
<details>
<summary>Click to See the Bugged Repay Modal</summary>
<img src="https://user-images.githubusercontent.com/68657634/189810271-10b42c6e-71ca-4c15-b803-0dced13afa62.gif">
</details>

<details>
<summary>Click to See the Current Repay Modal</summary>
<img src="https://user-images.githubusercontent.com/68657634/189809330-10112a2d-192c-4813-a46a-78906606ff5c.gif">
</details>