### PR TITLE
margin: check token account states after invoke

### DIFF
--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -517,6 +517,10 @@ pub enum ErrorCode {
     #[msg("the current instruction was not directly invoked by the margin program")]
     IndirectInvocation,
 
+    /// 141004
+    #[msg("the invocation has made invalid modifications to an account")]
+    InvalidAccountModification,
+
     /// 141010 - Account cannot record any additional positions
     #[msg("account cannot record any additional positions")]
     MaxPositions = 135_010,

--- a/programs/margin/src/state/account.rs
+++ b/programs/margin/src/state/account.rs
@@ -257,7 +257,7 @@ impl MarginAccount {
         self.position_list().get_key(mint).copied()
     }
 
-    pub fn get_position(&mut self, mint: &Pubkey) -> Option<&AccountPosition> {
+    pub fn get_position(&self, mint: &Pubkey) -> Option<&AccountPosition> {
         self.position_list().get(mint)
     }
 

--- a/tests/hosted/src/context.rs
+++ b/tests/hosted/src/context.rs
@@ -117,6 +117,10 @@ impl MarginTestContext {
             .register_adapter_if_unregistered(&jet_bonds::ID)
             .await?;
 
+        ctx.margin
+            .register_adapter_if_unregistered(&spl_token::ID)
+            .await?;
+
         Ok(ctx)
     }
 

--- a/tests/hosted/src/margin.rs
+++ b/tests/hosted/src/margin.rs
@@ -288,7 +288,7 @@ impl MarginClient {
 pub struct MarginUser {
     pub tx: MarginTxBuilder,
     pub signer: Keypair,
-    rpc: Arc<dyn SolanaRpcClient>,
+    pub rpc: Arc<dyn SolanaRpcClient>,
 }
 
 impl Clone for MarginUser {
@@ -554,5 +554,10 @@ impl MarginUser {
                 .await?,
         )
         .await
+    }
+
+    pub async fn get_account_state(&self) -> Result<MarginAccount, Error> {
+        let account = self.rpc.get_account(self.address()).await?.unwrap();
+        Ok(MarginAccount::try_deserialize(&mut &account.data[..])?)
     }
 }


### PR DESCRIPTION
Introduce a new safety check for token accounts owned by a margin account, preventing any adapter from altering any aspect of the token account other than its balance.