### PR TITLE
misc fixes for localnet

### DIFF
--- a/libraries/rust/margin/src/tx_builder/airspace.rs
+++ b/libraries/rust/margin/src/tx_builder/airspace.rs
@@ -146,14 +146,7 @@ impl AirspaceAdmin {
     ) -> TransactionBuilder {
         let margin_config_ix = MarginConfigIxBuilder::new(self.airspace, self.payer);
 
-        // FIXME: remove control legacy
-        let ctrl_ix = ControlIxBuilder::new(self.payer);
-
-        vec![
-            ctrl_ix.register_adapter(&adapter_program_id),
-            margin_config_ix.configure_adapter(adapter_program_id, is_adapter),
-        ]
-        .into()
+        vec![margin_config_ix.configure_adapter(adapter_program_id, is_adapter)].into()
     }
 
     /// Configure an adapter that can be invoked through a margin account

--- a/libraries/ts/margin/src/margin/marginAccount.ts
+++ b/libraries/ts/margin/src/margin/marginAccount.ts
@@ -1601,13 +1601,9 @@ export class MarginAccount {
    *
    * @param {{
    *     instructions: TransactionInstruction[]
-   *     adapterProgram: Address
-   *     adapterMetadata: Address
    *     adapterInstruction: TransactionInstruction
    *   }} {
    *     instructions,
-   *     adapterProgram,
-   *     adapterMetadata,
    *     adapterInstruction
    *   }
    * @return {Promise<void>}
@@ -1615,13 +1611,9 @@ export class MarginAccount {
    */
   async withAdapterInvoke({
     instructions,
-    adapterProgram,
-    adapterMetadata,
     adapterInstruction
   }: {
     instructions: TransactionInstruction[]
-    adapterProgram: Address
-    adapterMetadata: Address
     adapterInstruction: TransactionInstruction
   }): Promise<void> {
     const ix = await this.programs.margin.methods
@@ -1629,8 +1621,8 @@ export class MarginAccount {
       .accounts({
         owner: this.owner,
         marginAccount: this.address,
-        adapterProgram,
-        adapterMetadata
+        adapterProgram: adapterInstruction.programId,
+        adapterMetadata: findDerivedAccount(this.programs.metadata.programId, adapterInstruction.programId)
       })
       .remainingAccounts(this.invokeAccounts(adapterInstruction))
       .instruction()

--- a/libraries/ts/margin/src/margin/pool/pool.ts
+++ b/libraries/ts/margin/src/margin/pool/pool.ts
@@ -901,8 +901,6 @@ export class Pool {
 
     await marginAccount.withAdapterInvoke({
       instructions,
-      adapterProgram: this.programs.config.marginPoolProgramId,
-      adapterMetadata: this.addresses.marginPoolAdapterMetadata,
       adapterInstruction: await this.programs.marginPool.methods
         .marginBorrow(change.changeKind.asParam(), change.value)
         .accounts({
@@ -997,8 +995,6 @@ export class Pool {
 
     await marginAccount.withAdapterInvoke({
       instructions,
-      adapterProgram: this.programs.config.marginPoolProgramId,
-      adapterMetadata: this.addresses.marginPoolAdapterMetadata,
       adapterInstruction: await this.programs.marginPool.methods
         .marginRepay(change.changeKind.asParam(), change.value)
         .accounts({
@@ -1128,8 +1124,6 @@ export class Pool {
 
     await marginAccount.withAdapterInvoke({
       instructions,
-      adapterProgram: this.programs.config.marginPoolProgramId,
-      adapterMetadata: this.addresses.marginPoolAdapterMetadata,
       adapterInstruction: await this.programs.marginPool.methods
         .withdraw(change.changeKind.asParam(), change.value)
         .accounts({
@@ -1326,11 +1320,6 @@ export class Pool {
     // Swap
     await marginAccount.withAdapterInvoke({
       instructions,
-      adapterProgram: this.programs.config.marginSwapProgramId,
-      adapterMetadata: findDerivedAccount(
-        this.programs.config.metadataProgramId,
-        this.programs.config.marginSwapProgramId
-      ),
       adapterInstruction: await this.programs.marginSwap.methods
         .marginSwap(changeKind.changeKind.asParam(), changeKind.value, minAmountOut.lamports)
         .accounts({
@@ -1541,8 +1530,6 @@ export class Pool {
     const loanNoteAccount = this.findLoanPositionAddress(marginAccount)
     await marginAccount.withAdapterInvoke({
       instructions: instructions,
-      adapterProgram: this.programs.config.marginPoolProgramId,
-      adapterMetadata: this.addresses.marginPoolAdapterMetadata,
       adapterInstruction: await this.programs.marginPool.methods
         .registerLoan()
         .accounts({
@@ -1576,8 +1563,6 @@ export class Pool {
     )
     await marginAccount.withAdapterInvoke({
       instructions,
-      adapterProgram: this.programs.config.marginPoolProgramId,
-      adapterMetadata: this.addresses.marginPoolAdapterMetadata,
       adapterInstruction: await this.programs.marginPool.methods
         .closeLoan()
         .accounts({

--- a/run_local_validator.sh
+++ b/run_local_validator.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-exec ./tests/scripts/on_localnet.sh start-new-validator
+case $1 in
+    -r|--reset)
+        exec ./tests/scripts/on_localnet.sh start-new-validator
+    ;;
+esac
+
+exec ./tests/scripts/on_localnet.sh resume-validator

--- a/tests/integration/bonds/marginOrderbook.test.ts
+++ b/tests/integration/bonds/marginOrderbook.test.ts
@@ -331,8 +331,6 @@ describe('margin bonds borrowing', async () => {
     let ixns = [];
     await margin.withAdapterInvoke({
       instructions: ixns,
-      adapterProgram: bondsProgram.programId,
-      adapterMetadata: CONFIG.bondsMetadata,
       adapterInstruction: ix
     });
     return ixns[0];

--- a/tests/scripts/localnet_lib.sh
+++ b/tests/scripts/localnet_lib.sh
@@ -74,6 +74,17 @@ start-validator() {
         $@
 }
 
+resume-validator() {
+    start-validator &
+
+    spid=$!
+
+    sleep ${VALIDATOR_STARTUP:-5}
+    cargo run --bin jet-oracle-mirror -- -s $MAINNET_ENDPOINT -tl &
+
+    wait $spid
+}
+
 start-new-validator() {
     start-validator -r &
 

--- a/tools/ctl/src/actions/margin_pool.rs
+++ b/tools/ctl/src/actions/margin_pool.rs
@@ -1,5 +1,5 @@
 use anchor_lang::AccountDeserialize;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use comfy_table::{presets::UTF8_FULL, Table};
 use jet_margin_sdk::{
@@ -208,6 +208,22 @@ pub async fn process_configure_pool(
     } else {
         Ok(client.plan()?.build())
     }
+}
+
+pub async fn process_show_pool(client: &Client, token: Pubkey) -> Result<Plan> {
+    let margin_pool = MarginPoolIxBuilder::new(token);
+
+    if !client.account_exists(&margin_pool.address).await? {
+        bail!("pool for token {} does not exist", token);
+    }
+
+    let margin_pool_data = client
+        .read_anchor_account::<MarginPool>(&margin_pool.address)
+        .await?;
+
+    println!("{:#?}", &margin_pool_data.config);
+
+    Ok(Plan::default())
 }
 
 fn override_pool_config_with_options(

--- a/tools/ctl/src/lib.rs
+++ b/tools/ctl/src/lib.rs
@@ -162,6 +162,12 @@ pub enum MarginPoolCommand {
 
     /// Show a summary of all margin pools
     List,
+
+    /// Show configuration for a pool
+    Show {
+        /// The token to show the pool for
+        token: Pubkey,
+    },
 }
 
 #[serde_as]
@@ -384,6 +390,9 @@ async fn run_margin_pool_command(client: &Client, command: MarginPoolCommand) ->
             actions::margin_pool::process_collect_pool_fees(client).await
         }
         MarginPoolCommand::List => actions::margin_pool::process_list_pools(client).await,
+        MarginPoolCommand::Show { token } => {
+            actions::margin_pool::process_show_pool(client, token).await
+        }
     }
 }
 


### PR DESCRIPTION
- `run_local_validator.sh` script now resumes by default, pass `-r` or `--reset` to reset the state
- Fix pool flags not passing through during environment setup
- Fix API for `withAdapterInvoke` to not require redundant accounts
- Add `show` command for displaying config for margin pools