### PR TITLE
test-env: margin token configs for bond markets

### DIFF
--- a/libraries/rust/margin/src/bonds/ix_builder.rs
+++ b/libraries/rust/margin/src/bonds/ix_builder.rs
@@ -700,6 +700,15 @@ impl BondsIxBuilder {
             &seed,
         ])
     }
+
+    pub fn claims_mint(manager_key: &Pubkey) -> Pubkey {
+        bonds_pda(&[jet_bonds::seeds::CLAIM_NOTES, manager_key.as_ref()])
+    }
+
+    pub fn collateral_mint(manager_key: &Pubkey) -> Pubkey {
+        bonds_pda(&[jet_bonds::seeds::DEPOSIT_NOTES, manager_key.as_ref()])
+    }
+
     pub fn split_ticket_key(&self, user: &Pubkey, seed: Vec<u8>) -> Pubkey {
         bonds_pda(&[
             jet_bonds::seeds::SPLIT_TICKET,

--- a/libraries/rust/margin/src/test_service.rs
+++ b/libraries/rust/margin/src/test_service.rs
@@ -292,6 +292,12 @@ fn create_airspace_token_bond_markets_tx(
             ],
             signers: vec![key_eq, key_bids, key_asks],
         });
+        txs.push(admin.register_bond_market(
+            mint,
+            bond_manager_seed,
+            tk_config.collateral_weight,
+            tk_config.max_leverage,
+        ));
     }
 
     txs


### PR DESCRIPTION
- add claim and collateral mints for bond markets to the test environment initialization