### PR TITLE
test-env: add paused option for bond markets

### DIFF
--- a/libraries/rust/margin/src/test_service.rs
+++ b/libraries/rust/margin/src/test_service.rs
@@ -81,6 +81,10 @@ pub struct BondMarketConfig {
 
     /// The minimum order size for the AOB
     pub min_order_size: u64,
+
+    /// Whether or not order matching should be paused for the market
+    #[serde(default)]
+    pub paused: bool,
 }
 
 /// Configuration for margin pools
@@ -292,6 +296,14 @@ fn create_airspace_token_bond_markets_tx(
             ],
             signers: vec![key_eq, key_bids, key_asks],
         });
+
+        if bm_config.paused {
+            txs.last_mut()
+                .unwrap()
+                .instructions
+                .push(bonds_ix.pause_order_matching().unwrap());
+        }
+
         txs.push(admin.register_bond_market(
             mint,
             bond_manager_seed,

--- a/libraries/rust/margin/src/tx_builder/airspace.rs
+++ b/libraries/rust/margin/src/tx_builder/airspace.rs
@@ -192,7 +192,7 @@ impl AirspaceAdmin {
         let collateral_update = TokenConfigUpdate {
             admin: TokenAdmin::Adapter(jet_bonds::ID),
             underlying_mint: token_mint,
-            token_kind: TokenKind::Claim,
+            token_kind: TokenKind::AdapterCollateral,
             value_modifier: max_leverage,
             max_staleness: 0,
         };

--- a/localnet.toml
+++ b/localnet.toml
@@ -27,6 +27,7 @@ max_leverage = 20_00
 [[airspace.tokens.USDC.bond_markets]]
 duration = 5
 min_order_size = 10
+paused = true
 
 [airspace.tokens.USDC.margin_pool_config]
 flags = 0b0010 # ALLOW_LENDING

--- a/tests/hosted/src/context.rs
+++ b/tests/hosted/src/context.rs
@@ -206,6 +206,7 @@ impl MarginTestContext {
                             bond_markets: vec![BondMarketConfig {
                                 duration: 5,
                                 min_order_size: 10,
+                                paused: false,
                             }],
                         },
                     ),


### PR DESCRIPTION
* set default localnet environment to use paused market
* also fix wrong token kind for bond market collateral types in margin