### PR TITLE
Fixes to the `lending collateral` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 name = "agnostic-orderbook"
 version = "1.0.0"
-source = "git+https://github.com/jet-lab/agnostic-orderbook.git?branch=paused-order-summary-posted-amounts#2fb8ce6878e47f62e5714ddd78905bb2745b8bf5"
+source = "git+https://github.com/jet-lab/agnostic-orderbook.git?branch=main#15c47292a59fc5c098ae65727f4ebc749a323dd7"
 dependencies = [
  "bonfida-utils",
  "borsh 0.9.3",

--- a/libraries/rust/margin/Cargo.toml
+++ b/libraries/rust/margin/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 
 jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "main" }
 
-agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "paused-order-summary-posted-amounts", features = ["lib", "utils"] }
+agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "main", features = ["lib", "utils"] }
 
 pyth-sdk-solana = "0.4"
 solana-sdk = "1.10"

--- a/programs/bonds/Cargo.toml
+++ b/programs/bonds/Cargo.toml
@@ -33,7 +33,7 @@ pyth-sdk-solana = "0.4"
 serde = { version = "1.0", optional = true }
 proc-macros = { path = "../../libraries/rust/proc-macros" }
 
-agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "paused-order-summary-posted-amounts", features = ["lib", "utils"] }
+agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "main", features = ["lib", "utils"] }
 
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 anchor-spl =  { git = "https://github.com/jet-lab/anchor", branch = "master" }

--- a/programs/bonds/src/margin/instructions/margin_lend_order.rs
+++ b/programs/bonds/src/margin/instructions/margin_lend_order.rs
@@ -61,7 +61,6 @@ pub fn handler(ctx: Context<MarginLendOrder>, params: OrderParams, seed: Vec<u8>
         &seed,
         callback_info,
         &order_summary,
-        &ctx.accounts.inner.orderbook_mut.bond_manager,
     )?;
     ctx.accounts.margin_user.assets.stake_tickets(staked)?;
     mint_to!(

--- a/tests/hosted/Cargo.toml
+++ b/tests/hosted/Cargo.toml
@@ -36,7 +36,7 @@ solana-sdk = "1.10"
 solana-client = "1.10"
 solana-cli-config = "1.10"
 
-agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "paused-order-summary-posted-amounts", features = ["lib", "utils"] }
+agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "main", features = ["lib", "utils"] }
 
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }


### PR DESCRIPTION
I did not see a need to pass a reference to the `bond_manager` in the `lend` method as it was already in the `OrderbookMut` struct.

Returned the `agnostic-orderbook` cargo reference to point to main.