### PR TITLE
Fix `SplitTicket` value calculation

### DIFF
--- a/programs/bonds/src/orderbook/state.rs
+++ b/programs/bonds/src/orderbook/state.rs
@@ -344,12 +344,10 @@ impl OrderParams {
 }
 
 pub struct SensibleOrderSummary {
-    limit_price: u64,
-    summary: OrderSummary,
+    pub limit_price: u64,
+    pub summary: OrderSummary,
 }
 
-// fixme i think most of these are wrong. there may be issues with the aaob
-// implementation which is a huge mess of spaghetti code
 impl SensibleOrderSummary {
     pub fn summary(&self) -> OrderSummary {
         OrderSummary {
@@ -381,14 +379,12 @@ impl SensibleOrderSummary {
     /// the total of all quote posted and filled
     /// NOT the same as the "max quote"
     pub fn quote_combined(&self) -> Result<u64> {
-        // Ok(self.quote_posted()? + self.quote_filled())
         Ok(self.summary.total_quote_qty)
     }
 
     /// the total of all base posted and filled
     /// NOT the same as the "max base"
     pub fn base_combined(&self) -> u64 {
-        // self.base_posted() + self.base_filled()
         self.summary.total_base_qty
     }
 }

--- a/tests/hosted/src/bonds.rs
+++ b/tests/hosted/src/bonds.rs
@@ -716,6 +716,17 @@ impl<P: Proxy> BondsUser<P> {
             .await
     }
 
+    pub async fn redeem_split_ticket(&self, seed: &[u8]) -> Result<Signature> {
+        let ticket = self.split_ticket_key(seed);
+        let ix = self
+            .manager
+            .ix_builder
+            .redeem_ticket(self.proxy.pubkey(), ticket, None)?;
+        self.client
+            .send_and_confirm_1tx(&[self.proxy.invoke_signed(ix)], &[&self.owner])
+            .await
+    }
+
     pub async fn sell_tickets_order(&self, params: OrderParams) -> Result<Signature> {
         let borrow =
             self.manager


### PR DESCRIPTION
Owning to a misunderstanding of the values in the `OrderSummary`, we were using the wrong values to calculate principal and interest