### PR TITLE
localnet: add swap pool initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ dependencies = [
  "anchor-spl",
  "bytemuck",
  "pyth-sdk-solana 0.4.2",
+ "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/libraries/rust/margin/src/ix_builder/test_service.rs
+++ b/libraries/rust/margin/src/ix_builder/test_service.rs
@@ -17,11 +17,19 @@
 
 use anchor_lang::{InstructionData, ToAccountMetas};
 use solana_sdk::{
-    instruction::Instruction, pubkey, pubkey::Pubkey, rent::Rent, system_program, sysvar::SysvarId,
+    instruction::Instruction,
+    pubkey,
+    pubkey::Pubkey,
+    rent::Rent,
+    system_program,
+    sysvar::{self, SysvarId},
 };
 
 use jet_test_service::{
-    seeds::{TOKEN_INFO, TOKEN_MINT, TOKEN_PYTH_PRICE, TOKEN_PYTH_PRODUCT},
+    seeds::{
+        SWAP_POOL_MINT, SWAP_POOL_STATE, SWAP_POOL_TOKENS, TOKEN_INFO, TOKEN_MINT,
+        TOKEN_PYTH_PRICE, TOKEN_PYTH_PRODUCT,
+    },
     TokenCreateParams,
 };
 
@@ -122,6 +130,35 @@ pub fn token_update_pyth_price(
     }
 }
 
+/// Create a swap pool
+pub fn spl_swap_pool_create(payer: &Pubkey, token_a: &Pubkey, token_b: &Pubkey) -> Instruction {
+    let addrs = derive_swap_pool(token_a, token_b);
+    let accounts = jet_test_service::accounts::SplSwapPoolCreate {
+        payer: *payer,
+        mint_a: *token_a,
+        mint_b: *token_b,
+        info_a: derive_token_info(token_a),
+        info_b: derive_token_info(token_b),
+        pool_state: addrs.state,
+        pool_authority: addrs.authority,
+        pool_mint: addrs.mint,
+        pool_token_a: addrs.token_a_account,
+        pool_token_b: addrs.token_b_account,
+        pool_fees: addrs.fees,
+        swap_program: spl_token_swap::ID,
+        token_program: spl_token::ID,
+        system_program: system_program::ID,
+        rent: sysvar::rent::ID,
+    }
+    .to_account_metas(None);
+
+    Instruction {
+        program_id: jet_test_service::ID,
+        accounts,
+        data: jet_test_service::instruction::SplSwapPoolCreate {}.data(),
+    }
+}
+
 /// Get the token mint address for a given token name
 pub fn derive_token_mint(name: &str) -> Pubkey {
     if name == "SOL" {
@@ -144,4 +181,61 @@ pub fn derive_pyth_product(mint: &Pubkey) -> Pubkey {
 /// Get the pyth price account
 pub fn derive_pyth_price(mint: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[TOKEN_PYTH_PRICE, mint.as_ref()], &jet_test_service::ID).0
+}
+
+/// Get the addresses for a swap pool
+pub fn derive_swap_pool(token_a: &Pubkey, token_b: &Pubkey) -> SwapPoolAddress {
+    let state = Pubkey::find_program_address(
+        &[SWAP_POOL_STATE, token_a.as_ref(), token_b.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+    let authority = Pubkey::find_program_address(&[state.as_ref()], &spl_token_swap::ID).0;
+    let token_a_account = Pubkey::find_program_address(
+        &[SWAP_POOL_TOKENS, state.as_ref(), token_a.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+    let token_b_account = Pubkey::find_program_address(
+        &[SWAP_POOL_TOKENS, state.as_ref(), token_b.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+    let mint =
+        Pubkey::find_program_address(&[SWAP_POOL_MINT, state.as_ref()], &jet_test_service::ID).0;
+    let fees = Pubkey::find_program_address(
+        &[SWAP_POOL_TOKENS, state.as_ref(), mint.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+
+    SwapPoolAddress {
+        state,
+        authority,
+        token_a_account,
+        token_b_account,
+        mint,
+        fees,
+    }
+}
+
+/// Set of addresses for a test swap pool
+pub struct SwapPoolAddress {
+    /// The address of the swap pool state
+    pub state: Pubkey,
+
+    /// The authority
+    pub authority: Pubkey,
+
+    /// The token A vault
+    pub token_a_account: Pubkey,
+
+    /// The token B vault
+    pub token_b_account: Pubkey,
+
+    /// The LP token
+    pub mint: Pubkey,
+
+    /// The account to collect fees
+    pub fees: Pubkey,
 }

--- a/localnet.toml
+++ b/localnet.toml
@@ -16,6 +16,9 @@ name = "Bitcoin"
 decimals = 6
 precision = 6
 
+[swap_pools]
+spl = ["Bitcoin/USDC"]
+
 [[airspace]]
 name = "default"
 is_restricted = false

--- a/programs/test-service/Cargo.toml
+++ b/programs/test-service/Cargo.toml
@@ -22,3 +22,5 @@ anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 
 pyth-sdk-solana = "0.4"
 bytemuck = "1.7"
+
+spl-token-swap = { version = "2.1", features = ["no-entrypoint"] }

--- a/programs/test-service/src/instructions/mod.rs
+++ b/programs/test-service/src/instructions/mod.rs
@@ -1,3 +1,5 @@
+mod swaps;
 mod tokens;
 
+pub use swaps::*;
 pub use tokens::*;

--- a/programs/test-service/src/instructions/swaps/mod.rs
+++ b/programs/test-service/src/instructions/swaps/mod.rs
@@ -1,0 +1,3 @@
+mod spl_swap_pool_create;
+
+pub use spl_swap_pool_create::*;

--- a/programs/test-service/src/instructions/swaps/spl_swap_pool_create.rs
+++ b/programs/test-service/src/instructions/swaps/spl_swap_pool_create.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2022 JET PROTOCOL HOLDINGS, LLC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+
+use anchor_lang::solana_program::program_pack::Pack;
+use anchor_lang::{prelude::*, solana_program::program::invoke_signed};
+use anchor_spl::token::{Mint, Token, TokenAccount};
+
+use crate::instructions::TokenRequest;
+use crate::seeds::{SWAP_POOL_MINT, SWAP_POOL_STATE, SWAP_POOL_TOKENS};
+use crate::state::TokenInfo;
+
+#[derive(Accounts)]
+pub struct SplSwapPoolCreate<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+
+    #[account(mut)]
+    mint_a: Box<Account<'info, Mint>>,
+
+    #[account(mut)]
+    mint_b: Box<Account<'info, Mint>>,
+
+    #[account(constraint = info_a.mint == mint_a.key())]
+    info_a: Box<Account<'info, TokenInfo>>,
+
+    #[account(constraint = info_b.mint == mint_b.key())]
+    info_b: Box<Account<'info, TokenInfo>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_STATE,
+                mint_a.key().as_ref(),
+                mint_b.key().as_ref()
+              ],
+              bump,
+              space = 1 + spl_token_swap::state::SwapV1::LEN,
+              owner = spl_token_swap::ID,
+              payer = payer
+    )]
+    pool_state: AccountInfo<'info>,
+
+    #[account(seeds = [pool_state.key().as_ref()],
+              bump,
+              seeds::program = spl_token_swap::ID
+    )]
+    pool_authority: AccountInfo<'info>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_MINT,
+                pool_state.key().as_ref()
+              ],
+              bump,
+              mint::decimals = 6,
+              mint::authority = pool_authority,
+              payer = payer
+    )]
+    pool_mint: Box<Account<'info, Mint>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_TOKENS,
+                pool_state.key().as_ref(),
+                mint_a.key().as_ref()
+              ],
+              bump,
+              token::mint = mint_a,
+              token::authority = pool_authority,
+              payer = payer,
+    )]
+    pool_token_a: Box<Account<'info, TokenAccount>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_TOKENS,
+                pool_state.key().as_ref(),
+                mint_b.key().as_ref()
+              ],
+              bump,
+              token::mint = mint_b,
+              token::authority = pool_authority,
+              payer = payer,
+    )]
+    pool_token_b: Box<Account<'info, TokenAccount>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_TOKENS,
+                pool_state.key().as_ref(),
+                pool_mint.key().as_ref()
+              ],
+              bump,
+              token::mint = pool_mint,
+              token::authority = payer,
+              payer = payer,
+    )]
+    pool_fees: Box<Account<'info, TokenAccount>>,
+
+    swap_program: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+    system_program: Program<'info, System>,
+    rent: Sysvar<'info, Rent>,
+}
+
+impl<'info> SplSwapPoolCreate<'info> {
+    fn request_token_a(&self) -> Result<()> {
+        crate::token_request(
+            Context::new(
+                &crate::ID,
+                &mut TokenRequest {
+                    requester: self.payer.clone(),
+                    mint: (*self.mint_a).clone(),
+                    info: (*self.info_a).clone(),
+                    destination: (*self.pool_token_a).clone(),
+                    token_program: self.token_program.clone(),
+                },
+                &[],
+                BTreeMap::new(),
+            ),
+            1000,
+        )
+    }
+
+    fn request_token_b(&self) -> Result<()> {
+        crate::token_request(
+            Context::new(
+                &crate::ID,
+                &mut TokenRequest {
+                    requester: self.payer.clone(),
+                    mint: (*self.mint_b).clone(),
+                    info: (*self.info_b).clone(),
+                    destination: (*self.pool_token_b).clone(),
+                    token_program: self.token_program.clone(),
+                },
+                &[],
+                BTreeMap::new(),
+            ),
+            1000,
+        )
+    }
+}
+
+pub fn spl_swap_pool_create_handler(ctx: Context<SplSwapPoolCreate>) -> Result<()> {
+    ctx.accounts.request_token_a()?;
+    ctx.accounts.request_token_b()?;
+
+    let bump = *ctx.bumps.get("pool_state").unwrap();
+
+    let ix = spl_token_swap::instruction::initialize(
+        ctx.accounts.swap_program.key,
+        ctx.accounts.token_program.key,
+        ctx.accounts.pool_state.key,
+        ctx.accounts.pool_authority.key,
+        &ctx.accounts.pool_token_a.key(),
+        &ctx.accounts.pool_token_b.key(),
+        &ctx.accounts.pool_mint.key(),
+        &ctx.accounts.pool_fees.key(),
+        &ctx.accounts.pool_fees.key(),
+        bump,
+        spl_token_swap::curve::fees::Fees {
+            // The fee parameters are taken from one of spl-token-swap tests
+            trade_fee_numerator: 1,
+            trade_fee_denominator: 400,
+            owner_trade_fee_numerator: 2,
+            owner_trade_fee_denominator: 500,
+            owner_withdraw_fee_numerator: 4,
+            owner_withdraw_fee_denominator: 100,
+            host_fee_numerator: 1,
+            host_fee_denominator: 100,
+        },
+        spl_token_swap::curve::base::SwapCurve {
+            curve_type: spl_token_swap::curve::base::CurveType::ConstantProduct,
+            calculator: Box::new(spl_token_swap::curve::constant_product::ConstantProductCurve),
+        },
+    )?;
+
+    let mint_a_key = ctx.accounts.mint_a.key();
+    let mint_b_key = ctx.accounts.mint_b.key();
+
+    let pool_signer_seeds = [
+        SWAP_POOL_STATE,
+        mint_a_key.as_ref(),
+        mint_b_key.as_ref(),
+        &[bump],
+    ];
+
+    invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.pool_state.to_account_info(),
+            ctx.accounts.pool_authority.to_account_info(),
+            ctx.accounts.pool_token_a.to_account_info(),
+            ctx.accounts.pool_token_b.to_account_info(),
+            ctx.accounts.pool_mint.to_account_info(),
+            ctx.accounts.pool_fees.to_account_info(),
+            ctx.accounts.pool_fees.to_account_info(),
+            ctx.accounts.token_program.to_account_info(),
+        ],
+        &[&pool_signer_seeds],
+    )?;
+
+    Ok(())
+}

--- a/programs/test-service/src/instructions/tokens/token_request.rs
+++ b/programs/test-service/src/instructions/tokens/token_request.rs
@@ -24,21 +24,21 @@ use crate::{error::TestServiceError, seeds::TOKEN_INFO, state::TokenInfo};
 pub struct TokenRequest<'info> {
     /// user requesting tokens
     #[account(mut)]
-    requester: Signer<'info>,
+    pub requester: Signer<'info>,
 
     /// The relevant token mint
     #[account(mut)]
-    mint: Account<'info, Mint>,
+    pub mint: Account<'info, Mint>,
 
     /// The test info for the token
     #[account(has_one = mint)]
-    info: Account<'info, TokenInfo>,
+    pub info: Account<'info, TokenInfo>,
 
     /// The destination account for the minted tokens
     #[account(mut)]
-    destination: Account<'info, TokenAccount>,
+    pub destination: Account<'info, TokenAccount>,
 
-    token_program: Program<'info, Token>,
+    pub token_program: Program<'info, Token>,
 }
 
 pub fn token_request_handler(ctx: Context<TokenRequest>, amount: u64) -> Result<()> {

--- a/programs/test-service/src/lib.rs
+++ b/programs/test-service/src/lib.rs
@@ -43,6 +43,15 @@ pub mod seeds {
 
     #[constant]
     pub const TOKEN_PYTH_PRODUCT: &[u8] = b"token-pyth-product";
+
+    #[constant]
+    pub const SWAP_POOL_STATE: &[u8] = b"swap-pool-state";
+
+    #[constant]
+    pub const SWAP_POOL_MINT: &[u8] = b"swap-pool-mint";
+
+    #[constant]
+    pub const SWAP_POOL_TOKENS: &[u8] = b"swap-pool-tokens";
 }
 
 #[program]
@@ -84,6 +93,11 @@ pub mod jet_test_service {
         expo: i32,
     ) -> Result<()> {
         token_update_pyth_price_handler(ctx, price, conf, expo)
+    }
+
+    /// Create a SPL swap pool
+    pub fn spl_swap_pool_create(ctx: Context<SplSwapPoolCreate>) -> Result<()> {
+        spl_swap_pool_create_handler(ctx)
     }
 }
 

--- a/tests/hosted/src/context.rs
+++ b/tests/hosted/src/context.rs
@@ -15,7 +15,7 @@ use solana_sdk::signature::{Keypair, Signer};
 
 use jet_margin_sdk::test_service::{
     init_environment, AirspaceConfig, AirspaceTokenConfig, BondMarketConfig, EnvironmentConfig,
-    MarginPoolConfig, TokenDescription,
+    MarginPoolConfig, SwapPoolsConfig, TokenDescription,
 };
 use jet_metadata::TokenKind;
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
@@ -222,6 +222,9 @@ impl MarginTestContext {
                     ),
                 ]),
             }],
+            swap_pools: SwapPoolsConfig {
+                spl: vec!["Bitcoin/USDC".to_owned()],
+            },
         }
     }
 }

--- a/tools/ctl/src/actions/test.rs
+++ b/tools/ctl/src/actions/test.rs
@@ -5,7 +5,9 @@ use anyhow::{bail, Result};
 use jet_margin_sdk::{
     bonds::bonds_pda,
     ix_builder::{derive_airspace, test_service::derive_token_mint},
-    test_service::{init_environment, AirspaceConfig, EnvironmentConfig, TokenDescription},
+    test_service::{
+        init_environment, AirspaceConfig, EnvironmentConfig, SwapPoolsConfig, TokenDescription,
+    },
 };
 use serde::{Deserialize, Serialize};
 use solana_sdk::{pubkey, pubkey::Pubkey, signer::Signer};
@@ -53,6 +55,9 @@ pub async fn process_generate_app_config(
 struct TestEnvConfig {
     token: Vec<TokenDescription>,
     airspace: Vec<AirspaceConfig>,
+
+    #[serde(default)]
+    swap_pools: SwapPoolsConfig,
 }
 
 fn read_env_config_from_file(
@@ -66,6 +71,7 @@ fn read_env_config_from_file(
         authority,
         tokens: config.token,
         airspaces: config.airspace,
+        swap_pools: config.swap_pools,
     })
 }
 


### PR DESCRIPTION
Add setup for SPL swap pools for use in localnet

This change on its own isn't really enough to make it useful, since there's nothing to balance the pools _and_ it's not connected to the app configuration.