### PR TITLE
simplify hosted tests

### DIFF
--- a/tests/scripts/localnet_lib.sh
+++ b/tests/scripts/localnet_lib.sh
@@ -81,30 +81,23 @@ start-oracle() {
 
 resume-validator() {
     start-validator &
-
     start-oracle
-
     wait $VALIDATOR_PID
 }
 
 start-new-validator() {
     start-validator -r &
-
     cargo run --bin jetctl -- test init-env -ul --no-confirm localnet.toml
     cargo run --bin jetctl -- test generate-app-config -ul --no-confirm localnet.toml -o app/public/localnet.config.json
-
     start-oracle
-
     wait $VALIDATOR_PID
 }
 
 with-validator() {
     start-validator -r &
-    
     if [[ ${SOLANA_LOGS:-false} == true ]]; then
         solana -ul logs &
     fi
-
     $@
 }
 

--- a/tests/scripts/localnet_lib.sh
+++ b/tests/scripts/localnet_lib.sh
@@ -71,6 +71,8 @@ start-validator() {
         --bpf-program $ORCAv2_PID $ORCAv2_SO \
         --quiet \
         $@
+    VALIDATOR_PID=$!
+    sleep ${VALIDATOR_STARTUP:-5}
 }
 
 start-oracle() {
@@ -79,8 +81,6 @@ start-oracle() {
 
 resume-validator() {
     start-validator &
-    VALIDATOR_PID=$!
-    sleep ${VALIDATOR_STARTUP:-5}
 
     start-oracle
 
@@ -89,8 +89,6 @@ resume-validator() {
 
 start-new-validator() {
     start-validator -r &
-    VALIDATOR_PID=$!
-    sleep ${VALIDATOR_STARTUP:-5}
 
     cargo run --bin jetctl -- test init-env -ul --no-confirm localnet.toml
     cargo run --bin jetctl -- test generate-app-config -ul --no-confirm localnet.toml -o app/public/localnet.config.json
@@ -102,8 +100,6 @@ start-new-validator() {
 
 with-validator() {
     start-validator -r &
-    VALIDATOR_PID=$!
-    sleep ${VALIDATOR_STARTUP:-5}
     
     if [[ ${SOLANA_LOGS:-false} == true ]]; then
         solana -ul logs &
@@ -113,6 +109,6 @@ with-validator() {
 }
 
 kill_validator() {
-    [ -z $VALIDATOR_PID ] || (kill $VALIDATOR_PID; killall solana-test-validator)
+    [ -z $VALIDATOR_PID ] || (kill $VALIDATOR_PID; pkill solana-test-validator; echo)
 }
 trap kill_validator EXIT SIGHUP SIGINT SIGTERM

--- a/tests/scripts/localnet_lib.sh
+++ b/tests/scripts/localnet_lib.sh
@@ -30,6 +30,7 @@ ORCAv2_SO=$ORCA_V2_MAINNET
 
 PROGRAM_FEATURES='testing'
 TEST_FEATURES="${BATCH:-batch_all},localnet"
+VALIDATOR_PID=
 
 anchor-build() {
     anchor build $@ -- --features $PROGRAM_FEATURES
@@ -78,20 +79,17 @@ start-oracle() {
 
 resume-validator() {
     start-validator &
-
-    spid=$!
-
+    VALIDATOR_PID=$!
     sleep ${VALIDATOR_STARTUP:-5}
+
     start-oracle
 
-    wait $spid
+    wait $VALIDATOR_PID
 }
 
 start-new-validator() {
     start-validator -r &
-
-    spid=$!
-
+    VALIDATOR_PID=$!
     sleep ${VALIDATOR_STARTUP:-5}
 
     cargo run --bin jetctl -- test init-env -ul --no-confirm localnet.toml
@@ -99,44 +97,22 @@ start-new-validator() {
 
     start-oracle
 
-    wait $spid
+    wait $VALIDATOR_PID
 }
 
 with-validator() {
     start-validator -r &
-
-    spid=$!
+    VALIDATOR_PID=$!
     sleep ${VALIDATOR_STARTUP:-5}
     
     if [[ ${SOLANA_LOGS:-false} == true ]]; then
         solana -ul logs &
     fi
 
-    cargo run --bin jetctl -- test init-env -ul --no-confirm localnet.toml
-    cargo run --bin jetctl -- test generate-app-config -ul --no-confirm localnet.toml -o app/public/localnet.config.json
-
     $@
-    
-    kill $spid
-    sleep 2
 }
 
-cleanup() {
-    pkill -P $$ || true
-    wait || true
+kill_validator() {
+    [ -z $VALIDATOR_PID ] || (kill $VALIDATOR_PID; killall solana-test-validator)
 }
-
-trap_add() {
-    trap_add_cmd=$1; shift || fatal "${FUNCNAME} usage error"
-    for trap_add_name in "$@"; do
-        trap -- "$(
-            extract_trap_cmd() { printf '%s\n' "${3:-}"; }
-            eval "extract_trap_cmd $(trap -p "${trap_add_name}")"
-            printf '%s\n' "${trap_add_cmd}"
-        )" "${trap_add_name}" \
-            || fatal "unable to add to trap ${trap_add_name}"
-    done
-}
-
-declare -f -t trap_add
-trap_add 'cleanup' EXIT
+trap kill_validator EXIT SIGHUP SIGINT SIGTERM


### PR DESCRIPTION
I've removed some extraneous code that was running during the hosted tests for no reason. It was setting up all kinds of global state that was not actually used in the test. The hosted tests set up their own tokens etc for each test so there's no need for this global setup. Also we should try to limit the global state as much as possible so it's clear what's going on in each test without having to think about interactions with other tests.

I also have a fix in here to get the localnet to shutdown more reliably when the hosted tests either complete or are cancelled.