### PR TITLE
merge common program libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,7 +1910,7 @@ dependencies = [
  "jet-margin-sdk",
  "jet-margin-swap",
  "jet-metadata",
- "jet-proto-math 1.1.0 (git+https://github.com/jet-lab/program-libraries?branch=fixed-point-math)",
+ "jet-program-common",
  "jet-simulation",
  "jet-static-program-registry",
  "jet-test-service",
@@ -2162,10 +2162,10 @@ dependencies = [
  "bytemuck",
  "itertools 0.10.5",
  "jet-margin",
- "jet-proto-math 1.1.0 (git+https://github.com/jet-lab/program-libraries?branch=main)",
+ "jet-program-common",
+ "jet-program-proc-macros",
  "num-derive",
  "num-traits",
- "proc-macros",
  "pyth-sdk-solana 0.4.2",
  "serde",
  "serde_json",
@@ -2203,7 +2203,7 @@ dependencies = [
  "heck 0.4.0",
  "indicatif",
  "jet-margin-sdk",
- "jet-proto-math 1.1.0 (git+https://github.com/jet-lab/program-libraries?branch=main)",
+ "jet-program-common",
  "lazy_static",
  "pyth-sdk-solana 0.4.2",
  "serde",
@@ -2234,8 +2234,8 @@ dependencies = [
  "itertools 0.10.5",
  "jet-airspace",
  "jet-metadata",
- "jet-proto-math 1.1.0 (git+https://github.com/jet-lab/program-libraries?branch=main)",
- "jet-proto-proc-macros",
+ "jet-program-common",
+ "jet-program-proc-macros",
  "pyth-sdk-solana 0.4.2",
  "serde",
  "serde_test",
@@ -2252,7 +2252,7 @@ dependencies = [
  "bytemuck",
  "jet-margin",
  "jet-metadata",
- "jet-proto-math 1.1.0 (git+https://github.com/jet-lab/program-libraries?branch=main)",
+ "jet-program-common",
  "pyth-sdk-solana 0.4.2",
  "serde",
  "serde_test",
@@ -2281,7 +2281,7 @@ dependencies = [
  "jet-margin-pool",
  "jet-margin-swap",
  "jet-metadata",
- "jet-proto-math 1.1.0 (git+https://github.com/jet-lab/program-libraries?branch=main)",
+ "jet-program-common",
  "jet-simulation",
  "jet-static-program-registry",
  "jet-test-service",
@@ -2334,9 +2334,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "jet-proto-math"
-version = "1.1.0"
-source = "git+https://github.com/jet-lab/program-libraries?branch=fixed-point-math#9b9a5a72718f3af8322b31e61b182772d28eec11"
+name = "jet-program-common"
+version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "bytemuck",
@@ -2347,27 +2346,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "jet-proto-math"
-version = "1.1.0"
-source = "git+https://github.com/jet-lab/program-libraries?branch=main#7e00d07729d2a079d7d0af5c49b359965df6256f"
-dependencies = [
- "anchor-lang",
- "bytemuck",
- "num-traits",
- "static_assertions",
- "thiserror",
- "uint 0.9.4",
-]
-
-[[package]]
-name = "jet-proto-proc-macros"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eab4c6fd9509fa9c5e6f329363fe47aa77343a5d0b2f82db5a5a2c1e7e3ef6d"
+name = "jet-program-proc-macros"
+version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "static_assertions",
  "syn 1.0.102",
 ]
 
@@ -3186,14 +3169,6 @@ dependencies = [
  "syn 1.0.102",
  "version_check",
  "yansi",
-]
-
-[[package]]
-name = "proc-macros"
-version = "0.1.0"
-dependencies = [
- "quote 1.0.21",
- "syn 1.0.102",
 ]
 
 [[package]]
@@ -5677,7 +5652,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytemuck",
- "jet-proto-math 1.1.0 (git+https://github.com/jet-lab/program-libraries?branch=fixed-point-math)",
+ "jet-program-common",
  "js-sys",
  "rand_chacha 0.3.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ members = [
     "libraries/ts/bonds/wasm-utils",
     "tools/*"
 ]
-
-[patch.crates-io]
-jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "main" }

--- a/check
+++ b/check
@@ -38,7 +38,7 @@ hosted-tests-localnet() { local args=$@
 
 cargo-lint() {
     cargo fmt --all --check
-    cargo clippy --all-targets -- -Dwarnings
+    cargo clippy --all-targets -- -Dwarnings # -A clippy::result_large_err
 }
 
 cargo-test() {

--- a/libraries/rust/margin/Cargo.toml
+++ b/libraries/rust/margin/Cargo.toml
@@ -23,8 +23,6 @@ tokio = { version = "1", features = ["rt"] }
 rand = { version = "0.8.5" }
 serde = { version = "1", features = ["derive"] }
 
-jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "main" }
-
 agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "main", features = ["lib", "utils"] }
 
 pyth-sdk-solana = "0.4"
@@ -35,6 +33,7 @@ anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 anchor-client = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 
 jet-simulation = { git = "https://github.com/jet-lab/jet-simulation", branch = "master" }
+jet-program-common = { path = "../program-common" }
 jet-test-service = { path = "../../../programs/test-service", features = ["no-entrypoint"] }
 jet-bonds = { path = "../../../programs/bonds", features = ["no-entrypoint", "cli"] }
 jet-airspace = { path = "../../../programs/airspace", features = ["no-entrypoint"] }

--- a/libraries/rust/margin/src/spl_swap.rs
+++ b/libraries/rust/margin/src/spl_swap.rs
@@ -24,7 +24,7 @@ use std::{
 
 use anchor_lang::AccountDeserialize;
 use anyhow::Result;
-use jet_proto_math::Number128;
+use jet_program_common::Number128;
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
 use solana_sdk::{program_pack::Pack, pubkey::Pubkey};
 use spl_token_swap::state::SwapV1;

--- a/libraries/rust/margin/src/test_service.rs
+++ b/libraries/rust/margin/src/test_service.rs
@@ -184,9 +184,7 @@ pub fn init_environment(
     config: &EnvironmentConfig,
     rent: &Rent,
 ) -> anyhow::Result<Vec<TransactionBuilder>> {
-    let mut txs = vec![];
-
-    txs.push(global_initialize_instructions(config.authority));
+    let mut txs = vec![global_initialize_instructions(config.authority)];
 
     txs.extend(create_global_adapter_register_tx(config.authority));
     txs.extend(create_token_tx(config));
@@ -199,9 +197,8 @@ pub fn init_environment(
 /// Basic environment setup for hosted tests that has only the necessary global
 /// state initialized
 pub fn minimal_environment(authority: Pubkey) -> anyhow::Result<Vec<TransactionBuilder>> {
-    let mut txs = vec![];
+    let mut txs = vec![global_initialize_instructions(authority)];
 
-    txs.push(global_initialize_instructions(authority));
     txs.extend(create_global_adapter_register_tx(authority));
 
     // todo move airspace creation into individual tests

--- a/libraries/rust/program-common/Cargo.toml
+++ b/libraries/rust/program-common/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "jet-program-common"
+version = "0.1.0"
+edition = "2021"
+
+description = "A library of common types/utilities suitable for use in solana programs"
+license = "AGPL-3.0-or-later"
+homepage = "https://jetprotocol.io"
+repository = "https://github.com/jet-lab/jet-v2"
+
+[dependencies]
+uint = "0.9"
+thiserror = "1.0.20"
+bytemuck = { version = "1.7", features = ["derive"] }
+static_assertions = "1.1.0"
+
+# Traits
+num-traits = "0.2"
+anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }

--- a/libraries/rust/program-common/src/fp32.rs
+++ b/libraries/rust/program-common/src/fp32.rs
@@ -1,0 +1,250 @@
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+use bytemuck::{Pod, Zeroable};
+
+pub const FP32_ONE: u128 = 1 << 32;
+
+#[derive(Pod, Zeroable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Fp32(u128);
+
+impl Fp32 {
+    pub const ONE: Self = Self(FP32_ONE);
+    pub const ZERO: Self = Self(0);
+    pub const MAX: Self = Self(u128::MAX);
+    pub const MIN: Self = Self(u128::MIN);
+
+    /// wraps a u128 value without any logical conversions
+    pub fn wrap_u128(n: u128) -> Self {
+        Self(n)
+    }
+
+    /// returns fixed-point to decimal representation
+    pub fn as_decimal_u64(self) -> Option<u64> {
+        let res = self.0 / Self::ONE.0;
+        if res > u64::MAX as u128 {
+            None
+        } else {
+            Some(res as u64)
+        }
+    }
+
+    /// returns fixed-point to decimal representation, rounded up
+    pub fn as_decimal_u64_ceil(self) -> Option<u64> {
+        let add_one = (!(self.0 as u32)).wrapping_add(1) as u128;
+        self.0
+            .checked_add(add_one)
+            .and_then(|n| Self(n).as_decimal_u64())
+    }
+
+    /// Keeps representation as a fixed-point 32 number
+    pub fn downcast_u64(self) -> Option<u64> {
+        if self.0 > u64::MAX as u128 {
+            None
+        } else {
+            Some(self.0 as u64)
+        }
+    }
+
+    /// multiplies self with rhs yielding a decimal u64
+    pub fn decimal_u64_mul(&self, rhs: u64) -> Option<u64> {
+        (*self * rhs).as_decimal_u64()
+    }
+
+    /// divides self with rhs yielding a u64
+    pub fn u64_div(&self, rhs: u64) -> Option<u64> {
+        (*self / rhs).as_decimal_u64()
+    }
+
+    /// upcasts and wraps an existing 64-bit fp32
+    pub fn upcast_fp32(fp: u64) -> Self {
+        Self(fp as u128)
+    }
+}
+
+impl<T: Into<u128>> From<T> for Fp32 {
+    fn from(n: T) -> Fp32 {
+        Fp32(n.into() * FP32_ONE)
+    }
+}
+
+impl Add<Fp32> for Fp32 {
+    type Output = Fp32;
+
+    fn add(self, rhs: Fp32) -> Self::Output {
+        Self(self.0.add(rhs.0))
+    }
+}
+
+impl Sub<Fp32> for Fp32 {
+    type Output = Fp32;
+
+    fn sub(self, rhs: Fp32) -> Self::Output {
+        Self(self.0.sub(rhs.0))
+    }
+}
+
+impl AddAssign<Fp32> for Fp32 {
+    fn add_assign(&mut self, rhs: Fp32) {
+        self.0.add_assign(rhs.0)
+    }
+}
+
+impl SubAssign<Fp32> for Fp32 {
+    fn sub_assign(&mut self, rhs: Fp32) {
+        self.0.sub_assign(rhs.0)
+    }
+}
+
+impl MulAssign<Fp32> for Fp32 {
+    fn mul_assign(&mut self, rhs: Fp32) {
+        self.0.mul_assign(rhs.0);
+        self.0.div_assign(Self::ONE.0);
+    }
+}
+
+impl Mul<Fp32> for Fp32 {
+    type Output = Fp32;
+
+    fn mul(self, rhs: Fp32) -> Self::Output {
+        Self(self.0.mul(rhs.0).div(FP32_ONE))
+    }
+}
+
+impl Div<Fp32> for Fp32 {
+    type Output = Fp32;
+
+    fn div(self, rhs: Fp32) -> Self::Output {
+        Self(self.0.mul(FP32_ONE).div(rhs.0))
+    }
+}
+
+impl<T: Into<u128>> Mul<T> for Fp32 {
+    type Output = Fp32;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self(self.0.mul(rhs.into()))
+    }
+}
+
+impl<T: Into<u128>> Div<T> for Fp32 {
+    type Output = Fp32;
+
+    fn div(self, rhs: T) -> Self::Output {
+        Self(self.0.div(rhs.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_equals_zero() {
+        assert_eq!(Fp32::ZERO, Fp32::from(0u64));
+    }
+
+    #[test]
+    fn one_equals_one() {
+        assert_eq!(Fp32::ONE, Fp32::from(1u64));
+    }
+
+    #[test]
+    fn one_plus_one_equals_two() {
+        assert_eq!(Fp32::from(2u64), Fp32::ONE + Fp32::ONE);
+    }
+
+    #[test]
+    fn one_minus_one_equals_zero() {
+        assert_eq!(Fp32::ONE - Fp32::from(1u64), Fp32::ZERO);
+    }
+
+    #[test]
+    fn one_times_one_equals_one() {
+        assert_eq!(Fp32::ONE, Fp32::ONE * Fp32::ONE);
+        assert_eq!(Fp32::ONE, Fp32::from(1u64) * Fp32::ONE);
+    }
+
+    #[test]
+    fn one_divided_by_one_equals_one() {
+        assert_eq!(Fp32::ONE, Fp32::ONE / Fp32::ONE);
+        assert_eq!(Fp32::ONE, Fp32::from(1u64) / Fp32::ONE);
+    }
+
+    #[test]
+    fn one_thousand_div_100_equals_ten() {
+        assert_eq!(Fp32::from(10u64), Fp32::from(1_000u64) / Fp32::from(100u64));
+    }
+
+    #[test]
+    fn multiply_by_u64() {
+        assert_eq!(Fp32::from(3u64), Fp32::from(1u64) * 3u64)
+    }
+
+    #[test]
+    fn test_add_assign_101_2() {
+        let mut a = Fp32::from(101u64);
+        a += Fp32::from(2u64);
+        assert_eq!(Fp32::from(103u64), a);
+    }
+
+    #[test]
+    fn test_sub_assign_101_2() {
+        let mut a = Fp32::from(101u64);
+        a -= Fp32::from(2u64);
+        assert_eq!(Fp32::from(99u64), a);
+    }
+
+    #[test]
+    fn test_mul_assign_101_2() {
+        let mut a = Fp32::from(101u64);
+        a *= Fp32::from(2u64);
+        assert_eq!(Fp32::from(202u64), a);
+    }
+
+    #[test]
+    fn test_div_assign_101_2() {
+        let mut a = Fp32::from(101u64);
+        a = a / Fp32::from(2u64);
+        assert_eq!(Fp32::from(505u64) / Fp32::from(10u64), a);
+    }
+
+    #[test]
+    fn as_u64() {
+        let u64in = 31455u64;
+        let a = Fp32::from(u64in);
+        let b = a.as_decimal_u64().unwrap();
+        assert_eq!(b, u64in);
+    }
+
+    #[test]
+    #[should_panic]
+    fn as_u64_panic_big() {
+        let a = Fp32::from(u64::MAX as u128 + 1);
+        a.as_decimal_u64().unwrap();
+    }
+
+    #[test]
+    fn u64_mul() {
+        let a = 100u64;
+        let fp = Fp32::from(10u64);
+
+        assert_eq!(fp.decimal_u64_mul(a).unwrap(), 1_000);
+    }
+
+    #[test]
+    fn u64_div() {
+        let a = 10u64;
+        let fp = Fp32::from(100u64);
+
+        assert_eq!(fp.u64_div(a).unwrap(), 10u64)
+    }
+
+    #[test]
+    fn up_and_downcasting() {
+        let fp32_u64 = 10 * (FP32_ONE as u64);
+        let up = Fp32::upcast_fp32(fp32_u64);
+
+        assert_eq!(up.downcast_u64().unwrap(), fp32_u64);
+    }
+}

--- a/libraries/rust/program-common/src/functions.rs
+++ b/libraries/rust/program-common/src/functions.rs
@@ -1,0 +1,39 @@
+use crate::number::*;
+
+/// Computes the Taylor expansion of exp(x) - 1, using the
+/// indicated number of terms.
+/// For example,
+///     expm1_approx(x, 3) = x + x^2 / 2 + x^3 / 6
+pub fn expm1_approx(x: Number, terms: usize) -> Number {
+    if terms == 0 {
+        return 0.into();
+    }
+    if terms == 1 {
+        return x;
+    }
+
+    let mut z = x;
+    let mut acc = x;
+    let mut fac = 1u64;
+
+    for k in 2..terms + 1 {
+        z *= x;
+        fac *= k as u64;
+        acc += z / fac;
+    }
+
+    acc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_5() {
+        assert_eq!(
+            Number::from_decimal(221402666666665u64, -15),
+            expm1_approx(Number::from_decimal(2, -1), 5)
+        )
+    }
+}

--- a/libraries/rust/program-common/src/lib.rs
+++ b/libraries/rust/program-common/src/lib.rs
@@ -1,0 +1,18 @@
+mod fp32;
+mod functions;
+mod number;
+mod number_128;
+
+pub mod traits;
+
+#[doc(inline)]
+pub use functions::*;
+
+#[doc(inline)]
+pub use number::*;
+
+#[doc(inline)]
+pub use number_128::*;
+
+#[doc(inline)]
+pub use fp32::*;

--- a/libraries/rust/program-common/src/number.rs
+++ b/libraries/rust/program-common/src/number.rs
@@ -1,0 +1,452 @@
+//! Yet another decimal library
+
+use std::{
+    fmt::Debug,
+    iter::Sum,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+};
+
+use bytemuck::{Pod, Zeroable};
+use std::fmt::{Display, Formatter};
+use thiserror::Error;
+use uint::construct_uint;
+
+construct_uint! {
+    #[derive(Pod, Zeroable)]
+    pub struct U192(3);
+}
+
+pub const BPS_EXPONENT: i32 = -4;
+const PRECISION: i32 = 15;
+const ONE: U192 = U192([1_000_000_000_000_000, 0, 0]);
+const U64_MAX: U192 = U192([u64::MAX, 0x0, 0x0]);
+const U128_MAX: U192 = U192([u64::MAX, u64::MAX, 0x0]);
+
+/// A large unsigned integer
+#[derive(Pod, Zeroable, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[repr(transparent)]
+pub struct Number(U192);
+
+static_assertions::const_assert_eq!(24, std::mem::size_of::<Number>());
+static_assertions::const_assert_eq!(0, std::mem::size_of::<Number>() % 8);
+impl Number {
+    pub const ONE: Self = Self(ONE);
+    pub const ZERO: Self = Self(U192::zero());
+    pub const MAX: Self = Self(U192([u64::MAX, u64::MAX, u64::MAX]));
+    pub const MIN: Self = Self::ZERO;
+    pub const BITS: u32 = 192;
+
+    /// Convert this number to fit in a u64
+    ///
+    /// The precision of the number in the u64 is based on the
+    /// exponent provided.
+    pub fn as_u64(&self, exponent: impl Into<i32>) -> u64 {
+        let extra_precision = PRECISION + exponent.into();
+        let prec_value = Self::ten_pow(extra_precision.unsigned_abs());
+
+        let target_value = if extra_precision < 0 {
+            self.0 * prec_value
+        } else {
+            self.0 / prec_value
+        };
+
+        if target_value > U64_MAX {
+            panic!("cannot convert to u64 due to overflow");
+        }
+
+        target_value.as_u64()
+    }
+
+    /// Ceiling value of number, fit in a u64
+    ///
+    /// The precision of the number in the u64 is based on the
+    /// exponent provided.
+    ///
+    /// The result is rounded up to the nearest one, based on the
+    /// target precision.
+    pub fn as_u64_ceil(&self, exponent: impl Into<i32>) -> u64 {
+        let extra_precision = PRECISION + exponent.into();
+        let prec_value = Self::ten_pow(extra_precision.unsigned_abs());
+
+        let target_rounded = prec_value - U192::from(1) + self.0;
+        let target_value = if extra_precision < 0 {
+            target_rounded * prec_value
+        } else {
+            target_rounded / prec_value
+        };
+
+        if target_value > U64_MAX {
+            panic!("cannot convert to u64 due to overflow");
+        }
+
+        target_value.as_u64()
+    }
+
+    /// Convert this number to fit in a u64
+    ///
+    /// The precision of the number in the u64 is based on the
+    /// exponent provided.
+    ///
+    /// The result is rounded to the nearest one, based on the
+    /// target precision.
+    pub fn as_u64_rounded(&self, exponent: impl Into<i32>) -> u64 {
+        let extra_precision = PRECISION + exponent.into();
+        let prec_value = Self::ten_pow(extra_precision.unsigned_abs());
+
+        let rounding = match extra_precision > 0 {
+            true => U192::from(1) * prec_value / 2,
+            false => U192::zero(),
+        };
+
+        let target_rounded = rounding + self.0;
+        let target_value = if extra_precision < 0 {
+            target_rounded * prec_value
+        } else {
+            target_rounded / prec_value
+        };
+
+        if target_value > U64_MAX {
+            panic!("cannot convert to u64 due to overflow");
+        }
+
+        target_value.as_u64()
+    }
+
+    /// Convert this number to fit in a u128
+    ///
+    /// The precision of the number in the u128 is based on the
+    /// exponent provided.
+    pub fn as_u128(&self, exponent: impl Into<i32>) -> u128 {
+        let extra_precision = PRECISION + exponent.into();
+        let prec_value = Self::ten_pow(extra_precision.unsigned_abs());
+
+        let target_value = if extra_precision < 0 {
+            self.0 * prec_value
+        } else {
+            self.0 / prec_value
+        };
+
+        if target_value > U128_MAX {
+            panic!("cannot convert to u128 due to overflow");
+        }
+
+        target_value.as_u128()
+    }
+
+    /// Convert another integer into a `Number`.
+    pub fn from_decimal(value: impl Into<U192>, exponent: impl Into<i32>) -> Self {
+        let extra_precision = PRECISION + exponent.into();
+        let prec_value = Self::ten_pow(extra_precision.unsigned_abs());
+
+        if extra_precision < 0 {
+            Self(value.into() / prec_value)
+        } else {
+            Self(value.into() * prec_value)
+        }
+    }
+
+    /// Convert from basis points into a `Number`
+    pub fn from_bps(basis_points: u16) -> Number {
+        Number::from_decimal(basis_points, BPS_EXPONENT)
+    }
+
+    pub fn pow(&self, exp: impl Into<Number>) -> Number {
+        let value = self.0.pow(exp.into().0);
+
+        Self(value)
+    }
+
+    pub fn saturating_add(&self, n: Number) -> Number {
+        Number(self.0.saturating_add(n.0))
+    }
+
+    pub fn saturating_sub(&self, n: Number) -> Number {
+        Number(self.0.saturating_sub(n.0))
+    }
+
+    pub fn saturating_mul(&self, n: Number) -> Number {
+        Number(self.0.saturating_mul(n.0))
+    }
+
+    pub fn ten_pow(exponent: u32) -> U192 {
+        let value: u64 = match exponent {
+            16 => 10_000_000_000_000_000,
+            15 => 1_000_000_000_000_000,
+            14 => 100_000_000_000_000,
+            13 => 10_000_000_000_000,
+            12 => 1_000_000_000_000,
+            11 => 100_000_000_000,
+            10 => 10_000_000_000,
+            9 => 1_000_000_000,
+            8 => 100_000_000,
+            7 => 10_000_000,
+            6 => 1_000_000,
+            5 => 100_000,
+            4 => 10_000,
+            3 => 1_000,
+            2 => 100,
+            1 => 10,
+            0 => 1,
+            _ => panic!("no support for exponent: {}", exponent),
+        };
+
+        value.into()
+    }
+
+    /// Get the underlying representation in bits
+    pub fn into_bits(self) -> [u8; 24] {
+        unsafe { std::mem::transmute(self.0 .0) }
+    }
+
+    /// Read a number from a raw 196-bit representation, which was previously
+    /// returned by a call to `into_bits`.
+    pub fn from_bits(bits: [u8; 24]) -> Self {
+        Self(U192(unsafe { std::mem::transmute(bits) }))
+    }
+}
+
+impl<T: Into<U192>> From<T> for Number {
+    fn from(n: T) -> Number {
+        Number(n.into() * ONE)
+    }
+}
+
+impl From<Number> for [u8; 24] {
+    fn from(n: Number) -> Self {
+        n.into_bits()
+    }
+}
+
+impl Debug for Number {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        <Self as Display>::fmt(self, f)
+    }
+}
+
+impl Display for Number {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // todo optimize
+        let rem = self.0 % ONE;
+        let decimal_digits = PRECISION as usize;
+        let rem_str = rem.to_string();
+        // regular padding like {:010} doesn't work with U192
+        let decimals = "0".repeat(decimal_digits - rem_str.len()) + &*rem_str;
+        let stripped_decimals = decimals.trim_end_matches('0');
+        let pretty_decimals = if stripped_decimals.is_empty() {
+            "0"
+        } else {
+            stripped_decimals
+        };
+        if self.0 < ONE {
+            write!(f, "0.{}", pretty_decimals)?;
+        } else {
+            let int = self.0 / ONE;
+            write!(f, "{}.{}", int, pretty_decimals)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    #[error("An integer value overflowed")]
+    Overflow(Number),
+
+    #[error("Attempting to divide by zero")]
+    DivideByZero,
+}
+
+impl Add<Number> for Number {
+    type Output = Number;
+
+    fn add(self, rhs: Number) -> Self::Output {
+        Self(self.0.add(rhs.0))
+    }
+}
+
+impl AddAssign<Number> for Number {
+    fn add_assign(&mut self, rhs: Number) {
+        self.0.add_assign(rhs.0)
+    }
+}
+
+impl SubAssign<Number> for Number {
+    fn sub_assign(&mut self, rhs: Number) {
+        self.0.sub_assign(rhs.0)
+    }
+}
+
+impl Sub<Number> for Number {
+    type Output = Number;
+
+    fn sub(self, rhs: Number) -> Self::Output {
+        Self(self.0.sub(rhs.0))
+    }
+}
+
+impl Mul<Number> for Number {
+    type Output = Number;
+
+    fn mul(self, rhs: Number) -> Self::Output {
+        Self(self.0.mul(rhs.0).div(ONE))
+    }
+}
+
+impl MulAssign<Number> for Number {
+    fn mul_assign(&mut self, rhs: Number) {
+        self.0.mul_assign(rhs.0);
+        self.0.div_assign(ONE);
+    }
+}
+
+impl Div<Number> for Number {
+    type Output = Number;
+
+    fn div(self, rhs: Number) -> Self::Output {
+        Self(self.0.mul(ONE).div(rhs.0))
+    }
+}
+
+impl<T: Into<U192>> Mul<T> for Number {
+    type Output = Number;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self(self.0.mul(rhs.into()))
+    }
+}
+
+impl<T: Into<U192>> Div<T> for Number {
+    type Output = Number;
+
+    fn div(self, rhs: T) -> Self::Output {
+        Self(self.0.div(rhs.into()))
+    }
+}
+
+impl Sum for Number {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.reduce(|a, b| a + b).unwrap_or(Self::ZERO)
+    }
+}
+
+impl num_traits::CheckedAdd for Number {
+    fn checked_add(&self, v: &Self) -> Option<Self> {
+        self.0.checked_add(v.0).map(Number)
+    }
+}
+
+impl num_traits::CheckedDiv for Number {
+    fn checked_div(&self, v: &Self) -> Option<Self> {
+        self.0.checked_div(v.0).map(Number)
+    }
+}
+
+impl num_traits::CheckedMul for Number {
+    fn checked_mul(&self, v: &Self) -> Option<Self> {
+        self.0.checked_mul(v.0).map(Number)
+    }
+}
+
+impl num_traits::CheckedSub for Number {
+    fn checked_sub(&self, v: &Self) -> Option<Self> {
+        self.0.checked_sub(v.0).map(Number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_equals_zero() {
+        assert_eq!(Number::ZERO, Number::from_decimal(0, 0));
+        assert_eq!(Number::ZERO, Number::from(0u64));
+    }
+
+    #[test]
+    fn one_equals_one() {
+        assert_eq!(Number::ONE, Number::from_decimal(1, 0));
+        assert_eq!(Number::ONE, Number::from(1u64));
+    }
+
+    #[test]
+    fn one_plus_one_equals_two() {
+        assert_eq!(Number::from_decimal(2, 0), Number::ONE + Number::ONE);
+    }
+
+    #[test]
+    fn one_minus_one_equals_zero() {
+        assert_eq!(Number::ONE - Number::ONE, Number::ZERO);
+    }
+
+    #[test]
+    fn one_times_one_equals_one() {
+        assert_eq!(Number::ONE, Number::ONE * Number::ONE);
+    }
+
+    #[test]
+    fn one_divided_by_one_equals_one() {
+        assert_eq!(Number::ONE, Number::ONE / Number::ONE);
+    }
+
+    #[test]
+    fn ten_div_100_equals_point_1() {
+        assert_eq!(
+            Number::from_decimal(1, -1),
+            Number::from_decimal(1, 1) / Number::from_decimal(100, 0)
+        );
+    }
+
+    #[test]
+    fn multiply_by_u64() {
+        assert_eq!(
+            Number::from_decimal(3, 1),
+            Number::from_decimal(1, 1) * 3u64
+        )
+    }
+
+    #[test]
+    fn ceil_gt_one() {
+        assert_eq!(Number::from_decimal(11, -1).as_u64_ceil(0), 2u64);
+        assert_eq!(Number::from_decimal(19, -1).as_u64_ceil(0), 2u64);
+    }
+
+    #[test]
+    fn ceil_lt_one() {
+        assert_eq!(Number::from_decimal(1, -1).as_u64_ceil(0), 1u64);
+        assert_eq!(Number::from_decimal(1, -10).as_u64_ceil(0), 1u64);
+    }
+
+    #[test]
+    fn ceil_of_int() {
+        assert_eq!(Number::from_decimal(1, 0).as_u64_ceil(0), 1u64);
+        assert_eq!(
+            Number::from_decimal(1_000_000u64, 0).as_u64_ceil(0),
+            1_000_000u64
+        );
+    }
+
+    #[test]
+    fn to_string() {
+        assert_eq!("1000.0", Number::from(1000).to_string());
+        assert_eq!("1.0", Number::from(1).to_string());
+        assert_eq!("0.001", Number::from_decimal(1, -3).to_string());
+    }
+
+    #[test]
+    fn into_bits() {
+        let bits = Number::from_decimal(1242, -3).into_bits();
+        let number = Number::from_bits(bits);
+
+        assert_eq!(Number::from_decimal(1242, -3), number);
+    }
+
+    #[test]
+    fn from_bits() {
+        let bits: [u8; 24] = {
+            let number: Number = 100.into();
+            number.into()
+        };
+        assert_eq!(Number::from_decimal(100, 0).into_bits(), bits);
+    }
+}

--- a/libraries/rust/program-common/src/number.rs
+++ b/libraries/rust/program-common/src/number.rs
@@ -1,4 +1,5 @@
 //! Yet another decimal library
+#![allow(clippy::assign_op_pattern)]
 
 use std::{
     fmt::Debug,

--- a/libraries/rust/program-common/src/number_128.rs
+++ b/libraries/rust/program-common/src/number_128.rs
@@ -1,0 +1,488 @@
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use bytemuck::{Pod, Zeroable};
+
+const PRECISION: i32 = 10;
+const ONE: i128 = 10_000_000_000;
+
+const POWERS_OF_TEN: &[i128] = &[
+    1,
+    10,
+    100,
+    1_000,
+    10_000,
+    100_000,
+    1_000_000,
+    10_000_000,
+    100_000_000,
+    1_000_000_000,
+    10_000_000_000,
+    100_000_000_000,
+    1_000_000_000_000,
+];
+
+/// A fixed-point decimal number 128 bits wide
+#[derive(Pod, Zeroable, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(C)]
+pub struct Number128(i128);
+
+impl Number128 {
+    pub const ONE: Self = Self(ONE);
+    pub const ZERO: Self = Self(0i128);
+    pub const MAX: Self = Self(i128::MAX);
+    pub const MIN: Self = Self(i128::MIN);
+    pub const BITS: u32 = i128::BITS;
+
+    /// Convert this number to fit in a u64
+    ///
+    /// The precision of the number in the u64 is based on the
+    /// exponent provided.
+    pub fn as_u64(&self, exponent: impl Into<i32>) -> u64 {
+        let extra_precision = PRECISION + exponent.into();
+        let prec_value = POWERS_OF_TEN[extra_precision.unsigned_abs() as usize];
+
+        let target_value = if extra_precision < 0 {
+            self.0 * prec_value
+        } else {
+            self.0 / prec_value
+        };
+
+        if target_value > std::u64::MAX as i128 {
+            panic!("cannot convert to u64 due to overflow");
+        }
+
+        if target_value < 0 {
+            panic!("cannot convert to u64 because value < 0");
+        }
+
+        target_value as u64
+    }
+
+    /// Convert this number to a f64
+    pub fn as_f64(&self) -> f64 {
+        // i128::{MAX|MIN} fits within f64
+        self.to_i128() as f64 / 10_000_000_000.0
+    }
+
+    /// Convert another integer
+    pub fn from_decimal(value: impl Into<i128>, exponent: impl Into<i32>) -> Self {
+        let extra_precision = PRECISION + exponent.into();
+        let prec_value = POWERS_OF_TEN[extra_precision.unsigned_abs() as usize];
+
+        if extra_precision < 0 {
+            Self(value.into() / prec_value)
+        } else {
+            Self(value.into() * prec_value)
+        }
+    }
+
+    /// Convert from basis points
+    pub fn from_bps(basis_points: u16) -> Self {
+        Self::from_decimal(basis_points, crate::BPS_EXPONENT)
+    }
+
+    /// Get the underlying 128-bit representation in bytes.
+    /// Uses the target endianness of the caller
+    pub fn into_bits(self) -> [u8; 16] {
+        self.0.to_ne_bytes()
+    }
+
+    /// Read a number from a raw 128-bit representation, which was previously
+    /// returned by a call to `into_bits`.
+    /// Uses the target endianness of the caller
+    pub fn from_bits(bits: [u8; 16]) -> Self {
+        Self(i128::from_ne_bytes(bits))
+    }
+
+    /// Get the underlying i128 value
+    pub fn to_i128(self) -> i128 {
+        self.0
+    }
+
+    /// Create `Number128` from an `i128`
+    pub fn from_i128(value: i128) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Debug for Number128 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as std::fmt::Display>::fmt(self, f)
+    }
+}
+
+impl std::fmt::Display for Number128 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // todo optimize
+        let rem = self.0 % ONE;
+        let decimal_digits = PRECISION as usize;
+        // convert to abs to remove sign
+        let rem_str = rem.abs().to_string();
+        // regular padding like {:010} doesn't work with i128
+        let decimals = "0".repeat(decimal_digits - rem_str.len()) + &*rem_str;
+        let stripped_decimals = decimals.trim_end_matches('0');
+        let pretty_decimals = if stripped_decimals.is_empty() {
+            "0"
+        } else {
+            stripped_decimals
+        };
+        if self.0 < -ONE {
+            let int = self.0 / ONE;
+            write!(f, "{}.{}", int, pretty_decimals)?;
+        } else if self.0 < 0 {
+            write!(f, "-0.{}", pretty_decimals)?;
+        } else if self.0 < ONE {
+            write!(f, "0.{}", pretty_decimals)?;
+        } else {
+            let int = self.0 / ONE;
+            write!(f, "{}.{}", int, pretty_decimals)?;
+        }
+        Ok(())
+    }
+}
+
+impl Add<Number128> for Number128 {
+    type Output = Self;
+
+    fn add(self, rhs: Number128) -> Self::Output {
+        Self(self.0.checked_add(rhs.0).unwrap())
+    }
+}
+
+impl AddAssign<Number128> for Number128 {
+    fn add_assign(&mut self, rhs: Number128) {
+        self.0 = self.0.checked_add(rhs.0).unwrap();
+    }
+}
+
+impl Sub<Number128> for Number128 {
+    type Output = Self;
+
+    fn sub(self, rhs: Number128) -> Self::Output {
+        Self(self.0.checked_sub(rhs.0).unwrap())
+    }
+}
+
+impl SubAssign<Number128> for Number128 {
+    fn sub_assign(&mut self, rhs: Number128) {
+        self.0 = self.0.checked_sub(rhs.0).unwrap();
+    }
+}
+
+impl Mul<Number128> for Number128 {
+    type Output = Number128;
+
+    fn mul(self, rhs: Number128) -> Self::Output {
+        Self(self.0.checked_mul(rhs.0).unwrap().div(ONE))
+    }
+}
+
+impl MulAssign<Number128> for Number128 {
+    fn mul_assign(&mut self, rhs: Number128) {
+        self.0 = self.0 * rhs.0 / ONE;
+    }
+}
+
+impl Div<Number128> for Number128 {
+    type Output = Number128;
+
+    fn div(self, rhs: Number128) -> Self::Output {
+        Self(self.0.mul(ONE).div(rhs.0))
+    }
+}
+
+impl DivAssign<Number128> for Number128 {
+    fn div_assign(&mut self, rhs: Number128) {
+        self.0 = self.0 * ONE / rhs.0;
+    }
+}
+
+impl<T: Into<i128>> Mul<T> for Number128 {
+    type Output = Number128;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self(self.0.mul(rhs.into()))
+    }
+}
+
+impl<T: Into<i128>> Div<T> for Number128 {
+    type Output = Number128;
+
+    fn div(self, rhs: T) -> Self::Output {
+        Self(self.0.div(rhs.into()))
+    }
+}
+
+impl<T: Into<i128>> From<T> for Number128 {
+    fn from(n: T) -> Self {
+        Self::from_i128(n.into())
+    }
+}
+
+impl num_traits::CheckedAdd for Number128 {
+    fn checked_add(&self, v: &Self) -> Option<Self> {
+        self.0.checked_add(v.0).map(|n| n.into())
+    }
+}
+
+impl num_traits::CheckedDiv for Number128 {
+    fn checked_div(&self, v: &Self) -> Option<Self> {
+        self.0.checked_div(v.0).map(|n| n.into())
+    }
+}
+
+impl num_traits::CheckedMul for Number128 {
+    fn checked_mul(&self, v: &Self) -> Option<Self> {
+        self.0.checked_mul(v.0).map(|n| n.into())
+    }
+}
+
+impl num_traits::CheckedSub for Number128 {
+    fn checked_sub(&self, v: &Self) -> Option<Self> {
+        self.0.checked_sub(v.0).map(|n| n.into())
+    }
+}
+
+impl Neg for Number128 {
+    type Output = Number128;
+
+    fn neg(self) -> Self::Output {
+        Number128(-self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_equals_zero() {
+        assert_eq!(Number128::ZERO, Number128::from_decimal(0, 0));
+    }
+
+    #[test]
+    fn one_equals_one() {
+        assert_eq!(Number128::ONE, Number128::from_decimal(1, 0));
+    }
+
+    #[test]
+    fn negative_one_equals_negative_one() {
+        assert_eq!(-Number128::ONE, Number128::from_decimal(-1, 0));
+    }
+
+    #[test]
+    fn one_plus_one_equals_two() {
+        assert_eq!(
+            Number128::from_decimal(2, 0),
+            Number128::ONE + Number128::ONE
+        );
+    }
+
+    #[test]
+    fn one_minus_one_equals_zero() {
+        assert_eq!(Number128::ONE - Number128::ONE, Number128::ZERO);
+    }
+
+    #[test]
+    fn one_times_one_equals_one() {
+        assert_eq!(Number128::ONE, Number128::ONE * Number128::ONE);
+    }
+
+    #[test]
+    fn one_divided_by_one_equals_one() {
+        assert_eq!(Number128::ONE, Number128::ONE / Number128::ONE);
+    }
+
+    #[test]
+    fn ten_div_100_equals_point_1() {
+        assert_eq!(
+            Number128::from_decimal(1, -1),
+            Number128::from_decimal(1, 1) / Number128::from_decimal(100, 0)
+        );
+    }
+
+    #[test]
+    fn comparison() {
+        let a = Number128::from_decimal(1000, -4);
+        let b = Number128::from_decimal(10, -2);
+        assert!(a >= b);
+
+        let c = Number128::from_decimal(1001, -4);
+        assert!(c > a);
+        assert!(c > b);
+
+        let d = Number128::from_decimal(9999999, -8);
+        assert!(d < a);
+        assert!(d < b);
+        assert!(d < c);
+        assert!(d <= d);
+
+        assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
+        assert_eq!(a.cmp(&c), std::cmp::Ordering::Less);
+        assert_eq!(a.cmp(&d), std::cmp::Ordering::Greater);
+    }
+
+    #[test]
+    fn multiply_by_u64() {
+        assert_eq!(
+            Number128::from_decimal(3, 1),
+            Number128::from_decimal(1, 1) * 3u64
+        )
+    }
+
+    #[test]
+    fn test_add_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a += Number128::from_decimal(2, 0);
+        assert_eq!(Number128::from_decimal(103, 0), a);
+    }
+
+    #[test]
+    fn test_sub_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a -= Number128::from_decimal(2, 0);
+        assert_eq!(Number128::from_decimal(99, 0), a);
+    }
+
+    #[test]
+    fn test_mul_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a *= Number128::from_decimal(2, 0);
+        assert_eq!(Number128::from_decimal(202, 0).0, a.0);
+    }
+
+    #[test]
+    fn test_div_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a /= Number128::from_decimal(2, 0);
+        assert_eq!(Number128::from_decimal(505, -1), a);
+    }
+
+    #[test]
+    fn test_div_assign_102_3() {
+        let mut a = Number128::from_decimal(1, 1);
+        a /= Number128::from_decimal(100, 0);
+        assert_eq!(Number128::from_decimal(1, -1).0, a.0);
+    }
+
+    #[test]
+    fn div_into_i128() {
+        let a = Number128::from_decimal(1000, 0);
+        let b = a / 500;
+        assert_eq!(Number128::from_decimal(2, 0), b);
+
+        let c = Number128::from_decimal(1000, -3);
+        let d = c / 3;
+        assert_eq!(Number128::from_decimal(3333333333i64, -10).0, d.0);
+    }
+
+    #[test]
+    fn equality() {
+        let a = Number128::from_decimal(1000, -4);
+        let b = Number128::from_decimal(10, -2);
+        assert_eq!(a, b);
+
+        let c = Number128::from_decimal(-1000, -4);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn as_u64() {
+        let u64in = 31455;
+        let a = Number128::from_decimal(u64in, -3);
+        let b = a.as_u64(-3);
+        assert_eq!(b, u64in);
+    }
+
+    #[test]
+    #[should_panic = "cannot convert to u64 because value < 0"]
+    fn as_u64_panic_neg() {
+        let a = Number128::from_decimal(-10000, -3);
+        a.as_u64(-3);
+    }
+
+    #[test]
+    #[should_panic = "cannot convert to u64 due to overflow"]
+    fn as_u64_panic_big() {
+        let a = Number128::from_decimal(u64::MAX as i128 + 1, -3);
+        a.as_u64(-3);
+    }
+
+    #[test]
+    fn as_f64() {
+        let n = Number128::from_bps(15000);
+        assert_eq!(1.5, n.as_f64());
+
+        // Test that conversion is within bounds and doesn't lose precision for min
+        let n = Number128::MIN; // -170141183460469231731687303715884105728
+        assert_eq!(-17014118346046923173168730371.5884105728, n.as_f64());
+
+        // Test that conversion is within bounds and doesn't lose precision for max
+        let n = Number128::MAX; // 170141183460469231731687303715884105727
+        assert_eq!(17014118346046923173168730371.5884105727, n.as_f64());
+
+        // More cases
+        let n = Number128::from_bps(0) - Number128::from_bps(15000);
+        assert_eq!(-1.5, n.as_f64());
+
+        let n = Number128::from_decimal(12345678901i128, -10);
+        assert_eq!(1.2345678901, n.as_f64());
+
+        let n = Number128::from_decimal(-12345678901i128, -10);
+        assert_eq!(-1.2345678901, n.as_f64());
+
+        let n = Number128::from_decimal(-12345678901i128, -9);
+        assert_eq!(-12.345678901, n.as_f64());
+
+        let n = Number128::from_decimal(12345678901i128, -9);
+        assert_eq!(12.345678901, n.as_f64());
+
+        let n = Number128::from_decimal(ONE - 1, 1);
+        assert_eq!(99999999990.0, n.as_f64());
+
+        let n = Number128::from_decimal(12345678901i128, -13);
+        assert_eq!(0.0012345678, n.as_f64());
+
+        let n = Number128::from_decimal(-12345678901i128, -13);
+        assert_eq!(-0.0012345678, n.as_f64());
+    }
+
+    #[test]
+    fn display() {
+        let a = Number128::from_bps(15000);
+        assert_eq!("1.5", a.to_string().as_str());
+
+        let a = Number128::from_bps(0) - Number128::from_bps(15000);
+        assert_eq!("-1.5", a.to_string().as_str());
+
+        let b = Number128::from_decimal(12345678901i128, -10);
+        assert_eq!("1.2345678901", b.to_string().as_str());
+
+        let b = Number128::from_decimal(-12345678901i128, -10);
+        assert_eq!("-1.2345678901", b.to_string().as_str());
+
+        let c = Number128::from_decimal(-12345678901i128, -9);
+        assert_eq!("-12.345678901", c.to_string().as_str());
+
+        let c = Number128::from_decimal(12345678901i128, -9);
+        assert_eq!("12.345678901", c.to_string().as_str());
+
+        let d = Number128::from_decimal(ONE - 1, 1);
+        assert_eq!("99999999990.0", d.to_string().as_str());
+
+        let e = Number128::from_decimal(12345678901i128, -13);
+        assert_eq!("0.0012345678", e.to_string().as_str());
+
+        let e = Number128::from_decimal(-12345678901i128, -13);
+        assert_eq!("-0.0012345678", e.to_string().as_str());
+    }
+
+    #[test]
+    fn into_bits() {
+        let bits = Number128::from_decimal(1242, -3).into_bits();
+        let number = Number128::from_bits(bits);
+
+        assert_eq!(Number128::from_decimal(1242, -3), number);
+    }
+}

--- a/libraries/rust/program-common/src/traits.rs
+++ b/libraries/rust/program-common/src/traits.rs
@@ -1,0 +1,102 @@
+use anchor_lang::{error, error_code, prelude::Result};
+use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
+
+use crate::{Number, U192};
+
+#[error_code]
+pub enum NumericalError {
+    #[msg("overflow on checked add")]
+    AdditionOverflow,
+    #[msg("overflow on checked add")]
+    MultiplicationOverflow,
+    #[msg("underflow on checked sub")]
+    SubtractionUnderflow,
+    #[msg("division by zero")]
+    ZeroDivision,
+}
+
+pub trait TryAddAssign: CheckedAdd {
+    fn try_add_assign(&mut self, amount: Self) -> Result<()> {
+        *self = self
+            .checked_add(&amount)
+            .ok_or_else(|| error!(NumericalError::AdditionOverflow))?;
+        Ok(())
+    }
+}
+
+pub trait TrySubAssign: CheckedSub {
+    fn try_sub_assign(&mut self, amount: Self) -> Result<()> {
+        *self = self
+            .checked_sub(&amount)
+            .ok_or_else(|| error!(NumericalError::SubtractionUnderflow))?;
+        Ok(())
+    }
+}
+impl<T: CheckedAdd> TryAddAssign for T {}
+impl<T: CheckedSub> TrySubAssign for T {}
+
+pub trait ToNumber {
+    fn to_number(self) -> Number;
+}
+
+impl<T: Into<U192>> ToNumber for T {
+    fn to_number(self) -> Number {
+        self.into().into()
+    }
+}
+
+pub trait NumberAddAssign: Into<U192> + From<Number> + Clone {
+    fn try_number_add_assign(&mut self, amount: impl Into<Number>) -> Result<()> {
+        *self = Number::from(self.clone())
+            .checked_add(&amount.into())
+            .ok_or_else(|| error!(NumericalError::AdditionOverflow))?
+            .into();
+
+        Ok(())
+    }
+}
+
+impl<T: Into<U192> + From<Number> + Clone> NumberAddAssign for T {}
+
+pub trait NumberSubAssign: Into<U192> + From<Number> + Clone {
+    fn try_number_sub_assign(&mut self, amount: impl Into<Number>) -> Result<()> {
+        *self = Number::from(self.clone())
+            .checked_sub(&amount.into())
+            .ok_or_else(|| error!(NumericalError::AdditionOverflow))?
+            .into();
+
+        Ok(())
+    }
+}
+
+impl<T: Into<U192> + From<Number> + Clone> NumberSubAssign for T {}
+
+pub trait SafeAdd: CheckedAdd {
+    fn safe_add(&self, amount: Self) -> Result<Self> {
+        self.checked_add(&amount)
+            .ok_or_else(|| error!(NumericalError::AdditionOverflow))
+    }
+}
+pub trait SafeDiv: CheckedDiv {
+    fn safe_div(&self, amount: Self) -> Result<Self> {
+        self.checked_div(&amount)
+            .ok_or_else(|| error!(NumericalError::ZeroDivision))
+    }
+}
+pub trait SafeMul: CheckedMul {
+    fn safe_mul(&self, amount: Self) -> Result<Self> {
+        self.checked_mul(&amount)
+            .ok_or_else(|| error!(NumericalError::MultiplicationOverflow))
+    }
+}
+pub trait SafeSub: CheckedSub {
+    fn safe_sub(&self, amount: Self) -> Result<Self> {
+        self.checked_sub(&amount)
+            .ok_or_else(|| error!(NumericalError::SubtractionUnderflow))
+    }
+}
+
+impl<T: CheckedAdd> SafeAdd for T {}
+impl<T: CheckedDiv> SafeDiv for T {}
+impl<T: CheckedMul> SafeMul for T {}
+impl<T: CheckedSub> SafeSub for T {}

--- a/libraries/rust/program-proc-macros/Cargo.toml
+++ b/libraries/rust/program-proc-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "proc-macros"
+name = "jet-program-proc-macros"
 version = "0.1.0"
 edition = "2021"
 
@@ -9,3 +9,4 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 quote = "1.0"
+proc-macro2 = "1.0"

--- a/libraries/rust/program-proc-macros/src/lib.rs
+++ b/libraries/rust/program-proc-macros/src/lib.rs
@@ -2,6 +2,26 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{self, DeriveInput};
 
+mod mem;
+
+/// Use the "aligns" or "size" options to ensure memory and storage safety with state structs or enums.
+///
+/// *aligns*: Ensure struct can be included in a parent struct that is packed (e.g. anchor's zero_copy)
+///           without messing up the parent's alignment
+///           *Important*: This does not guarantee alignment within this struct!
+///
+/// *size: usize*: Enforces that the struct is a specific size
+///
+/// For example, decorate a struct with any of these attributes:
+/// #[assert_size(128, aligns)
+/// #[assert_size(128)
+/// #[assert_size(aligns)
+/// #[assert_size(aligns, 128)
+#[proc_macro_attribute]
+pub fn assert_size(args: TokenStream, input_struct: TokenStream) -> TokenStream {
+    mem::handler(args.into(), input_struct.into()).into()
+}
+
 /// Implements BondTokenManager by implementing BondManagerProvider and
 /// TokenProgramProvider.
 ///

--- a/libraries/rust/program-proc-macros/src/mem.rs
+++ b/libraries/rust/program-proc-macros/src/mem.rs
@@ -1,0 +1,83 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{Ident, ItemEnum, ItemStruct};
+
+use proc_macro2;
+
+pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
+    let (ident, item) = (keep_trying! {
+        parse!(input as ItemStruct);
+        parse!(input as ItemEnum);
+    })
+    .expect("Must be an enum or a struct");
+    let new_tokens = parse_args(&args)
+        .iter()
+        .map(|c| to_token(c, &ident))
+        .collect::<Vec<_>>();
+    let tokens = quote! {
+        #(#new_tokens)*
+        #item
+    };
+    TokenStream::from(tokens)
+}
+
+macro_rules! parse {
+    ($input:ident as $type:ty) => {
+        syn::parse::<$type>($input.clone().into()).map(|s| (s.ident.clone(), s.to_token_stream()))
+    };
+}
+use parse;
+
+macro_rules! keep_trying {
+    ($first:expr; $($rest:expr);+;) => {
+        match $first {
+            Ok(ret) => Some(ret),
+            Err(_) => keep_trying! { $($rest);+; },
+        }
+    };
+    ($first:expr;) => {
+        match $first {
+            Ok(ret) => Some(ret),
+            Err(_) => None,
+        }
+    };
+}
+use keep_trying;
+
+enum Constraint {
+    Aligns,
+    Size(usize),
+}
+
+fn to_token(constraint: &Constraint, name: &Ident) -> proc_macro2::TokenStream {
+    match constraint {
+        Constraint::Aligns => quote! {
+            static_assertions::const_assert_eq!(0, std::mem::size_of::<#name>() % 8);
+        },
+        Constraint::Size(size) => quote! {
+            static_assertions::const_assert_eq!(#size, std::mem::size_of::<#name>());
+        },
+    }
+}
+
+fn parse_args(args: &TokenStream) -> Vec<Constraint> {
+    args.to_string()
+        .split(',')
+        .into_iter()
+        .map(|arg| {
+            let standarg: String = arg
+                .to_string()
+                .replace("\"", "")
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect();
+            if standarg == "aligns" {
+                Constraint::Aligns
+            } else if let Ok(size) = standarg.parse::<usize>() {
+                Constraint::Size(size)
+            } else {
+                panic!("Invalid argument: {}", arg);
+            }
+        })
+        .collect()
+}

--- a/libraries/rust/program-proc-macros/src/mem.rs
+++ b/libraries/rust/program-proc-macros/src/mem.rs
@@ -2,8 +2,6 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Ident, ItemEnum, ItemStruct};
 
-use proc_macro2;
-
 pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
     let (ident, item) = (keep_trying! {
         parse!(input as ItemStruct);
@@ -14,11 +12,11 @@ pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
         .iter()
         .map(|c| to_token(c, &ident))
         .collect::<Vec<_>>();
-    let tokens = quote! {
+
+    quote! {
         #(#new_tokens)*
         #item
-    };
-    TokenStream::from(tokens)
+    }
 }
 
 macro_rules! parse {
@@ -67,7 +65,7 @@ fn parse_args(args: &TokenStream) -> Vec<Constraint> {
         .map(|arg| {
             let standarg: String = arg
                 .to_string()
-                .replace("\"", "")
+                .replace('\\', "")
                 .chars()
                 .filter(|c| !c.is_whitespace())
                 .collect();

--- a/libraries/ts/bonds/wasm-utils/Cargo.toml
+++ b/libraries/ts/bonds/wasm-utils/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 js-sys = "0.3.59"
 wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
 
-jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "fixed-point-math", features = ["fixed-point", "number"] }
+jet-program-common = { path = "../../../rust/program-common" }
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/libraries/ts/bonds/wasm-utils/src/orderbook/critbit.rs
+++ b/libraries/ts/bonds/wasm-utils/src/orderbook/critbit.rs
@@ -460,7 +460,7 @@ impl<'a> Slab<'a> {
                 Node::Leaf => return Some(root),
                 Node::Inner => {
                     let node = self.inner_nodes[(!root) as usize];
-                    root = node.children[if find_max { 1 } else { 0 }];
+                    root = node.children[usize::from(find_max)];
                 }
             }
         }

--- a/libraries/ts/bonds/wasm-utils/src/orderbook/interest_pricing.rs
+++ b/libraries/ts/bonds/wasm-utils/src/orderbook/interest_pricing.rs
@@ -28,9 +28,8 @@
 
 use std::f64::consts::E;
 
-use jet_proto_math::{
-    fixed_point::{Fp32, FP32_ONE},
-    number::Number,
+use jet_program_common::{
+    Number, {Fp32, FP32_ONE},
 };
 
 const SECONDS_PER_YEAR: u64 = 31_536_000;

--- a/libraries/ts/bonds/wasm-utils/src/orderbook/methods.rs
+++ b/libraries/ts/bonds/wasm-utils/src/orderbook/methods.rs
@@ -1,4 +1,4 @@
-use jet_proto_math::fixed_point::Fp32;
+use jet_program_common::Fp32;
 use js_sys::{Array, Uint8Array};
 use wasm_bindgen::prelude::*;
 

--- a/programs/bonds/Cargo.toml
+++ b/programs/bonds/Cargo.toml
@@ -31,14 +31,15 @@ num-derive = "0.3.3"
 num-traits = "0.2"
 pyth-sdk-solana = "0.4"
 serde = { version = "1.0", optional = true }
-proc-macros = { path = "../../libraries/rust/proc-macros" }
 
 agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "main", features = ["lib", "utils"] }
 
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 anchor-spl =  { git = "https://github.com/jet-lab/anchor", branch = "master" }
 
-jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "main", features = ["traits"] }
+
+jet-program-proc-macros = { path = "../../libraries/rust/program-proc-macros" }
+jet-program-common = { path = "../../libraries/rust/program-common" }
 
 jet-margin = { path = "../margin", features = ["no-entrypoint"] }
 

--- a/programs/bonds/src/margin/instructions/margin_borrow_order.rs
+++ b/programs/bonds/src/margin/instructions/margin_borrow_order.rs
@@ -2,7 +2,7 @@ use agnostic_orderbook::state::Side;
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
 use jet_margin::{AdapterResult, PositionChange};
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager,

--- a/programs/bonds/src/margin/instructions/margin_lend_order.rs
+++ b/programs/bonds/src/margin/instructions/margin_lend_order.rs
@@ -1,6 +1,6 @@
 use agnostic_orderbook::state::Side;
 use anchor_lang::prelude::*;
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager,

--- a/programs/bonds/src/margin/instructions/margin_redeem_ticket.rs
+++ b/programs/bonds/src/margin/instructions/margin_redeem_ticket.rs
@@ -1,5 +1,5 @@
 use anchor_lang::prelude::*;
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager, margin::state::MarginUser,

--- a/programs/bonds/src/margin/instructions/margin_sell_tickets_order.rs
+++ b/programs/bonds/src/margin/instructions/margin_sell_tickets_order.rs
@@ -1,6 +1,6 @@
 use agnostic_orderbook::state::Side;
 use anchor_lang::prelude::*;
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager,

--- a/programs/bonds/src/margin/instructions/repay.rs
+++ b/programs/bonds/src/margin/instructions/repay.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use anchor_lang::{prelude::*, AccountsClose};
 use anchor_spl::token::{transfer, Token, TokenAccount, Transfer};
-use jet_proto_math::traits::TrySubAssign;
+use jet_program_common::traits::TrySubAssign;
 
 use crate::{
     events::{ObligationFulfilled, ObligationRepay},

--- a/programs/bonds/src/margin/instructions/settle.rs
+++ b/programs/bonds/src/margin/instructions/settle.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Token, TokenAccount};
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager, control::state::BondManager, margin::state::MarginUser,

--- a/programs/bonds/src/margin/state.rs
+++ b/programs/bonds/src/margin/state.rs
@@ -1,7 +1,7 @@
 use anchor_lang::{prelude::*, solana_program::clock::UnixTimestamp};
 use bytemuck::Zeroable;
 use jet_margin::{AdapterResult, MarginAccount};
-use jet_proto_math::traits::{SafeAdd, TryAddAssign, TrySubAssign};
+use jet_program_common::traits::{SafeAdd, TryAddAssign, TrySubAssign};
 
 use crate::{orderbook::state::OrderTag, BondsError};
 

--- a/programs/bonds/src/orderbook/instructions/consume_events/accounts.rs
+++ b/programs/bonds/src/orderbook/instructions/consume_events/accounts.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     control::state::{BondManager, CrankAuthorization},

--- a/programs/bonds/src/orderbook/instructions/consume_events/handler.rs
+++ b/programs/bonds/src/orderbook/instructions/consume_events/handler.rs
@@ -126,7 +126,7 @@ fn handle_fill<'info>(
             } else {
                 ctx.mint(
                     &ctx.accounts.bond_ticket_mint,
-                    &maker.as_token_account(),
+                    maker.as_token_account(),
                     base_size,
                 )?;
             }
@@ -153,7 +153,7 @@ fn handle_fill<'info>(
             } else {
                 ctx.withdraw(
                     &ctx.accounts.underlying_token_vault,
-                    &maker.as_token_account(),
+                    maker.as_token_account(),
                     quote_size,
                 )?;
             }
@@ -205,7 +205,7 @@ fn handle_out<'info>(
             } else {
                 ctx.withdraw(
                     &ctx.accounts.underlying_token_vault,
-                    &user.as_token_account(),
+                    user.as_token_account(),
                     quote_size,
                 )
             }
@@ -221,7 +221,7 @@ fn handle_out<'info>(
             } else {
                 ctx.mint(
                     &ctx.accounts.bond_ticket_mint,
-                    &user.as_token_account(),
+                    user.as_token_account(),
                     *base_size,
                 )
             }

--- a/programs/bonds/src/orderbook/instructions/consume_events/handler.rs
+++ b/programs/bonds/src/orderbook/instructions/consume_events/handler.rs
@@ -6,7 +6,7 @@ use agnostic_orderbook::{
     },
 };
 use anchor_lang::prelude::*;
-use jet_proto_math::traits::{SafeAdd, SafeSub};
+use jet_program_common::traits::{SafeAdd, SafeSub};
 use num_traits::FromPrimitive;
 
 use crate::{

--- a/programs/bonds/src/orderbook/instructions/lend_order.rs
+++ b/programs/bonds/src/orderbook/instructions/lend_order.rs
@@ -1,7 +1,7 @@
 use agnostic_orderbook::state::Side;
 use anchor_lang::prelude::*;
 use anchor_spl::token::{accessor::mint, Mint, Token, TokenAccount};
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager,

--- a/programs/bonds/src/orderbook/instructions/sell_tickets_order.rs
+++ b/programs/bonds/src/orderbook/instructions/sell_tickets_order.rs
@@ -1,7 +1,7 @@
 use agnostic_orderbook::state::Side;
 use anchor_lang::prelude::*;
 use anchor_spl::token::{accessor::mint, Mint, Token, TokenAccount};
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager, orderbook::state::*, serialization::RemainingAccounts,

--- a/programs/bonds/src/tickets/instructions/exchange_tokens.rs
+++ b/programs/bonds/src/tickets/instructions/exchange_tokens.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{transfer, Mint, Token, TokenAccount, Transfer};
-use proc_macros::BondTokenManager;
+use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager, control::state::BondManager,

--- a/programs/bonds/src/tickets/instructions/redeem_ticket.rs
+++ b/programs/bonds/src/tickets/instructions/redeem_ticket.rs
@@ -1,6 +1,6 @@
 use anchor_lang::{prelude::*, AccountsClose};
 use anchor_spl::token::{transfer, Token, TokenAccount, Transfer};
-use jet_proto_math::traits::SafeAdd;
+use jet_program_common::traits::SafeAdd;
 
 use crate::{
     control::state::BondManager,

--- a/programs/bonds/src/tickets/instructions/stake_bond_tickets.rs
+++ b/programs/bonds/src/tickets/instructions/stake_bond_tickets.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{burn, Burn, Mint, Token, TokenAccount};
-use jet_proto_math::traits::SafeAdd;
+use jet_program_common::traits::SafeAdd;
 
 use crate::{
     control::state::BondManager,

--- a/programs/margin-pool/Cargo.toml
+++ b/programs/margin-pool/Cargo.toml
@@ -30,7 +30,7 @@ anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 
 pyth-sdk-solana = "0.4"
 
-jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "main" }
+jet-program-common = { path = "../../libraries/rust/program-common" }
 jet-margin = { path = "../margin", features = ["cpi"] }
 jet-metadata = { path = "../metadata", features = ["cpi"] }
 

--- a/programs/margin-pool/src/instructions/configure.rs
+++ b/programs/margin-pool/src/instructions/configure.rs
@@ -48,7 +48,7 @@ pub fn configure_handler(ctx: Context<Configure>, config: Option<MarginPoolConfi
 
     if *ctx.accounts.pyth_price.key != Pubkey::default() {
         let product_data = ctx.accounts.pyth_product.try_borrow_data()?;
-        let product_account = pyth_sdk_solana::state::load_product_account(&**product_data)
+        let product_account = pyth_sdk_solana::state::load_product_account(&product_data)
             .map_err(|_| ErrorCode::InvalidPoolOracle)?;
 
         let expected_price_key = Pubkey::new_from_array(product_account.px_acc.val);

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use anchor_lang::{prelude::*, solana_program::clock::UnixTimestamp};
-use jet_proto_math::Number;
+use jet_program_common::Number;
 use pyth_sdk_solana::PriceFeed;
 #[cfg(any(test, feature = "cli"))]
 use serde::ser::{Serialize, SerializeStruct, Serializer};

--- a/programs/margin-pool/src/util.rs
+++ b/programs/margin-pool/src/util.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use anchor_lang::solana_program::clock::UnixTimestamp;
-use jet_proto_math::Number;
+use jet_program_common::Number;
 
 pub const SECONDS_PER_HOUR: UnixTimestamp = 3600;
 pub const SECONDS_PER_2H: UnixTimestamp = SECONDS_PER_HOUR * 2;
@@ -58,7 +58,7 @@ pub fn compound_interest(rate: Number, seconds: UnixTimestamp) -> Number {
 
     let x = rate * seconds / SECONDS_PER_YEAR;
 
-    jet_proto_math::expm1_approx(x, terms)
+    jet_program_common::expm1_approx(x, terms)
 }
 
 /// Linear interpolation between (x0, y0) and (x1, y1).

--- a/programs/margin/Cargo.toml
+++ b/programs/margin/Cargo.toml
@@ -31,8 +31,9 @@ anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 
 pyth-sdk-solana = "0.4"
 
-jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "main" }
-jet-proto-proc-macros = "1"
+jet-program-proc-macros = { path = "../../libraries/rust/program-proc-macros" }
+jet-program-common = { path = "../../libraries/rust/program-common" }
+
 jet-metadata = { path = "../metadata", features = ["no-entrypoint"] }
 jet-airspace = { path = "../airspace", features = ["no-entrypoint"] }
 

--- a/programs/margin/src/instructions/liquidate_begin.rs
+++ b/programs/margin/src/instructions/liquidate_begin.rs
@@ -17,7 +17,7 @@
 
 use anchor_lang::prelude::*;
 
-use jet_proto_math::Number128;
+use jet_program_common::Number128;
 
 use crate::{
     events, ErrorCode, Liquidation, LiquidationState, MarginAccount,

--- a/programs/margin/src/state/account.rs
+++ b/programs/margin/src/state/account.rs
@@ -21,7 +21,7 @@ use bytemuck::{Contiguous, Pod, Zeroable};
 #[cfg(any(test, feature = "cli"))]
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
-use jet_proto_math::Number128;
+use jet_program_common::Number128;
 
 use anchor_lang::Result as AnchorResult;
 use std::result::Result;

--- a/programs/margin/src/state/account/positions.rs
+++ b/programs/margin/src/state/account/positions.rs
@@ -20,8 +20,8 @@ use bytemuck::{Contiguous, Pod, Zeroable};
 #[cfg(any(test, feature = "cli"))]
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
-use jet_proto_math::Number128;
-use jet_proto_proc_macros::assert_size;
+use jet_program_common::Number128;
+use jet_program_proc_macros::assert_size;
 
 use anchor_lang::Result as AnchorResult;
 use std::{convert::TryFrom, result::Result};

--- a/programs/margin/src/util.rs
+++ b/programs/margin/src/util.rs
@@ -339,7 +339,7 @@ mod test {
                 mutator(&mut ba, n);
                 assert_eq!(contains, ba.contains(n));
                 for i in 0..8u8 {
-                    if i as u8 != n {
+                    if i != n {
                         // other bits are unchanged
                         assert_eq!(BitSet(byte).contains(i), ba.contains(i));
                     }
@@ -357,9 +357,9 @@ mod test {
         assert_eq!(BitSet(0).min(), None);
         for extremum in 0..8 {
             let top = 2u8.checked_pow(extremum + 1).unwrap_or(u8::MAX);
-            for byte in 2u8.pow(extremum as u32)..top {
-                assert_eq!(extremum as u32, BitSet(byte).max().unwrap());
-                assert_eq!(extremum as u32, BitSet(byte.reverse_bits()).min().unwrap());
+            for byte in 2u8.pow(extremum)..top {
+                assert_eq!(extremum, BitSet(byte).max().unwrap());
+                assert_eq!(extremum, BitSet(byte.reverse_bits()).min().unwrap());
             }
         }
     }

--- a/tests/hosted/Cargo.toml
+++ b/tests/hosted/Cargo.toml
@@ -56,10 +56,10 @@ jet-airspace = { path = "../../programs/airspace", features = ["no-entrypoint", 
 jet-test-service = { path = "../../programs/test-service", features = ["no-entrypoint"] }
 
 jet-margin-sdk = { path = "../../libraries/rust/margin", features = ["testing"] }
+jet-program-common = { path = "../../libraries/rust/program-common" }
 
 mock-adapter = { path = "../mock-adapter", features = ["no-entrypoint"] }
 
 jet-simulation = { git = "https://github.com/jet-lab/jet-simulation", branch = "master" }
-jet-proto-math = { git = "https://github.com/jet-lab/program-libraries", branch = "fixed-point-math", features = ["full"] }
 
 itertools = "0.10.3"

--- a/tests/hosted/src/bin/populate_orderbook.rs
+++ b/tests/hosted/src/bin/populate_orderbook.rs
@@ -5,7 +5,7 @@ use anchor_lang::AccountDeserialize;
 use anyhow::Result;
 use jet_bonds::control::state::BondManager;
 use jet_margin_sdk::bonds::{BondsIxBuilder, OrderParams};
-use jet_proto_math::fixed_point::{Fp32, FP32_ONE};
+use jet_program_common::{Fp32, FP32_ONE};
 use rand::{thread_rng, Rng};
 use solana_client::{rpc_client::RpcClient, rpc_config::RpcSendTransactionConfig};
 use solana_sdk::{

--- a/tests/hosted/src/bonds.rs
+++ b/tests/hosted/src/bonds.rs
@@ -12,13 +12,13 @@ use anchor_lang::{AccountDeserialize, AnchorSerialize, InstructionData, ToAccoun
 use anchor_spl::token::TokenAccount;
 use anyhow::Result;
 use async_trait::async_trait;
+
 use jet_bonds::{
     control::state::BondManager,
     margin::state::MarginUser,
     orderbook::state::{event_queue_len, orderbook_slab_len, CallbackInfo, OrderParams},
     tickets::state::{ClaimTicket, SplitTicket},
 };
-
 use jet_margin_sdk::{
     bonds::{bonds_pda, event_builder::build_consume_events_info, BondsIxBuilder},
     ix_builder::{
@@ -32,7 +32,7 @@ use jet_margin_sdk::{
     tx_builder::global_initialize_instructions,
 };
 use jet_metadata::{PositionTokenMetadata, TokenKind};
-use jet_proto_math::fixed_point::Fp32;
+use jet_program_common::Fp32;
 use jet_simulation::{
     create_wallet, generate_keypair, send_and_confirm, solana_rpc_api::SolanaRpcClient,
 };

--- a/tests/hosted/src/bonds.rs
+++ b/tests/hosted/src/bonds.rs
@@ -184,40 +184,31 @@ impl TestManager {
         let init_eq = {
             let rent = this
                 .client
-                .get_minimum_balance_for_rent_exemption(event_queue_len(
-                    EVENT_QUEUE_CAPACITY as usize,
-                ))
+                .get_minimum_balance_for_rent_exemption(event_queue_len(EVENT_QUEUE_CAPACITY))
                 .await?;
-            this.ix_builder.initialize_event_queue(
-                &eq_kp.pubkey(),
-                EVENT_QUEUE_CAPACITY as usize,
-                rent,
-            )?
+            this.ix_builder
+                .initialize_event_queue(&eq_kp.pubkey(), EVENT_QUEUE_CAPACITY, rent)?
         };
 
         let init_bids = {
             let rent = this
                 .client
-                .get_minimum_balance_for_rent_exemption(orderbook_slab_len(
-                    ORDERBOOK_CAPACITY as usize,
-                ))
+                .get_minimum_balance_for_rent_exemption(orderbook_slab_len(ORDERBOOK_CAPACITY))
                 .await?;
             this.ix_builder.initialize_orderbook_slab(
                 &bids_kp.pubkey(),
-                ORDERBOOK_CAPACITY as usize,
+                ORDERBOOK_CAPACITY,
                 rent,
             )?
         };
         let init_asks = {
             let rent = this
                 .client
-                .get_minimum_balance_for_rent_exemption(orderbook_slab_len(
-                    ORDERBOOK_CAPACITY as usize,
-                ))
+                .get_minimum_balance_for_rent_exemption(orderbook_slab_len(ORDERBOOK_CAPACITY))
                 .await?;
             this.ix_builder.initialize_orderbook_slab(
                 &asks_kp.pubkey(),
-                ORDERBOOK_CAPACITY as usize,
+                ORDERBOOK_CAPACITY,
                 rent,
             )?
         };

--- a/tests/hosted/src/tokens.rs
+++ b/tests/hosted/src/tokens.rs
@@ -34,7 +34,7 @@ use solana_sdk::{system_instruction, system_program};
 
 use anchor_lang::{InstructionData, ToAccountMetas};
 
-use jet_proto_math::number_128::Number128;
+use jet_program_common::Number128;
 use jet_simulation::{generate_keypair, send_and_confirm, solana_rpc_api::SolanaRpcClient};
 
 /// Utility for managing the creation of tokens and their prices

--- a/tests/hosted/tests/bonds.rs
+++ b/tests/hosted/tests/bonds.rs
@@ -19,7 +19,7 @@ use jet_margin_sdk::{
     util::data::Concat,
 };
 use jet_margin_sdk::{margin_integrator::RefreshingProxy, tx_builder::MarginTxBuilder};
-use jet_proto_math::fixed_point::Fp32;
+use jet_program_common::Fp32;
 
 use solana_sdk::signer::Signer;
 

--- a/tools/ctl/Cargo.toml
+++ b/tools/ctl/Cargo.toml
@@ -47,5 +47,5 @@ spl-token = "3"
 solana-remote-wallet = "1.10"
 
 serum_dex = "0.5"
-jet-proto-math = "1"
+jet-program-common = { path = "../../libraries/rust/program-common" }
 jet-margin-sdk = { path = "../../libraries/rust/margin" }

--- a/tools/ctl/src/actions/margin_pool.rs
+++ b/tools/ctl/src/actions/margin_pool.rs
@@ -422,7 +422,7 @@ async fn collect_pool_summary(
         .unwrap();
 
     let loans = spl_token::amount_to_ui_amount(
-        jet_proto_math::Number::from_bits(pool.borrowed_tokens).as_u64(0),
+        jet_program_common::Number::from_bits(pool.borrowed_tokens).as_u64(0),
         token_mint.decimals,
     );
     let rate = pool.interest_rate().to_string().parse::<f64>()?;


### PR DESCRIPTION
This merges in the libraries from https://github.com/jet-lab/program-libraries with different names:

* `jet-proto-proc-macros` merged as `jet-program-proc-macros`
* existing `proc-macros` library merged into `jet-program-proc-macros`
* `jet-proto-math` merged as `jet-program-common` with all features removed
* also includes some linting fixes for issues in clippy 1.65

Moving to this repo to simplify maintenance 