### PR TITLE
JET-1087: Update airspace events

### DIFF
--- a/programs/airspace/src/events.rs
+++ b/programs/airspace/src/events.rs
@@ -20,6 +20,14 @@ use anchor_lang::prelude::*;
 #[event]
 pub struct AirspaceCreated {
     pub airspace: Pubkey,
+    pub authority: Pubkey,
+    pub is_restricted: bool,
+}
+
+#[event]
+pub struct AirspaceAuthoritySet {
+    pub airspace: Pubkey,
+    pub authority: Pubkey,
 }
 
 #[event]
@@ -44,6 +52,5 @@ pub struct AirspacePermitCreated {
 #[event]
 pub struct AirspacePermitRevoked {
     pub airspace: Pubkey,
-    pub issuer: Pubkey,
-    pub owner: Pubkey,
+    pub permit: Pubkey,
 }

--- a/programs/airspace/src/instructions/airspace_create.rs
+++ b/programs/airspace/src/instructions/airspace_create.rs
@@ -49,7 +49,9 @@ pub fn airspace_create_handler(
     airspace.is_restricted = is_restricted;
 
     emit!(AirspaceCreated {
-        airspace: airspace.key()
+        airspace: airspace.key(),
+        authority,
+        is_restricted
     });
 
     Ok(())

--- a/programs/airspace/src/instructions/airspace_permit_revoke.rs
+++ b/programs/airspace/src/instructions/airspace_permit_revoke.rs
@@ -82,8 +82,7 @@ pub fn airspace_permit_revoke_handler(ctx: Context<AirspacePermitRevoke>) -> Res
 
     emit!(AirspacePermitRevoked {
         airspace: airspace.key(),
-        issuer: permit.issuer,
-        owner: permit.owner
+        permit: permit.key(),
     });
 
     Ok(())

--- a/programs/airspace/src/instructions/airspace_set_authority.rs
+++ b/programs/airspace/src/instructions/airspace_set_authority.rs
@@ -17,7 +17,7 @@
 
 use anchor_lang::prelude::*;
 
-use crate::state::Airspace;
+use crate::{events::AirspaceAuthoritySet, state::Airspace};
 
 #[derive(Accounts)]
 pub struct AirspaceSetAuthority<'info> {
@@ -36,6 +36,11 @@ pub fn airspace_set_authority_handler(
     let airspace = &mut ctx.accounts.airspace;
 
     airspace.authority = new_authority;
+
+    emit!(AirspaceAuthoritySet {
+        airspace: airspace.key(),
+        authority: new_authority
+    });
 
     Ok(())
 }


### PR DESCRIPTION
Adds and changes some fields to airspaces events, adds 1 event.

Doesn't look like there IDL is used on the TS lib (makes sense), so there's no updates there.