### PR TITLE
Constrain order prices for safety

### DIFF
--- a/libraries/rust/margin/src/bonds/ix_builder.rs
+++ b/libraries/rust/margin/src/bonds/ix_builder.rs
@@ -258,6 +258,7 @@ impl BondsIxBuilder {
         seed: [u8; 32],
         borrow_duration: i64,
         lend_duration: i64,
+        minimum_price: u64,
     ) -> Result<Instruction> {
         let data = jet_bonds::instruction::InitializeBondManager {
             params: InitializeBondManagerParams {
@@ -265,6 +266,7 @@ impl BondsIxBuilder {
                 seed,
                 borrow_duration,
                 lend_duration,
+                minimum_price,
             },
         }
         .data();

--- a/libraries/rust/margin/src/test_service.rs
+++ b/libraries/rust/margin/src/test_service.rs
@@ -90,6 +90,9 @@ pub struct BondMarketConfig {
     /// The minimum order size for the AOB
     pub min_order_size: u64,
 
+    /// The minimum price for the AOB
+    pub minimum_price: u64,
+
     /// Whether or not order matching should be paused for the market
     #[serde(default)]
     pub paused: bool,
@@ -374,6 +377,7 @@ fn create_airspace_token_bond_markets_tx(
                         bond_manager_seed,
                         bm_config.borrow_duration,
                         bm_config.lend_duration,
+                        bm_config.minimum_price,
                     )
                     .unwrap(),
                 bonds_ix

--- a/libraries/ts/bonds/src/bondMarket.ts
+++ b/libraries/ts/bonds/src/bondMarket.ts
@@ -42,6 +42,7 @@ export interface BondManagerInfo {
   reserved: number[]
   borrowDuration: BN
   lendDuration: BN
+  minimumPrice: BN
   nonce: BN
 }
 
@@ -195,7 +196,7 @@ export class BondMarket {
     const params: OrderParams = {
       maxBondTicketQty: new BN(U64_MAX.toString()),
       maxUnderlyingTokenQty: amount,
-      limitPrice: new BN(0.00001),
+      limitPrice: this.info.minimumPrice,
       matchLimit: new BN(U64_MAX.toString()),
       postOnly: false,
       postAllowed: false,

--- a/libraries/ts/bonds/src/types/jetBonds.ts
+++ b/libraries/ts/bonds/src/types/jetBonds.ts
@@ -2167,6 +2167,13 @@ export type JetBonds = {
             "type": "i64"
           },
           {
+            "name": "minimumPrice",
+            "docs": [
+              "Minimum allowable price for orders"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "nonce",
             "docs": [
               "Used to generate unique order tags"
@@ -5714,6 +5721,13 @@ export const IDL: JetBonds = {
               "Length of time before a claim is marked as mature, in seconds"
             ],
             "type": "i64"
+          },
+          {
+            "name": "minimumPrice",
+            "docs": [
+              "Minimum allowable price for orders"
+            ],
+            "type": "u64"
           },
           {
             "name": "nonce",

--- a/localnet.toml
+++ b/localnet.toml
@@ -31,6 +31,7 @@ max_leverage = 20_00
 borrow_duration = 86400
 lend_duration = 88000
 min_order_size = 10
+minimum_price = 4289087807
 paused = false
 ticket_price = "0.9"
 
@@ -38,6 +39,7 @@ ticket_price = "0.9"
 borrow_duration = 604800
 lend_duration = 610000
 min_order_size = 10
+minimum_price = 4253979509
 paused = false
 ticket_price = "0.9"
 

--- a/programs/bonds/src/control/instructions/initialize_bond_manager.rs
+++ b/programs/bonds/src/control/instructions/initialize_bond_manager.rs
@@ -19,6 +19,8 @@ pub struct InitializeBondManagerParams {
     pub borrow_duration: i64,
     /// Length of time before a claim is marked as mature, in seconds
     pub lend_duration: i64,
+    /// Minimum allowable price for orders
+    pub minimum_price: u64,
 }
 
 /// Initialize a [BondManager]
@@ -153,6 +155,7 @@ pub fn handler(
             lend_duration: params.lend_duration,
             underlying_oracle: ctx.accounts.underlying_oracle.key(),
             ticket_oracle: ctx.accounts.ticket_oracle.key(),
+            minimum_price: params.minimum_price,
         } ignoring {
             orderbook_market_state,
             event_queue,

--- a/programs/bonds/src/control/state.rs
+++ b/programs/bonds/src/control/state.rs
@@ -51,6 +51,8 @@ pub struct BondManager {
     pub borrow_duration: i64,
     /// Length of time before a claim is marked as mature, in seconds
     pub lend_duration: i64,
+    /// Minimum allowable price for orders
+    pub minimum_price: u64,
     /// Used to generate unique order tags
     pub nonce: u64,
 }

--- a/tests/hosted/src/bonds.rs
+++ b/tests/hosted/src/bonds.rs
@@ -68,6 +68,7 @@ pub const EVENT_QUEUE_CAPACITY: usize = 1_000;
 pub const BORROW_DURATION: i64 = 3;
 pub const LEND_DURATION: i64 = 5; // in seconds
 pub const MIN_ORDER_SIZE: u64 = 10;
+pub const MINIMUM_PRICE: u64 = 1_000_000;
 
 #[derive(Debug, Default, Clone)]
 pub struct Keys<T>(HashMap<String, T>);
@@ -235,6 +236,7 @@ impl TestManager {
             BOND_MANAGER_SEED,
             BORROW_DURATION,
             LEND_DURATION,
+            MINIMUM_PRICE,
         )?;
         let init_orderbook = this.ix_builder.initialize_orderbook(
             this.client.payer().pubkey(),

--- a/tests/hosted/tests/bonds.rs
+++ b/tests/hosted/tests/bonds.rs
@@ -285,6 +285,17 @@ async fn non_margin_orders_for_proxy<P: Proxy + GenerateProxy>(
             .is_some());
     }
 
+    // cannot make orders that represent a negative interest rate
+    let mut bad_params = OrderParams {
+        limit_price: jet_program_common::FP32_ONE as u64 + 1,
+        ..c_params
+    };
+    assert!(bob.lend_order(bad_params, &[3]).await.is_err());
+
+    // cannot make orders with a price below the minimum as specified by the market
+    bad_params.limit_price = manager.load_manager().await?.minimum_price - 1;
+    assert!(bob.lend_order(bad_params, &[3]).await.is_err());
+
     Ok(())
 }
 

--- a/tools/ctl/src/actions/bonds.rs
+++ b/tools/ctl/src/actions/bonds.rs
@@ -24,6 +24,9 @@ pub struct BondMarketParameters {
     pub min_order_size: u64,
 
     #[clap(long)]
+    pub minimum_price: u64,
+
+    #[clap(long)]
     pub seed: Vec<u8>,
 
     #[clap(long)]
@@ -112,6 +115,7 @@ pub async fn process_create_bond_market<'a>(
             seed,
             params.borrow_duration,
             params.lend_duration,
+            params.minimum_price,
         )?;
         steps.push(format!(
             "initialize-bond-manager for token [{}]",

--- a/tools/ctl/src/bin/launch_bonds_devnet.rs
+++ b/tools/ctl/src/bin/launch_bonds_devnet.rs
@@ -30,6 +30,7 @@ lazy_static::lazy_static! {
         borrow_duration: 3,
         lend_duration: 5,
         min_order_size: 1_000,
+        minimum_price: 4289087807,
         seed: Pubkey::default().to_bytes().to_vec(),
         token_mint: USDC,
         token_oracle: Pubkey::default(),


### PR DESCRIPTION
Limit prices on `OrderParams` should not be above one, representing a negative interest rate. Nor should they be below a market configurable `minimum_price`, which represents a maximum interest rate.