### PR TITLE
Fix `ConsumeEvents` instruction

### DIFF
--- a/programs/bonds/src/orderbook/instructions/consume_events/accounts.rs
+++ b/programs/bonds/src/orderbook/instructions/consume_events/accounts.rs
@@ -80,14 +80,14 @@ pub enum LoanAccount<'info> {
 }
 
 impl<'info> LoanAccount<'info> {
-    pub fn auto_stake(self) -> Result<AnchorAccount<'info, SplitTicket, Mut>> {
+    pub fn auto_stake(&mut self) -> Result<&mut AnchorAccount<'info, SplitTicket, Mut>> {
         match self {
             LoanAccount::AutoStake(split_ticket) => Ok(split_ticket),
             _ => panic!(),
         }
     }
 
-    pub fn new_debt(self) -> Result<AnchorAccount<'info, Obligation, Mut>> {
+    pub fn new_debt(&mut self) -> Result<&mut AnchorAccount<'info, Obligation, Mut>> {
         match self {
             LoanAccount::NewDebt(obligation) => Ok(obligation),
             _ => panic!(),

--- a/programs/bonds/src/orderbook/instructions/consume_events/handler.rs
+++ b/programs/bonds/src/orderbook/instructions/consume_events/handler.rs
@@ -29,7 +29,7 @@ pub fn handler<'info>(
     let mut num_iters = 0;
     let manager = ctx.accounts.bond_manager.load()?;
 
-    for event in queue(&ctx, Box::new(seeds))?.take(num_events as usize) {
+    for event in queue(&ctx, seeds)?.take(num_events as usize) {
         let mut res = event?;
         let (accounts, event) = res.as_mut();
 

--- a/programs/bonds/src/orderbook/instructions/consume_events/queue_iterator.rs
+++ b/programs/bonds/src/orderbook/instructions/consume_events/queue_iterator.rs
@@ -17,7 +17,7 @@ use super::{ConsumeEvents, EventAccounts, FillAccounts, LoanAccount, OutAccounts
 
 pub fn queue<'c, 'info>(
     ctx: &Context<'_, '_, 'c, 'info, ConsumeEvents<'info>>,
-    seeds: Vec<Vec<u8>>,
+    seeds: Box<Vec<Vec<u8>>>,
 ) -> Result<EventIterator<'c, 'info>> {
     Ok(EventIterator {
         queue: EventQueue::deserialize_market(ctx.accounts.event_queue.to_account_info())?.iter(),
@@ -39,11 +39,14 @@ pub struct EventIterator<'a, 'info> {
 }
 
 impl<'a, 'info> Iterator for EventIterator<'a, 'info> {
-    type Item = Result<(EventAccounts<'info>, OrderbookEvent)>;
+    type Item = Result<Box<(EventAccounts<'info>, OrderbookEvent)>>;
 
-    fn next(&mut self) -> Option<Result<(EventAccounts<'info>, OrderbookEvent)>> {
+    fn next(&mut self) -> Option<Result<Box<(EventAccounts<'info>, OrderbookEvent)>>> {
         let event = self.queue.next()?;
-        Some(self.extract_accounts(&event).map(|accts| (accts, event)))
+        Some(
+            self.extract_accounts(&event)
+                .map(|accts| Box::new((accts, event))),
+        )
     }
 }
 

--- a/programs/bonds/src/orderbook/instructions/consume_events/queue_iterator.rs
+++ b/programs/bonds/src/orderbook/instructions/consume_events/queue_iterator.rs
@@ -17,7 +17,7 @@ use super::{ConsumeEvents, EventAccounts, FillAccounts, LoanAccount, OutAccounts
 
 pub fn queue<'c, 'info>(
     ctx: &Context<'_, '_, 'c, 'info, ConsumeEvents<'info>>,
-    seeds: Box<Vec<Vec<u8>>>,
+    seeds: Vec<Vec<u8>>,
 ) -> Result<EventIterator<'c, 'info>> {
     Ok(EventIterator {
         queue: EventQueue::deserialize_market(ctx.accounts.event_queue.to_account_info())?.iter(),

--- a/programs/bonds/src/orderbook/state.rs
+++ b/programs/bonds/src/orderbook/state.rs
@@ -447,14 +447,14 @@ pub enum OrderbookEvent {
 }
 
 impl OrderbookEvent {
-    pub fn unwrap_fill(self) -> Result<FillInfo> {
+    pub fn unwrap_fill(&self) -> Result<&FillInfo> {
         match self {
             OrderbookEvent::Fill(fill) => Ok(fill),
             _ => err!(BondsError::InvalidEvent),
         }
     }
 
-    pub fn unwrap_out(self) -> Result<OutInfo> {
+    pub fn unwrap_out(&self) -> Result<&OutInfo> {
         match self {
             OrderbookEvent::Out(out) => Ok(out),
             _ => err!(BondsError::InvalidEvent),

--- a/tests/hosted/tests/bonds.rs
+++ b/tests/hosted/tests/bonds.rs
@@ -246,44 +246,39 @@ async fn non_margin_orders_for_proxy<P: Proxy + GenerateProxy>(
     bob.cancel_order(order_id).await?;
     assert!(manager.load_orderbook().await?.bids()?.first().is_none());
 
-    // only works on simulation right now
-    // Access violation in stack frame 5 at address 0x200005ff8 of size 8 by instruction #22627
-    #[cfg(not(feature = "localnet"))]
-    {
-        manager.consume_events().await?;
+    manager.consume_events().await?;
 
-        assert!(manager
-            .load_event_queue()
-            .await?
-            .inner()
-            .iter()
-            .next()
-            .is_none());
+    assert!(manager
+        .load_event_queue()
+        .await?
+        .inner()
+        .iter()
+        .next()
+        .is_none());
 
-        // test order pausing
-        manager.pause_orders().await?;
+    // test order pausing
+    manager.pause_orders().await?;
 
-        alice.sell_tickets_order(a_params).await?;
-        bob.lend_order(b_params, &[2]).await?;
+    alice.sell_tickets_order(a_params).await?;
+    bob.lend_order(b_params, &[2]).await?;
 
-        assert!(manager
-            .load_event_queue()
-            .await?
-            .inner()
-            .iter()
-            .next()
-            .is_none());
+    assert!(manager
+        .load_event_queue()
+        .await?
+        .inner()
+        .iter()
+        .next()
+        .is_none());
 
-        manager.resume_orders().await?;
+    manager.resume_orders().await?;
 
-        assert!(manager
-            .load_event_queue()
-            .await?
-            .inner()
-            .iter()
-            .next()
-            .is_some());
-    }
+    assert!(manager
+        .load_event_queue()
+        .await?
+        .inner()
+        .iter()
+        .next()
+        .is_some());
 
     Ok(())
 }


### PR DESCRIPTION
We were getting an error related to overflowing the limited instruction call stack. This PR moves more variables to the heap to allow the instruction to work normally.