### PR TITLE
JET-1065: Add event for borrow fills

### DIFF
--- a/libraries/ts/bonds/src/types/jetBonds.ts
+++ b/libraries/ts/bonds/src/types/jetBonds.ts
@@ -3083,6 +3083,58 @@ export type JetBonds = {
       ]
     },
     {
+      "name": "ObligationCreated",
+      "fields": [
+        {
+          "name": "obligation",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "borrowerAccount",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "orderId",
+          "type": {
+            "option": "u128"
+          },
+          "index": false
+        },
+        {
+          "name": "sequenceNumber",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "bondManager",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "maturationTimestamp",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "quoteFilled",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "baseFilled",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "flags",
+          "type": "u8",
+          "index": false
+        }
+      ]
+    },
+    {
       "name": "ObligationRepay",
       "fields": [
         {
@@ -6627,6 +6679,58 @@ export const IDL: JetBonds = {
         {
           "name": "postAllowed",
           "type": "bool",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "ObligationCreated",
+      "fields": [
+        {
+          "name": "obligation",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "borrowerAccount",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "orderId",
+          "type": {
+            "option": "u128"
+          },
+          "index": false
+        },
+        {
+          "name": "sequenceNumber",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "bondManager",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "maturationTimestamp",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "quoteFilled",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "baseFilled",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "flags",
+          "type": "u8",
           "index": false
         }
       ]

--- a/programs/bonds/src/margin/events.rs
+++ b/programs/bonds/src/margin/events.rs
@@ -1,6 +1,8 @@
 use agnostic_orderbook::state::OrderSummary;
 use anchor_lang::{event, prelude::*};
 
+use super::state::ObligationFlags;
+
 #[event]
 pub struct MarginUserInitialized {
     pub bond_manager: Pubkey,
@@ -31,6 +33,19 @@ pub enum OrderType {
     MarginSellTickets,
     Lend,
     SellTickets,
+}
+
+#[event]
+pub struct ObligationCreated {
+    pub obligation: Pubkey,
+    pub authority: Pubkey,
+    pub order_id: Option<u128>,
+    pub sequence_number: u64,
+    pub bond_manager: Pubkey,
+    pub maturation_timestamp: i64,
+    pub quote_filled: u64,
+    pub base_filled: u64,
+    pub flags: ObligationFlags,
 }
 
 #[event]

--- a/programs/bonds/src/margin/instructions/margin_borrow_order.rs
+++ b/programs/bonds/src/margin/instructions/margin_borrow_order.rs
@@ -117,7 +117,7 @@ pub fn handler(ctx: Context<MarginBorrowOrder>, params: OrderParams, seed: Vec<u
             maturation_timestamp,
             quote_filled,
             base_filled,
-            flags: ObligationFlags::default()
+            flags: obligation.flags
         });
     }
     let total_debt = order_summary.base_combined();

--- a/programs/bonds/src/margin/instructions/margin_borrow_order.rs
+++ b/programs/bonds/src/margin/instructions/margin_borrow_order.rs
@@ -6,6 +6,7 @@ use jet_program_proc_macros::BondTokenManager;
 
 use crate::{
     bond_token_manager::BondTokenManager,
+    events::ObligationCreated,
     margin::{
         events::{OrderPlaced, OrderType},
         state::{return_to_margin, MarginUser, Obligation, ObligationFlags},
@@ -94,16 +95,30 @@ pub fn handler(ctx: Context<MarginBorrowOrder>, params: OrderParams, seed: Vec<u
             ctx.accounts.system_program.to_account_info(),
             &Obligation::make_seeds(ctx.accounts.margin_user.key().as_ref(), seed.as_slice()),
         )?;
-        ctx.accounts.margin_user.assets.entitled_tokens += order_summary.quote_filled()?;
+        let quote_filled = order_summary.quote_filled()?;
+        let base_filled = order_summary.base_filled();
+        ctx.accounts.margin_user.assets.entitled_tokens += quote_filled;
         *obligation = Obligation {
             sequence_number,
             borrower_account: ctx.accounts.margin_user.key(),
             bond_manager: bond_manager.key(),
             order_tag: callback_info.order_tag,
             maturation_timestamp,
-            balance: order_summary.base_filled(),
+            balance: base_filled,
             flags: ObligationFlags::default(),
         };
+
+        emit!(ObligationCreated {
+            obligation: obligation.key(),
+            authority: ctx.accounts.margin_account.key(),
+            order_id: order_summary.summary().posted_order_id,
+            sequence_number,
+            bond_manager: bond_manager.key(),
+            maturation_timestamp,
+            quote_filled,
+            base_filled,
+            flags: ObligationFlags::default()
+        });
     }
     let total_debt = order_summary.base_combined();
     ctx.mint(&ctx.accounts.claims_mint, &ctx.accounts.claims, total_debt)?;


### PR DESCRIPTION
When an obligation is created on a market borrow, we do not emit an event for this. I've added it so we can get the borrow fill and the obligation.

I've also updated the IDL with the new event.