### PR TITLE
Avoid unnecessary token checks during margin_repay

### DIFF
--- a/programs/margin-pool/src/instructions/margin_repay.rs
+++ b/programs/margin-pool/src/instructions/margin_repay.rs
@@ -22,7 +22,6 @@ use anchor_spl::token::{self, Burn, Token, TokenAccount};
 
 use jet_margin::MarginAccount;
 
-use crate::instructions::withdraw;
 use crate::{events, state::*, ChangeKind, TokenChange};
 use crate::{Amount, ErrorCode};
 


### PR DESCRIPTION
`margin_repay` currently, unnecessarily, checks that the pool contains a number of tokens equal to the value of deposit notes being burned. The check is unnecessary because no underlying tokens are involved in this operation.

This is preventing the liquidation of margin accounts with deposit and loan notes in pools with maxed out utilisation.

This PR adds a method `margin_repay` to the `MarginAccount` that does not perform the unnecessary check on the vault balance, and uses that method instead of `withdraw` and `repay` in the `margin_repay` instruction.