### PR TITLE
add administrative instructions for transferring deposits and loans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,7 @@ dependencies = [
  "pyth-sdk-solana 0.4.2",
  "serde",
  "serde_test",
+ "solana-program",
  "static_assertions",
 ]
 
@@ -2256,6 +2257,7 @@ dependencies = [
  "pyth-sdk-solana 0.4.2",
  "serde",
  "serde_test",
+ "solana-program",
  "static_assertions",
 ]
 

--- a/programs/margin-pool/Cargo.toml
+++ b/programs/margin-pool/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0", optional = true }
 
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }
+solana-program = "1.10"
 
 pyth-sdk-solana = "0.4"
 

--- a/programs/margin-pool/src/instructions.rs
+++ b/programs/margin-pool/src/instructions.rs
@@ -27,6 +27,8 @@ mod register_loan;
 mod repay;
 mod withdraw;
 
+mod admin;
+
 pub use close_loan::*;
 pub use collect::*;
 pub use configure::*;
@@ -38,3 +40,5 @@ pub use margin_repay::*;
 pub use register_loan::*;
 pub use repay::*;
 pub use withdraw::*;
+
+pub use admin::*;

--- a/programs/margin-pool/src/instructions/admin/admin_transfer_loan.rs
+++ b/programs/margin-pool/src/instructions/admin/admin_transfer_loan.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2022 JET PROTOCOL HOLDINGS, LLC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount, Transfer};
+
+use crate::MarginPool;
+
+#[derive(Accounts)]
+pub struct AdminTransferLoan<'info> {
+    /// The administrative authority
+    #[account(address = super::ADMINISTRATOR)]
+    pub authority: Signer<'info>,
+
+    /// The margin pool with the loan
+    pub margin_pool: Account<'info, MarginPool>,
+
+    /// The loan account to be moved from
+    #[account(mut, token::authority = margin_pool)]
+    pub source_loan_account: Account<'info, TokenAccount>,
+
+    /// The loan account to be moved into
+    #[account(mut, token::authority = margin_pool)]
+    pub target_loan_account: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+impl<'info> AdminTransferLoan<'info> {
+    fn transfer_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        CpiContext::new(
+            self.token_program.to_account_info(),
+            Transfer {
+                from: self.source_loan_account.to_account_info(),
+                to: self.target_loan_account.to_account_info(),
+                authority: self.margin_pool.to_account_info(),
+            },
+        )
+    }
+}
+
+pub fn admin_transfer_loan_handler(ctx: Context<AdminTransferLoan>, amount: u64) -> Result<()> {
+    let source_seeds = ctx.accounts.margin_pool.signer_seeds()?;
+
+    token::transfer(
+        ctx.accounts
+            .transfer_context()
+            .with_signer(&[&source_seeds]),
+        amount,
+    )?;
+
+    Ok(())
+}

--- a/programs/margin-pool/src/instructions/admin/mod.rs
+++ b/programs/margin-pool/src/instructions/admin/mod.rs
@@ -1,0 +1,8 @@
+use anchor_lang::prelude::Pubkey;
+use anchor_lang::solana_program::pubkey;
+
+pub const ADMINISTRATOR: Pubkey = pubkey!("7R6FjP2HfXAgKQjURC4tCBrUmRQLCgEUeX2berrfU4ox");
+
+mod admin_transfer_loan;
+
+pub use admin_transfer_loan::*;

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -103,6 +103,11 @@ mod jet_margin_pool {
     pub fn close_loan(ctx: Context<CloseLoan>) -> Result<()> {
         instructions::close_loan_handler(ctx)
     }
+
+    /// Administrative function for moving loans between accounts
+    pub fn admin_transfer_loan(ctx: Context<AdminTransferLoan>, amount: u64) -> Result<()> {
+        instructions::admin_transfer_loan_handler(ctx, amount)
+    }
 }
 
 /// Interface for changing the token value of an account through pool instructions

--- a/programs/margin/Cargo.toml
+++ b/programs/margin/Cargo.toml
@@ -28,6 +28,7 @@ anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master", fe
     "init-if-needed",
 ] }
 anchor-spl = { git = "https://github.com/jet-lab/anchor", branch = "master" }
+solana-program = "1.10"
 
 pyth-sdk-solana = "0.4"
 

--- a/programs/margin/src/instructions.rs
+++ b/programs/margin/src/instructions.rs
@@ -28,6 +28,7 @@ mod register_position;
 mod update_position_balance;
 mod verify_healthy;
 
+mod admin;
 mod configure;
 mod positions;
 
@@ -44,5 +45,6 @@ pub use register_position::*;
 pub use update_position_balance::*;
 pub use verify_healthy::*;
 
+pub use admin::*;
 pub use configure::*;
 pub use positions::*;

--- a/programs/margin/src/instructions/admin/admin_transfer_position.rs
+++ b/programs/margin/src/instructions/admin/admin_transfer_position.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2022 JET PROTOCOL HOLDINGS, LLC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount, Transfer};
+
+use crate::{MarginAccount, SignerSeeds};
+
+#[derive(Accounts)]
+pub struct AdminTransferPosition<'info> {
+    /// The administrative authority
+    #[account(address = super::ADMINISTRATOR)]
+    pub authority: Signer<'info>,
+
+    /// The target margin account to move a position into
+    #[account(mut)]
+    pub target_account: AccountLoader<'info, MarginAccount>,
+
+    /// The source account to move a position out of
+    #[account(mut)]
+    pub source_account: AccountLoader<'info, MarginAccount>,
+
+    /// The token account to be moved from
+    #[account(mut)]
+    pub source_token_account: Account<'info, TokenAccount>,
+
+    /// The token account to be moved into
+    #[account(mut)]
+    pub target_token_account: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+impl<'info> AdminTransferPosition<'info> {
+    fn transfer_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        CpiContext::new(
+            self.token_program.to_account_info(),
+            Transfer {
+                from: self.source_token_account.to_account_info(),
+                to: self.target_token_account.to_account_info(),
+                authority: self.source_account.to_account_info(),
+            },
+        )
+    }
+}
+
+pub fn admin_transfer_position_handler(
+    ctx: Context<AdminTransferPosition>,
+    amount: u64,
+) -> Result<()> {
+    let source_seeds = ctx.accounts.source_account.load()?.signer_seeds_owned();
+
+    token::transfer(
+        ctx.accounts
+            .transfer_context()
+            .with_signer(&[&source_seeds.signer_seeds()]),
+        amount,
+    )?;
+
+    let source_tokens = &mut ctx.accounts.source_token_account;
+    let target_tokens = &mut ctx.accounts.target_token_account;
+
+    source_tokens.reload()?;
+    target_tokens.reload()?;
+
+    let mut source = ctx.accounts.source_account.load_mut()?;
+    let mut target = ctx.accounts.target_account.load_mut()?;
+
+    source.set_position_balance(
+        &source_tokens.mint,
+        &source_tokens.key(),
+        source_tokens.amount,
+    )?;
+    target.set_position_balance(
+        &target_tokens.mint,
+        &target_tokens.key(),
+        target_tokens.amount,
+    )?;
+
+    Ok(())
+}

--- a/programs/margin/src/instructions/admin/mod.rs
+++ b/programs/margin/src/instructions/admin/mod.rs
@@ -1,0 +1,8 @@
+use anchor_lang::prelude::Pubkey;
+use anchor_lang::solana_program::pubkey;
+
+pub const ADMINISTRATOR: Pubkey = pubkey!("7R6FjP2HfXAgKQjURC4tCBrUmRQLCgEUeX2berrfU4ox");
+
+mod admin_transfer_position;
+
+pub use admin_transfer_position::*;

--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -498,6 +498,14 @@ pub mod jet_margin {
     ) -> Result<()> {
         configure_liquidator_handler(ctx, is_liquidator)
     }
+
+    /// Allow governing address to transfer any position from one margin account to another
+    ///
+    /// This is provided as a mechanism to allow for manually fixing issues that occur in the
+    /// protocol due to bad user assets.
+    pub fn admin_transfer_position(ctx: Context<AdminTransferPosition>, amount: u64) -> Result<()> {
+        admin_transfer_position_handler(ctx, amount)
+    }
 }
 
 #[error_code]


### PR DESCRIPTION
These instructions allow the engineering team to manually fix accounts with bad assets by transferring the positions to a controllable account.