### PR TITLE
Add events for admin transfer

### DIFF
--- a/programs/margin-pool/src/events.rs
+++ b/programs/margin-pool/src/events.rs
@@ -89,6 +89,14 @@ pub struct Collect {
     pub summary: MarginPoolSummary,
 }
 
+#[event]
+pub struct LoanTransferred {
+    pub margin_pool: Pubkey,
+    pub source_loan_account: Pubkey,
+    pub target_loan_account: Pubkey,
+    pub amount: u64,
+}
+
 /// Common fields from MarginPool for event logging.
 #[derive(AnchorDeserialize, AnchorSerialize, Debug)]
 pub struct MarginPoolSummary {

--- a/programs/margin-pool/src/instructions/admin/admin_transfer_loan.rs
+++ b/programs/margin-pool/src/instructions/admin/admin_transfer_loan.rs
@@ -18,7 +18,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Token, TokenAccount, Transfer};
 
-use crate::MarginPool;
+use crate::{events::LoanTransferred, MarginPool};
 
 #[derive(Accounts)]
 pub struct AdminTransferLoan<'info> {
@@ -62,6 +62,13 @@ pub fn admin_transfer_loan_handler(ctx: Context<AdminTransferLoan>, amount: u64)
             .with_signer(&[&source_seeds]),
         amount,
     )?;
+
+    emit!(LoanTransferred {
+        margin_pool: ctx.accounts.margin_pool.key(),
+        source_loan_account: ctx.accounts.source_loan_account.key(),
+        target_loan_account: ctx.accounts.target_loan_account.key(),
+        amount
+    });
 
     Ok(())
 }

--- a/programs/margin/src/events.rs
+++ b/programs/margin/src/events.rs
@@ -105,6 +105,15 @@ pub struct LiquidationEnded {
     pub timed_out: bool,
 }
 
+#[event]
+pub struct TransferPosition {
+    pub source_margin_account: Pubkey,
+    pub target_margin_account: Pubkey,
+    pub source_token_account: Pubkey,
+    pub target_token_account: Pubkey,
+    pub amount: u64,
+}
+
 #[derive(AnchorDeserialize, AnchorSerialize)]
 pub struct ValuationSummary {
     pub equity: i128,

--- a/programs/margin/src/instructions/admin/admin_transfer_position.rs
+++ b/programs/margin/src/instructions/admin/admin_transfer_position.rs
@@ -18,7 +18,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Token, TokenAccount, Transfer};
 
-use crate::{MarginAccount, SignerSeeds};
+use crate::{events::TransferPosition, MarginAccount, SignerSeeds};
 
 #[derive(Accounts)]
 pub struct AdminTransferPosition<'info> {
@@ -90,6 +90,14 @@ pub fn admin_transfer_position_handler(
         &target_tokens.key(),
         target_tokens.amount,
     )?;
+
+    emit!(TransferPosition {
+        source_margin_account: ctx.accounts.source_account.key(),
+        target_margin_account: ctx.accounts.target_account.key(),
+        source_token_account: ctx.accounts.source_token_account.key(),
+        target_token_account: ctx.accounts.target_token_account.key(),
+        amount
+    });
 
     Ok(())
 }


### PR DESCRIPTION
Adds 2 events for the 2 new instructions so that we can account for their changes in the database.