### PR TITLE
Library improvements for liquidator

### DIFF
--- a/libraries/rust/margin/src/tx_builder/user.rs
+++ b/libraries/rust/margin/src/tx_builder/user.rs
@@ -261,7 +261,7 @@ impl MarginTxBuilder {
     pub async fn close_empty_positions(
         &self,
         loan_to_token: &HashMap<Pubkey, Pubkey>,
-    ) -> Result<Transaction> {
+    ) -> Result<TransactionBuilder> {
         let to_close = self
             .get_account_state()
             .await?
@@ -277,7 +277,7 @@ impl MarginTxBuilder {
             })
             .collect::<Vec<_>>();
 
-        self.create_transaction(&to_close).await
+        self.create_transaction_builder(&to_close)
     }
 
     /// Transaction to deposit tokens into a margin account
@@ -350,7 +350,7 @@ impl MarginTxBuilder {
         &self,
         token_mint: &Pubkey,
         change: TokenChange,
-    ) -> Result<Transaction> {
+    ) -> Result<TransactionBuilder> {
         let mut instructions = vec![];
         let pool = MarginPoolIxBuilder::new(*token_mint);
 
@@ -365,7 +365,7 @@ impl MarginTxBuilder {
             pool.margin_repay(self.ix.address, deposit_position, loan_position, change);
 
         instructions.push(self.adapter_invoke_ix(inner_repay_ix));
-        self.create_transaction(&instructions).await
+        self.create_transaction_builder(&instructions)
     }
 
     /// Transaction to repay a loan of tokens in a margin account from a token account
@@ -444,7 +444,7 @@ impl MarginTxBuilder {
         // for levswap
         change: TokenChange,
         minimum_amount_out: u64,
-    ) -> Result<Transaction> {
+    ) -> Result<TransactionBuilder> {
         let mut instructions = vec![];
         let source_pool = MarginPoolIxBuilder::new(*source_token_mint);
         let destination_pool = MarginPoolIxBuilder::new(*destination_token_mint);
@@ -501,7 +501,7 @@ impl MarginTxBuilder {
         instructions.push(self.ix.update_position_balance(source_position));
         instructions.push(self.ix.update_position_balance(destination_position));
 
-        self.create_transaction(&instructions).await
+        self.create_transaction_builder(&instructions)
     }
 
     /// Transaction to begin liquidating user account.

--- a/libraries/rust/margin/src/tx_builder/user.rs
+++ b/libraries/rust/margin/src/tx_builder/user.rs
@@ -498,6 +498,9 @@ impl MarginTxBuilder {
 
         instructions.push(self.adapter_invoke_ix(inner_swap_ix));
 
+        instructions.push(self.ix.update_position_balance(source_position));
+        instructions.push(self.ix.update_position_balance(destination_position));
+
         self.create_transaction(&instructions).await
     }
 

--- a/tests/hosted/src/margin.rs
+++ b/tests/hosted/src/margin.rs
@@ -417,8 +417,10 @@ impl MarginUser {
     }
 
     pub async fn margin_repay(&self, mint: &Pubkey, change: TokenChange) -> Result<(), Error> {
-        self.send_confirm_tx(self.tx.margin_repay(mint, change).await?)
+        self.rpc
+            .send_and_confirm(self.tx.margin_repay(mint, change).await?)
             .await
+            .map(|_| ())
     }
 
     pub async fn repay(
@@ -453,25 +455,27 @@ impl MarginUser {
         } else {
             (&swap_pool.token_b, &swap_pool.token_a)
         };
-        self.send_confirm_tx(
-            self.tx
-                .swap(
-                    source_mint,
-                    destination_mint,
-                    transit_source_account,
-                    transit_destination_account,
-                    &swap_pool.pool,
-                    &swap_pool.pool_mint,
-                    &swap_pool.fee_account,
-                    source_token,
-                    destination_token,
-                    program_id,
-                    change,
-                    minimum_amount_out,
-                )
-                .await?,
-        )
-        .await
+        self.rpc
+            .send_and_confirm(
+                self.tx
+                    .swap(
+                        source_mint,
+                        destination_mint,
+                        transit_source_account,
+                        transit_destination_account,
+                        &swap_pool.pool,
+                        &swap_pool.pool_mint,
+                        &swap_pool.fee_account,
+                        source_token,
+                        destination_token,
+                        program_id,
+                        change,
+                        minimum_amount_out,
+                    )
+                    .await?,
+            )
+            .await
+            .map(|_| ())
     }
 
     pub async fn positions(&self) -> Result<Vec<AccountPosition>, Error> {
@@ -510,8 +514,10 @@ impl MarginUser {
         &self,
         loan_to_token: &HashMap<Pubkey, Pubkey>,
     ) -> Result<(), Error> {
-        self.send_confirm_tx(self.tx.close_empty_positions(loan_to_token).await?)
+        self.rpc
+            .send_and_confirm(self.tx.close_empty_positions(loan_to_token).await?)
             .await
+            .map(|_| ())
     }
 
     /// Close a user's token positions for a specific mint.


### PR DESCRIPTION
This makes a few small changes, some of which have been lingering around in a branch that the liquidator uses.
The main change is to convert some methods returning `Transaction` to return `TransactionBuilder`