### PR TITLE
Update logic to refresh pools before tx

### DIFF
--- a/libraries/ts/margin/src/margin/pool/pool.ts
+++ b/libraries/ts/margin/src/margin/pool/pool.ts
@@ -695,24 +695,15 @@ export class Pool {
     marginAccount: MarginAccount
   }): Promise<void> {
     const poolsToRefresh: Pool[] = []
-    const liabilities = marginAccount.valuation.requiredCollateral.toNumber()
-    const requiredCollateral = marginAccount.valuation.liabilities.toNumber()
-    const totalRequired = liabilities + requiredCollateral
-    let effectiveCollateral = 0
     for (const pool of Object.values(pools)) {
       const assetCollateralWeight = pool.depositNoteMetadata.valueModifier.toNumber()
       const depositPosition = marginAccount.getPositionNullable(pool.addresses.depositNoteMint)
       const borrowPosition = marginAccount.getPositionNullable(pool.addresses.loanNoteMint)
-      if (borrowPosition && !borrowPosition.balance.eqn(0)) {
+      if (pool.address === this.address) {
         poolsToRefresh.push(pool)
-        break
-      } else if (
-        assetCollateralWeight > 0 &&
-        depositPosition &&
-        !depositPosition.balance.eqn(0) &&
-        effectiveCollateral < totalRequired
-      ) {
-        effectiveCollateral += depositPosition.value
+      } else if (borrowPosition && !borrowPosition.balance.eqn(0)) {
+        poolsToRefresh.push(pool)
+      } else if (assetCollateralWeight > 0 && depositPosition && !depositPosition.balance.eqn(0)) {
         poolsToRefresh.push(pool)
       }
     }


### PR DESCRIPTION
This addresses an issue where some transactions on a fresh margin account would fail.
The fix simplifies the logic of excluding pools, improving the coverage of pools to be refreshed.