### PR TITLE
fixed term api improvements

### DIFF
--- a/apps/react-app/src/components/fixed-term/borrow-entry/borrow-now.tsx
+++ b/apps/react-app/src/components/fixed-term/borrow-entry/borrow-now.tsx
@@ -46,13 +46,11 @@ export const BorrowNow = ({ token, decimals, marketAndConfig, marginConfig }: Re
     try {
       if (disabled || !wallet.publicKey) return;
       signature = await borrowNow({
-        market: marketAndConfig.market,
+        market: marketAndConfig,
         marginAccount,
-        marginConfig,
         provider,
         walletAddress: wallet.publicKey,
         pools: pools.tokenPools,
-        currentPool,
         amount,
         markets: markets.map(m => m.market)
       });

--- a/apps/react-app/src/components/fixed-term/borrow-entry/request-loan.tsx
+++ b/apps/react-app/src/components/fixed-term/borrow-entry/request-loan.tsx
@@ -55,9 +55,8 @@ export const RequestLoan = ({ token, decimals, marketAndConfig, marginConfig }: 
     try {
       if (disabled || !wallet.publicKey) return;
       signature = await requestLoan({
-        market: marketAndConfig.market,
+        market: marketAndConfig,
         marginAccount,
-        marginConfig,
         provider,
         walletAddress: wallet.publicKey,
         pools: pools.tokenPools,

--- a/apps/react-app/src/components/fixed-term/lend-entry/lend-now.tsx
+++ b/apps/react-app/src/components/fixed-term/lend-entry/lend-now.tsx
@@ -46,9 +46,8 @@ export const LendNow = ({ token, decimals, marketAndConfig, marginConfig }: Requ
     try {
       if (disabled || !wallet.publicKey) return;
       signature = await lendNow({
-        market: marketAndConfig.market,
+        market: marketAndConfig,
         marginAccount,
-        marginConfig,
         provider,
         walletAddress: wallet.publicKey,
         pools: pools.tokenPools,

--- a/apps/react-app/src/components/fixed-term/lend-entry/offer-loan.tsx
+++ b/apps/react-app/src/components/fixed-term/lend-entry/offer-loan.tsx
@@ -55,9 +55,8 @@ export const OfferLoan = ({ token, decimals, marketAndConfig, marginConfig }: Re
     try {
       if (disabled || !wallet.publicKey) return;
       signature = await offerLoan({
-        market: marketAndConfig.market,
+        market: marketAndConfig,
         marginAccount,
-        marginConfig,
         provider,
         walletAddress: wallet.publicKey,
         pools: pools.tokenPools,

--- a/localnet.toml
+++ b/localnet.toml
@@ -18,12 +18,12 @@ precision = 2
 
 [[token]]
 symbol = "BTC"
-name = "Bitcoin"
+name = "BTC"
 decimals = 6
 precision = 6
 
 [swap_pools]
-spl = ["Bitcoin/USDC", "Bitcoin/USDT"]
+spl = ["BTC/USDC", "BTC/USDT"]
 
 [[airspace]]
 name = "default"
@@ -88,11 +88,11 @@ borrow_rate_3 = 16000
 management_fee_rate = 20_00
 
 
-[airspace.tokens.Bitcoin]
+[airspace.tokens.BTC]
 collateral_weight = 75
 max_leverage = 20_00
 
-[airspace.tokens.Bitcoin.margin_pool_config]
+[airspace.tokens.BTC.margin_pool_config]
 flags = 0b0010 # ALLOW_LENDING
 utilization_rate_1 = 85_00
 utilization_rate_2 = 95_00

--- a/packages/fixed-term/src/api.ts
+++ b/packages/fixed-term/src/api.ts
@@ -1,14 +1,6 @@
 import { PublicKey, TransactionInstruction } from "@solana/web3.js"
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token"
-import {
-  AssociatedToken,
-  FixedTermMarketConfig,
-  MarginAccount,
-  MarginConfig,
-  Pool,
-  PoolTokenChange,
-  sendAll
-} from "@jet-lab/margin"
+import { AssociatedToken, FixedTermMarketConfig, MarginAccount, Pool, PoolTokenChange, sendAll } from "@jet-lab/margin"
 import { FixedTermMarket } from "./fixedTerm"
 import { AnchorProvider, BN } from "@project-serum/anchor"
 
@@ -59,7 +51,7 @@ interface IWithCreateFixedTermMarketAccount {
   markets: FixedTermMarket[]
   refreshPools: boolean
   pools: Record<string, Pool>
-  currentPool: Pool
+  pool: Pool
 }
 export const withCreateFixedTermMarketAccounts = async ({
   market,
@@ -69,7 +61,7 @@ export const withCreateFixedTermMarketAccounts = async ({
   markets,
   refreshPools,
   pools,
-  currentPool
+  pool
 }: IWithCreateFixedTermMarketAccount) => {
   const tokenMint = market.addresses.underlyingTokenMint
   const ticketMint = market.addresses.ticketMint
@@ -87,7 +79,7 @@ export const withCreateFixedTermMarketAccounts = async ({
   await refreshAllMarkets(markets, marketIXS, marginAccount, market.address)
 
   if (refreshPools) {
-    await currentPool.withPrioritisedPositionRefresh({
+    await pool.withPrioritisedPositionRefresh({
       instructions: marketIXS,
       pools,
       marginAccount
@@ -98,15 +90,16 @@ export const withCreateFixedTermMarketAccounts = async ({
 
 // MARKET MAKER ORDERS
 interface ICreateLendOrder {
-  market: FixedTermMarket
+  market: {
+    market: FixedTermMarket
+    config: FixedTermMarketConfig
+  }
   provider: AnchorProvider
   marginAccount: MarginAccount
-  marginConfig: MarginConfig
   walletAddress: PublicKey
   amount: BN
   basisPoints: BN
   pools: Record<string, Pool>
-  currentPool: Pool
   marketAccount?: string
   marketConfig: FixedTermMarketConfig
   markets: FixedTermMarket[]
@@ -115,50 +108,44 @@ export const offerLoan = async ({
   market,
   provider,
   marginAccount,
-  marginConfig,
   walletAddress,
   amount,
   basisPoints,
   pools,
-  currentPool,
   marketConfig,
   markets
 }: ICreateLendOrder) => {
-  // Fail if there is no active fixed term market program id in the config
-  if (!marginConfig.fixedTermMarketProgramId) {
-    throw new Error("There is no market configured on this network")
-  }
-
+  const pool = pools[market.config.symbol]
   const instructions: TransactionInstruction[][] = []
   // Create relevant accounts if they do not exist
   const { marketIXS } = await withCreateFixedTermMarketAccounts({
-    market,
+    market: market.market,
     provider,
     marginAccount,
     walletAddress,
     markets,
     pools,
-    currentPool,
+    pool,
     refreshPools: true
   })
   instructions.push(marketIXS)
   const orderIXS: TransactionInstruction[] = []
 
   // refresh pool positions
-  await currentPool.withPrioritisedPositionRefresh({
+  await pool.withPrioritisedPositionRefresh({
     instructions: orderIXS,
     pools,
     marginAccount
   })
 
   // create lend instruction
-  await currentPool.withWithdrawToMargin({
+  await pool.withWithdrawToMargin({
     instructions: orderIXS,
     marginAccount,
     change: PoolTokenChange.shiftBy(amount)
   })
 
-  const loanOffer = await market.offerLoanIx(
+  const loanOffer = await market.market.offerLoanIx(
     marginAccount,
     amount,
     basisPoints,
@@ -175,13 +162,14 @@ export const offerLoan = async ({
 }
 
 interface ICreateBorrowOrder {
-  market: FixedTermMarket
+  market: {
+    market: FixedTermMarket
+    config: FixedTermMarketConfig
+  }
   marginAccount: MarginAccount
-  marginConfig: MarginConfig
   provider: AnchorProvider
   walletAddress: PublicKey
   pools: Record<string, Pool>
-  currentPool: Pool
   amount: BN
   basisPoints: BN
   marketConfig: FixedTermMarketConfig
@@ -191,45 +179,40 @@ interface ICreateBorrowOrder {
 export const requestLoan = async ({
   market,
   marginAccount,
-  marginConfig,
   provider,
   walletAddress,
   pools,
-  currentPool,
   amount,
   basisPoints,
   marketConfig,
   markets
 }: ICreateBorrowOrder): Promise<string> => {
-  // Fail if there is no active fixed term market program id in the config
-  if (!marginConfig.fixedTermMarketProgramId) {
-    throw new Error("There is no market configured on this network")
-  }
+  const pool = pools[market.config.symbol]
 
   const instructions: TransactionInstruction[][] = []
   // Create relevant accounts if they do not exist
   const { marketIXS } = await withCreateFixedTermMarketAccounts({
-    market,
+    market: market.market,
     provider,
     marginAccount,
     walletAddress,
     markets,
     pools,
-    currentPool,
+    pool,
     refreshPools: true
   })
   instructions.push(marketIXS)
 
   const orderIXS: TransactionInstruction[] = []
   // refresh pools positions
-  await currentPool.withPrioritisedPositionRefresh({
+  await pool.withPrioritisedPositionRefresh({
     instructions: orderIXS,
     pools,
     marginAccount
   })
 
   // Create borrow instruction
-  const borrowOffer = await market.requestBorrowIx(
+  const borrowOffer = await market.market.requestBorrowIx(
     marginAccount,
     walletAddress,
     amount,
@@ -247,40 +230,41 @@ export const requestLoan = async ({
 }
 
 interface ICancelOrder {
-  market: FixedTermMarket
+  market: {
+    market: FixedTermMarket
+    config: FixedTermMarketConfig
+  }
   marginAccount: MarginAccount
   provider: AnchorProvider
   orderId: Uint8Array
   pools: Record<string, Pool>
-  currentPool: Pool
 }
 export const cancelOrder = async ({
   market,
   marginAccount,
   provider,
   orderId,
-  pools,
-  currentPool
+  pools
 }: ICancelOrder): Promise<string> => {
   let instructions: TransactionInstruction[] = []
-  const borrowerAccount = await market.deriveMarginUserAddress(marginAccount)
-
+  const borrowerAccount = await market.market.deriveMarginUserAddress(marginAccount)
+  const pool = pools[market.config.symbol]
   // refresh pools positions
-  await currentPool.withPrioritisedPositionRefresh({
+  await pool.withPrioritisedPositionRefresh({
     instructions,
     pools,
     marginAccount
   })
 
   // refresh market instruction
-  const refreshIx = await market.program.methods
+  const refreshIx = await market.market.program.methods
     .refreshPosition(true)
     .accounts({
       marginUser: borrowerAccount,
       marginAccount: marginAccount.address,
-      market: market.addresses.market,
-      underlyingOracle: market.addresses.underlyingOracle,
-      ticketOracle: market.addresses.ticketOracle,
+      market: market.market.addresses.market,
+      underlyingOracle: market.market.addresses.underlyingOracle,
+      ticketOracle: market.market.addresses.ticketOracle,
       tokenProgram: TOKEN_PROGRAM_ID
     })
     .instruction()
@@ -289,7 +273,7 @@ export const cancelOrder = async ({
     instructions,
     adapterInstruction: refreshIx
   })
-  const cancelLoan = await market.cancelOrderIx(marginAccount, orderId)
+  const cancelLoan = await market.market.cancelOrderIx(marginAccount, orderId)
   await marginAccount.withAdapterInvoke({
     instructions,
     adapterInstruction: cancelLoan
@@ -300,57 +284,49 @@ export const cancelOrder = async ({
 // MARKET TAKER ORDERS
 
 interface IBorrowNow {
-  market: FixedTermMarket
+  market: {
+    market: FixedTermMarket
+    config: FixedTermMarketConfig
+  }
   marginAccount: MarginAccount
-  marginConfig: MarginConfig
   provider: AnchorProvider
   walletAddress: PublicKey
   pools: Record<string, Pool>
-  currentPool: Pool
   amount: BN
   markets: FixedTermMarket[]
 }
 
 export const borrowNow = async ({
-  marginConfig,
   market,
   marginAccount,
   provider,
   walletAddress,
-  currentPool,
   pools,
   amount,
   markets
 }: IBorrowNow): Promise<string> => {
-  // Fail if there is no active fixed term market program id in the config
-  if (!marginConfig.fixedTermMarketProgramId) {
-    throw new Error("There is no fixed term market configured on this network")
-  }
+  const pool = pools[market.config.symbol]
 
   const instructions: TransactionInstruction[][] = []
   // Create relevant accounts if they do not exist
   const { marketIXS, tokenMint } = await withCreateFixedTermMarketAccounts({
-    market,
+    market: market.market,
     provider,
     marginAccount,
     walletAddress,
     markets,
     pools,
-    currentPool,
+    pool,
     refreshPools: true
   })
+
   instructions.push(marketIXS)
   // refresh pools positions
   const orderIXS: TransactionInstruction[] = []
-  await currentPool.withPrioritisedPositionRefresh({
-    instructions: orderIXS,
-    pools,
-    marginAccount
-  })
 
   // Create borrow instruction
   const seed = createRandomSeed(8)
-  const borrowNow = await market.borrowNowIx(marginAccount, walletAddress, amount, seed)
+  const borrowNow = await market.market.borrowNowIx(marginAccount, walletAddress, amount, seed)
 
   await marginAccount.withAdapterInvoke({
     instructions: orderIXS,
@@ -359,13 +335,14 @@ export const borrowNow = async ({
 
   const change = PoolTokenChange.shiftBy(amount.sub(new BN(1)))
   const source = AssociatedToken.derive(tokenMint, marginAccount.address)
-  const position = currentPool.findDepositPositionAddress(marginAccount)
-  const depositIx = await currentPool.programs.marginPool.methods
+  const position = await pool.withGetOrRegisterDepositPosition({ instructions: orderIXS, marginAccount })
+
+  const depositIx = await pool.programs.marginPool.methods
     .deposit(change.changeKind.asParam(), change.value)
     .accounts({
-      marginPool: currentPool.address,
-      vault: currentPool.addresses.vault,
-      depositNoteMint: currentPool.addresses.depositNoteMint,
+      marginPool: pool.address,
+      vault: pool.addresses.vault,
+      depositNoteMint: pool.addresses.depositNoteMint,
       depositor: marginAccount.address,
       source,
       destination: position,
@@ -381,58 +358,52 @@ export const borrowNow = async ({
 }
 
 interface ILendNow {
-  market: FixedTermMarket
+  market: {
+    market: FixedTermMarket
+    config: FixedTermMarketConfig
+  }
   marginAccount: MarginAccount
-  marginConfig: MarginConfig
   provider: AnchorProvider
   walletAddress: PublicKey
   pools: Record<string, Pool>
-  currentPool: Pool
   amount: BN
   markets: FixedTermMarket[]
 }
 
 export const lendNow = async ({
-  marginConfig,
   market,
   marginAccount,
   provider,
   walletAddress,
-  currentPool,
   pools,
   amount,
   markets
 }: ILendNow): Promise<string> => {
-  // Fail if there is no active fixed term market program id in the config
-  if (!marginConfig.fixedTermMarketProgramId) {
-    throw new Error("There is no market configured on this network")
-  }
-
+  const pool = pools[market.config.symbol]
   const instructions: TransactionInstruction[][] = []
   // Create relevant accounts if they do not exist
   const { marketIXS } = await withCreateFixedTermMarketAccounts({
-    market,
+    market: market.market,
     provider,
     marginAccount,
     walletAddress,
     markets,
     pools,
-    currentPool,
+    pool,
     refreshPools: true
   })
   instructions.push(marketIXS)
-
   const orderIXS: TransactionInstruction[] = []
 
   // create lend instruction
-  await currentPool.withWithdrawToMargin({
+  await pool.withWithdrawToMargin({
     instructions: orderIXS,
     marginAccount,
     change: PoolTokenChange.shiftBy(amount)
   })
 
   // Create borrow instruction
-  const lendNow = await market.lendNowIx(marginAccount, amount, walletAddress, createRandomSeed(8))
+  const lendNow = await market.market.lendNowIx(marginAccount, amount, walletAddress, createRandomSeed(8))
 
   await marginAccount.withAdapterInvoke({
     instructions: orderIXS,


### PR DESCRIPTION
- fixes fixed market actions when the current pool selected is related to a different token compared to the fixed term market
- fixes deposits following a borrow when the user does not have an existing position in the pool related to the current fixed term market
- temporarily rename `Bitcoin` token to `BTC` as that mismatch creates issues with the transactions