### PR TITLE
fix some program crate exports

### DIFF
--- a/programs/fixed-term/src/margin/mod.rs
+++ b/programs/fixed-term/src/margin/mod.rs
@@ -1,5 +1,5 @@
 pub mod instructions;
-pub(crate) mod origination_fee;
+pub mod origination_fee;
 pub mod state;
 
 pub(crate) mod events;

--- a/programs/fixed-term/src/margin/origination_fee.rs
+++ b/programs/fixed-term/src/margin/origination_fee.rs
@@ -1,4 +1,4 @@
-const FEE_UNIT: u64 = 1_000_000;
+pub const FEE_UNIT: u64 = 1_000_000;
 
 /// based on some requested amount, determines the size of a borrow order that
 /// adds an origination fee.

--- a/programs/margin-pool/src/lib.rs
+++ b/programs/margin-pool/src/lib.rs
@@ -22,7 +22,7 @@ mod state;
 mod util;
 use instructions::*;
 
-pub use state::{MarginPool, MarginPoolConfig, PoolFlags};
+pub use state::{MarginPool, MarginPoolConfig, PoolAction, PoolFlags};
 pub mod events;
 
 declare_id!("JPPooLEqRo3NCSx82EdE2VZY5vUaSsgskpZPBHNGVLZ");

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -529,7 +529,7 @@ impl MarginPool {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct FullAmount {
     pub tokens: u64,
     pub notes: u64,


### PR DESCRIPTION
Adding some additional exports for clients to use:

- fixed-term now exports the `origination_fee` module
- margin-pool now exports the `PoolAction` type, which is used in conversion functions on the pool