### PR TITLE
sdk: minor refactoring

### DIFF
--- a/libraries/rust/margin/src/fixed_term/event_consumer.rs
+++ b/libraries/rust/margin/src/fixed_term/event_consumer.rs
@@ -71,7 +71,7 @@ impl EventConsumer {
                         users: HashMap::new(),
                         builder: FixedTermIxBuilder::new_from_state(
                             self.rpc.payer().pubkey(),
-                            structure,
+                            &structure,
                         ),
                     })),
                 );

--- a/libraries/rust/margin/src/tx_builder/fixed_term.rs
+++ b/libraries/rust/margin/src/tx_builder/fixed_term.rs
@@ -74,7 +74,7 @@ impl FixedTermPositionRefresher {
     /// register a fixed term market to check when refreshing positions
     pub async fn add_fixed_term_market(&mut self, address: Pubkey) -> Result<()> {
         let market = get_anchor_account::<Market>(self.rpc.clone(), &address).await?;
-        let builder = FixedTermIxBuilder::new_from_state(self.rpc.payer().pubkey(), market);
+        let builder = FixedTermIxBuilder::new_from_state(self.rpc.payer().pubkey(), &market);
 
         self.fixed_term_markets.insert(address, builder);
 

--- a/libraries/rust/program-common/src/number_128.rs
+++ b/libraries/rust/program-common/src/number_128.rs
@@ -37,7 +37,7 @@ const POWERS_OF_TEN: &[i128] = &[
 ];
 
 /// A fixed-point decimal number 128 bits wide
-#[derive(Pod, Zeroable, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Pod, Zeroable, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(C)]
 pub struct Number128(i128);
 

--- a/tests/hosted/src/bin/populate_orderbook.rs
+++ b/tests/hosted/src/bin/populate_orderbook.rs
@@ -71,7 +71,7 @@ impl Client {
 
             Market::try_deserialize(&mut data.as_slice())?
         };
-        let ix = FixedTermIxBuilder::new_from_state(signer.pubkey(), market);
+        let ix = FixedTermIxBuilder::new_from_state(signer.pubkey(), &market);
 
         Ok(Self { conn, ix, signer })
     }

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -20,8 +20,8 @@ use jet_fixed_term::{
 };
 use jet_margin_sdk::{
     fixed_term::{
-        event_consumer::EventConsumer, fixed_term_market_pda, FixedTermIxBuilder,
-        OrderBookAddresses, OwnedEventQueue,
+        event_consumer::EventConsumer, fixed_term_address, FixedTermIxBuilder, OrderBookAddresses,
+        OwnedEventQueue,
     },
     ix_builder::{
         get_control_authority_address, get_metadata_address, ControlIxBuilder, MarginIxBuilder,
@@ -131,7 +131,7 @@ impl TestManager {
         let oracle = TokenManager::new(client.clone())
             .create_oracle(&mint.pubkey())
             .await?;
-        let ticket_mint = fixed_term_market_pda(&[
+        let ticket_mint = fixed_term_address(&[
             jet_fixed_term::seeds::TICKET_MINT,
             FixedTermIxBuilder::market_key(
                 &Pubkey::default(), //todo airspace
@@ -584,7 +584,7 @@ impl GenerateProxy for NoProxy {
 #[async_trait]
 impl GenerateProxy for MarginIxBuilder {
     async fn generate(manager: Arc<TestManager>, owner: &Keypair) -> Result<Self> {
-        let margin = MarginIxBuilder::new(owner.pubkey(), 0);
+        let margin = MarginIxBuilder::new(manager.ix_builder.airspace(), owner.pubkey(), 0);
         manager
             .sign_send_transaction(&[margin.create_account()], Some(&[owner]))
             .await?;
@@ -1007,6 +1007,7 @@ pub async fn create_fixed_term_market_margin_user(
                 None,
                 wallet.pubkey(),
                 0,
+                ctx.margin.airspace(),
             )),
             Arc::new(
                 FixedTermPositionRefresher::new(

--- a/tests/hosted/src/margin.rs
+++ b/tests/hosted/src/margin.rs
@@ -78,8 +78,12 @@ impl MarginClient {
         }
     }
 
+    pub fn airspace(&self) -> Pubkey {
+        self.tx_admin.airspace
+    }
+
     pub fn user(&self, keypair: &Keypair, seed: u16) -> Result<MarginUser, Error> {
-        let tx = MarginTxBuilder::new_with_airspace(
+        let tx = MarginTxBuilder::new(
             self.rpc.clone(),
             Some(Keypair::from_bytes(&keypair.to_bytes())?),
             keypair.pubkey(),
@@ -103,9 +107,9 @@ impl MarginClient {
         let tx = MarginTxBuilder::new_liquidator(
             self.rpc.clone(),
             Some(Keypair::from_bytes(&keypair.to_bytes())?),
+            self.airspace(),
             *owner,
             seed,
-            keypair.pubkey(),
         );
 
         Ok(MarginUser {
@@ -443,8 +447,6 @@ impl MarginUser {
         program_id: &Pubkey,
         source_mint: &Pubkey,
         destination_mint: &Pubkey,
-        transit_source_account: &Pubkey,
-        transit_destination_account: &Pubkey,
         swap_pool: &SplSwapPool,
         change: TokenChange,
         minimum_amount_out: u64,
@@ -461,8 +463,6 @@ impl MarginUser {
                     .swap(
                         source_mint,
                         destination_mint,
-                        transit_source_account,
-                        transit_destination_account,
                         &swap_pool.pool,
                         &swap_pool.pool_mint,
                         &swap_pool.fee_account,

--- a/tests/hosted/tests/fixed_term.rs
+++ b/tests/hosted/tests/fixed_term.rs
@@ -317,6 +317,7 @@ async fn margin_repay() -> Result<()> {
                 None,
                 wallet.pubkey(),
                 0,
+                margin.airspace,
             )),
             Arc::new(
                 FixedTermPositionRefresher::new(

--- a/tests/hosted/tests/swap.rs
+++ b/tests/hosted/tests/swap.rs
@@ -148,8 +148,8 @@ async fn swap_test_impl(test_name: &str, swap_program_id: Pubkey) -> Result<(), 
         assert_eq!(swap_pool.pool, pool.pool);
     }
 
-    let user_a_usdc_transit = user_a.create_deposit_position(&env.usdc).await?;
-    let user_a_tsol_transit = user_a.create_deposit_position(&env.tsol).await?;
+    let _user_a_usdc_transit = user_a.create_deposit_position(&env.usdc).await?;
+    let _user_a_tsol_transit = user_a.create_deposit_position(&env.tsol).await?;
 
     // Create some tokens for each user to deposit
     let user_a_usdc_account = ctx
@@ -231,8 +231,6 @@ async fn swap_test_impl(test_name: &str, swap_program_id: Pubkey) -> Result<(), 
             &swap_program_id,
             &env.usdc,
             &env.tsol,
-            &user_a_usdc_transit,
-            &user_a_tsol_transit,
             &swap_pool,
             TokenChange::shift(100 * ONE_USDC),
             // we want a minimum of 0.9 SOL for 100 USDC
@@ -258,8 +256,6 @@ async fn swap_test_impl(test_name: &str, swap_program_id: Pubkey) -> Result<(), 
             &swap_program_id,
             &env.usdc,
             &env.tsol,
-            &user_a_usdc_transit,
-            &user_a_tsol_transit,
             &swap_pool,
             TokenChange::set(2_000 * ONE_USDC),
             // Value doesn't matter
@@ -274,8 +270,6 @@ async fn swap_test_impl(test_name: &str, swap_program_id: Pubkey) -> Result<(), 
             &swap_program_id,
             &env.usdc,
             &env.tsol,
-            &user_a_usdc_transit,
-            &user_a_tsol_transit,
             &swap_pool,
             TokenChange::set(900 * ONE_USDC),
             // Value doesn't matter
@@ -290,8 +284,6 @@ async fn swap_test_impl(test_name: &str, swap_program_id: Pubkey) -> Result<(), 
             &swap_program_id,
             &env.usdc,
             &env.tsol,
-            &user_a_usdc_transit,
-            &user_a_tsol_transit,
             &swap_pool,
             TokenChange::set(799 * ONE_USDC),
             // we want a minimum of 0.9 SOL for 101 USDC (1000 - 100 - 799)
@@ -313,8 +305,6 @@ async fn swap_test_impl(test_name: &str, swap_program_id: Pubkey) -> Result<(), 
             &swap_program_id,
             &env.tsol,
             &env.usdc,
-            &user_a_tsol_transit,
-            &user_a_usdc_transit,
             &swap_pool,
             TokenChange::set(0),
             90 * 10 * ONE_USDC,

--- a/tools/ctl/src/actions/margin.rs
+++ b/tools/ctl/src/actions/margin.rs
@@ -138,10 +138,10 @@ pub async fn process_refresh_metadata(client: &Client, token: Pubkey) -> Result<
 
     for (address, mut account) in margin_accounts {
         let ix = MarginIxBuilder::new_with_payer(
+            Pubkey::default(), // FIXME: read airspace from margin account
             account.owner,
             u16::from_le_bytes(account.user_seed),
             client.signer()?,
-            None,
         );
 
         if let Some(position) = account.get_position(&deposit_token) {
@@ -200,10 +200,10 @@ pub async fn process_update_balances(
         .await?;
 
     let ix = MarginIxBuilder::new_with_payer(
+        Pubkey::default(), // FIXME: read airspace from margin account
         account.owner,
         u16::from_le_bytes(account.user_seed),
         client.signer()?,
-        None,
     );
     let mut steps = vec![];
     let mut instructions = vec![];
@@ -232,10 +232,10 @@ pub async fn process_transfer_position(
         .await?;
 
     let ix = MarginIxBuilder::new_with_payer(
+        Pubkey::default(), // FIXME: read airspace from margin account
         source.owner,
         u16::from_le_bytes(source.user_seed),
         resolve_payer(client)?,
-        Some(jet_program_common::ADMINISTRATOR),
     );
     let pool_ix = MarginPoolIxBuilder::new(token);
     let position_token_mint = pool_ix.deposit_note_mint;
@@ -243,7 +243,7 @@ pub async fn process_transfer_position(
         Some(n) => n,
         None => {
             client
-                .read_token_account(&ix.get_token_account_address(&position_token_mint).0)
+                .read_token_account(&ix.get_token_account_address(&position_token_mint))
                 .await?
                 .amount
         }

--- a/tools/ctl/src/actions/margin_pool.rs
+++ b/tools/ctl/src/actions/margin_pool.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use comfy_table::{presets::UTF8_FULL, Table};
 use jet_margin_sdk::{
     ix_builder::{
-        get_metadata_address, loan_token_account, ControlIxBuilder, MarginPoolConfiguration,
+        derive_loan_account, get_metadata_address, ControlIxBuilder, MarginPoolConfiguration,
         MarginPoolIxBuilder,
     },
     jet_control::TokenMetadataParams,
@@ -219,7 +219,7 @@ pub async fn process_transfer_loan(
     amount: Option<u64>,
 ) -> Result<Plan> {
     let ix = MarginPoolIxBuilder::new(token);
-    let loan_account = loan_token_account(&source_account, &ix.loan_note_mint).0;
+    let loan_account = derive_loan_account(&source_account, &ix.loan_note_mint);
     let amount = match amount {
         Some(n) => n,
         None => client.read_token_account(&loan_account).await?.amount,

--- a/tools/ctl/src/actions/test.rs
+++ b/tools/ctl/src/actions/test.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path};
 use anchor_lang::prelude::Rent;
 use anyhow::{bail, Result};
 use jet_margin_sdk::{
-    fixed_term::fixed_term_market_pda,
+    fixed_term::fixed_term_address,
     ix_builder::{
         derive_airspace,
         test_service::{derive_swap_pool, derive_token_mint},
@@ -194,7 +194,7 @@ async fn generate_fixed_term_markets_app_config_from_env(
 }
 
 fn derive_market(airspace: &Pubkey, token_mint: &Pubkey, seed: [u8; 32]) -> Pubkey {
-    fixed_term_market_pda(&[
+    fixed_term_address(&[
         jet_margin_sdk::jet_fixed_term::seeds::MARKET,
         airspace.as_ref(),
         token_mint.as_ref(),


### PR DESCRIPTION
pulled out some changes made while working on the new client

- require airspace for margin ix builder
- simplify API for building swap instructions
- stop returning nonces when deriving addreses, since they are never really required
- random other stuff