### PR TITLE
fix repay: validate market vault and update user claim

### DIFF
--- a/libraries/rust/instructions/src/fixed_term.rs
+++ b/libraries/rust/instructions/src/fixed_term.rs
@@ -832,6 +832,9 @@ impl FixedTermIxBuilder {
             payer: *payer,
             underlying_token_vault: self.underlying_token_vault,
             token_program: spl_token::ID,
+            claims: margin_user.claims,
+            claims_mint: self.claims,
+            market: self.market,
         }
         .to_account_metas(None);
 

--- a/programs/fixed-term/src/margin/instructions/repay.rs
+++ b/programs/fixed-term/src/margin/instructions/repay.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 
 use anchor_lang::{prelude::*, AccountsClose};
-use anchor_spl::token::{transfer, Mint, Token, TokenAccount, Transfer};
+use anchor_spl::token::{transfer, Token, Transfer};
 use jet_program_common::traits::TrySubAssign;
 use jet_program_proc_macros::MarketTokenManager;
 
@@ -35,22 +35,22 @@ pub struct Repay<'info> {
 
     /// The token account to deposit tokens from
     #[account(mut)]
-    pub source: Account<'info, TokenAccount>,
+    pub source: AccountInfo<'info>,
 
     /// The signing authority for the source_account
     pub payer: Signer<'info>,
 
     /// The token vault holding the underlying token of the ticket
     #[account(mut)]
-    pub underlying_token_vault: Account<'info, TokenAccount>,
+    pub underlying_token_vault: AccountInfo<'info>,
 
     /// The token account representing claims for this margin user
     #[account(mut)]
-    pub claims: Account<'info, TokenAccount>,
+    pub claims: AccountInfo<'info>,
 
     /// The token account representing claims for this margin user
     #[account(mut)]
-    pub claims_mint: Account<'info, Mint>,
+    pub claims_mint: AccountInfo<'info>,
 
     #[account(
         has_one = claims_mint @ FixedTermErrorCode::WrongClaimMint,

--- a/programs/fixed-term/src/margin/instructions/repay.rs
+++ b/programs/fixed-term/src/margin/instructions/repay.rs
@@ -1,19 +1,22 @@
 use std::cmp::min;
 
 use anchor_lang::{prelude::*, AccountsClose};
-use anchor_spl::token::{transfer, Token, TokenAccount, Transfer};
+use anchor_spl::token::{transfer, Mint, Token, TokenAccount, Transfer};
 use jet_program_common::traits::TrySubAssign;
+use jet_program_proc_macros::MarketTokenManager;
 
 use crate::{
+    control::state::Market,
     events::{TermLoanFulfilled, TermLoanRepay},
     margin::state::{MarginUser, TermLoan},
+    market_token_manager::MarketTokenManager,
     FixedTermErrorCode,
 };
 
-#[derive(Accounts)]
+#[derive(Accounts, MarketTokenManager)]
 pub struct Repay<'info> {
     /// The account tracking information related to this particular user
-    #[account(mut)]
+    #[account(mut, has_one = claims)]
     pub margin_user: Account<'info, MarginUser>,
 
     #[account(
@@ -41,6 +44,20 @@ pub struct Repay<'info> {
     #[account(mut)]
     pub underlying_token_vault: Account<'info, TokenAccount>,
 
+    /// The token account representing claims for this margin user
+    #[account(mut)]
+    pub claims: Account<'info, TokenAccount>,
+
+    /// The token account representing claims for this margin user
+    #[account(mut)]
+    pub claims_mint: Account<'info, Mint>,
+
+    #[account(
+        has_one = claims_mint,
+        has_one = underlying_token_vault @ FixedTermErrorCode::WrongVault,
+    )]
+    pub market: AccountLoader<'info, Market>,
+
     /// SPL token program
     pub token_program: Program<'info, Token>,
 }
@@ -61,6 +78,7 @@ impl<'info> Repay<'info> {
 pub fn handler(ctx: Context<Repay>, amount: u64) -> Result<()> {
     let amount = min(amount, ctx.accounts.term_loan.balance);
     transfer(ctx.accounts.transfer_context(), amount)?;
+    ctx.burn_notes(&ctx.accounts.claims_mint, &ctx.accounts.claims, amount)?;
 
     let term_loan = &mut ctx.accounts.term_loan;
     let user = &mut ctx.accounts.margin_user;

--- a/programs/fixed-term/src/margin/instructions/repay.rs
+++ b/programs/fixed-term/src/margin/instructions/repay.rs
@@ -16,7 +16,7 @@ use crate::{
 #[derive(Accounts, MarketTokenManager)]
 pub struct Repay<'info> {
     /// The account tracking information related to this particular user
-    #[account(mut, has_one = claims)]
+    #[account(mut, has_one = claims @ FixedTermErrorCode::WrongClaimAccount)]
     pub margin_user: Account<'info, MarginUser>,
 
     #[account(
@@ -53,7 +53,7 @@ pub struct Repay<'info> {
     pub claims_mint: Account<'info, Mint>,
 
     #[account(
-        has_one = claims_mint,
+        has_one = claims_mint @ FixedTermErrorCode::WrongClaimMint,
         has_one = underlying_token_vault @ FixedTermErrorCode::WrongVault,
     )]
     pub market: AccountLoader<'info, Market>,


### PR DESCRIPTION
Fixes two problems with the repay instruction in fixed term:
- the vault was not validated, so someone could "repay" to a wallet owned by themselves and get credited towards their loan balance without actually repaying
- the claim balance in the margin account was not updated, which is easy to handle here, so users are forced to also include a settle instruction