### PR TITLE
settle fixes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -140,4 +140,4 @@ jobs:
       - name: E2E
         run: |
           chmod -R 777 /root
-          SOLANA_LOGS=false ./check e2e-tests
+          SOLANA_LOGS=false ./check e2e

--- a/check
+++ b/check
@@ -10,13 +10,13 @@
 # Run jobs in the container used for CI:
 #   ./check in-docker '<job-name or all>'
 #
-# NOTE you may need to install cypress for the in-docker e2e-tests to run:
+# NOTE you may need to install cypress for the in-docker e2e to run:
 #   ./check in-docker install-cypress
 #
 # This script can also be sourced:
 #   . check
 # Then you can run any of the subcommands without calling ./check:
-#   e2e-tests    # tab completion is available
+#   e2e    # tab completion is available
 
 DOCKER_IMAGE=jetprotocol/builder:rust-1.65.0-node-18.12.1-solana-1.13.5-anchor-0.25.0-1
 SOLANA_MAINNET_RPC=${SOLANA_MAINNET_RPC:-'https://solana-api.projectserum.com'}
@@ -24,11 +24,12 @@ SOLANA_MAINNET_RPC=${SOLANA_MAINNET_RPC:-'https://solana-api.projectserum.com'}
 #################
 # Workflow Jobs
 
-e2e-tests() { local args=$@
+e2e() { local args=$@
     extract-arg --skip-yarn || yarn-build
     rm -f apps/react-app/public/localnet.config.json
     anchor test $args -- --features testing
 }
+e2e-tests() { e2e $@; } # alias to avoid frustration. remove if no one is using it
 
 hosted-tests-localnet() { local args=$@
     extract-arg --skip-build || tests/scripts/on_localnet.sh anchor-build
@@ -116,7 +117,7 @@ all() {
     cargo-lint
     cargo-test
     hosted-tests-localnet $@
-    e2e-tests --skip-build
+    e2e --skip-build
 }
 
 # assumes "args" variable is set.

--- a/libraries/rust/margin/src/fixed_term/settler.rs
+++ b/libraries/rust/margin/src/fixed_term/settler.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::future::join_all;
+use jet_instructions::margin::accounting_invoke;
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
 use solana_sdk::pubkey::Pubkey;
 
@@ -66,7 +67,7 @@ async fn settle_with_recovery(
     tracing::debug!("sending settle tx for margin accounts {margin_accounts:?}");
     match margin_accounts
         .iter()
-        .map(|ma| builder.margin_settle(*ma))
+        .map(|margin_account| accounting_invoke(*margin_account, builder.settle(*margin_account)))
         .collect::<Vec<_>>()
         .with_signers(&[])
         .send_and_confirm(&rpc)

--- a/libraries/rust/margin/src/fixed_term/settler.rs
+++ b/libraries/rust/margin/src/fixed_term/settler.rs
@@ -8,7 +8,7 @@ use solana_sdk::pubkey::Pubkey;
 use super::FixedTermIxBuilder;
 use crate::{solana::transaction::WithSigner, util::no_dupe_queue::AsyncNoDupeQueue};
 
-pub const SETTLES_PER_TX: usize = 4;
+pub const SETTLES_PER_TX: usize = 3;
 
 /// Loops forever to keep checking the queue for margin accounts.
 /// Sends a separate Settle transaction for each without blocking.

--- a/packages/margin/src/fixed-term/fixedTerm.ts
+++ b/packages/margin/src/fixed-term/fixedTerm.ts
@@ -344,6 +344,7 @@ export class FixedTermMarket {
       .accounts({
         ...this.addresses,
         marginUser: marketUser,
+        marginAccount: user.address,
         ticketCollateral,
         tokenProgram: TOKEN_PROGRAM_ID,
         claims,
@@ -406,8 +407,6 @@ export class FixedTermMarket {
     const marginUser = await this.deriveMarginUserAddress(user)
     const claims = await this.deriveMarginUserClaims(marginUser)
     const ticketCollateral = await this.deriveTicketCollateral(marginUser)
-    const underlyingSettlement = await getAssociatedTokenAddress(this.addresses.underlyingTokenMint, user.address, true)
-    const ticketSettlement = await getAssociatedTokenAddress(this.addresses.ticketMint, user.address, true)
     return await this.program.methods
       .initializeMarginUser()
       .accounts({
@@ -416,8 +415,6 @@ export class FixedTermMarket {
         marginAccount: user.address,
         claims,
         ticketCollateral,
-        underlyingSettlement,
-        ticketSettlement,
         payer,
         rent: SYSVAR_RENT_PUBKEY,
         systemProgram: SystemProgram.programId,

--- a/packages/margin/src/fixed-term/types/JetFixedTerm.ts
+++ b/packages/margin/src/fixed-term/types/JetFixedTerm.ts
@@ -4,87 +4,63 @@ export type JetFixedTerm = {
   "constants": [
     {
       "name": "MARKET",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"market\""
+      "type": "bytes",
+      "value": "[109, 97, 114, 107, 101, 116]"
     },
     {
       "name": "TICKET_ACCOUNT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"ticket_account\""
+      "type": "bytes",
+      "value": "[116, 105, 99, 107, 101, 116, 95, 97, 99, 99, 111, 117, 110, 116]"
     },
     {
       "name": "TICKET_MINT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"ticket_mint\""
+      "type": "bytes",
+      "value": "[116, 105, 99, 107, 101, 116, 95, 109, 105, 110, 116]"
     },
     {
       "name": "CRANK_AUTHORIZATION",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"crank_authorization\""
+      "type": "bytes",
+      "value": "[99, 114, 97, 110, 107, 95, 97, 117, 116, 104, 111, 114, 105, 122, 97, 116, 105, 111, 110]"
     },
     {
       "name": "CLAIM_NOTES",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"claim_notes\""
+      "type": "bytes",
+      "value": "[99, 108, 97, 105, 109, 95, 110, 111, 116, 101, 115]"
     },
     {
       "name": "TICKET_COLLATERAL_NOTES",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"ticket_collateral_notes\""
+      "type": "bytes",
+      "value": "[116, 105, 99, 107, 101, 116, 95, 99, 111, 108, 108, 97, 116, 101, 114, 97, 108, 95, 110, 111, 116, 101, 115]"
     },
     {
       "name": "EVENT_ADAPTER",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"event_adapter\""
+      "type": "bytes",
+      "value": "[101, 118, 101, 110, 116, 95, 97, 100, 97, 112, 116, 101, 114]"
     },
     {
       "name": "TERM_LOAN",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"term_loan\""
+      "type": "bytes",
+      "value": "[116, 101, 114, 109, 95, 108, 111, 97, 110]"
     },
     {
       "name": "TERM_DEPOSIT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"term_deposit\""
+      "type": "bytes",
+      "value": "[116, 101, 114, 109, 95, 100, 101, 112, 111, 115, 105, 116]"
     },
     {
       "name": "ORDERBOOK_MARKET_STATE",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"orderbook_market_state\""
+      "type": "bytes",
+      "value": "[111, 114, 100, 101, 114, 98, 111, 111, 107, 95, 109, 97, 114, 107, 101, 116, 95, 115, 116, 97, 116, 101]"
     },
     {
       "name": "MARGIN_USER",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"margin_user\""
+      "type": "bytes",
+      "value": "[109, 97, 114, 103, 105, 110, 95, 117, 115, 101, 114]"
     },
     {
       "name": "UNDERLYING_TOKEN_VAULT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"underlying_token_vault\""
+      "type": "bytes",
+      "value": "[117, 110, 100, 101, 114, 108, 121, 105, 110, 103, 95, 116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116]"
     }
   ],
   "instructions": [
@@ -646,16 +622,6 @@ export type JetFixedTerm = {
           "isSigner": false
         },
         {
-          "name": "underlyingSettlement",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "ticketSettlement",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "payer",
           "isMut": true,
           "isSigner": true
@@ -769,7 +735,7 @@ export type JetFixedTerm = {
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "The market token vault"
+            "Where to receive borrowed tokens"
           ]
         },
         {
@@ -1363,6 +1329,14 @@ export type JetFixedTerm = {
           ]
         },
         {
+          "name": "marginAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "use accounting_invoke"
+          ]
+        },
+        {
           "name": "market",
           "isMut": false,
           "isSigner": false,
@@ -1417,12 +1391,18 @@ export type JetFixedTerm = {
         {
           "name": "underlyingSettlement",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "docs": [
+            "Where to receive owed tokens"
+          ]
         },
         {
           "name": "ticketSettlement",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "docs": [
+            "Where to receive owed tickets"
+          ]
         }
       ],
       "args": []
@@ -2278,14 +2258,14 @@ export type JetFixedTerm = {
             "docs": [
               "Length of time before a borrow is marked as due, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "lendTenor",
             "docs": [
               "Length of time before a claim is marked as mature, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "originationFee",
@@ -2376,22 +2356,6 @@ export type JetFixedTerm = {
               "Token account used by the margin program to track the collateral value of positions",
               "which are internal to fixed-term market, such as SplitTicket, ClaimTicket, and open orders.",
               "this does *not* represent underlying tokens or ticket tokens, those are registered independently in margin"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "underlyingSettlement",
-            "docs": [
-              "The `settle` instruction is permissionless, therefore the user must specify upon margin account creation",
-              "the address to send owed tokens"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "ticketSettlement",
-            "docs": [
-              "The `settle` instruction is permissionless, therefore the user must specify upon margin account creation",
-              "the address to send owed tickets"
             ],
             "type": "publicKey"
           },
@@ -2629,14 +2593,14 @@ export type JetFixedTerm = {
             "docs": [
               "Length of time before a borrow is marked as due, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "lendTenor",
             "docs": [
               "Length of time before a claim is marked as mature, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "originationFee",
@@ -3027,20 +2991,6 @@ export type JetFixedTerm = {
       }
     },
     {
-      "name": "EventTag",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Fill"
-          },
-          {
-            "name": "Out"
-          }
-        ]
-      }
-    },
-    {
       "name": "OrderbookEvent",
       "type": {
         "kind": "enum",
@@ -3101,12 +3051,12 @@ export type JetFixedTerm = {
         },
         {
           "name": "borrowTenor",
-          "type": "i64",
+          "type": "u64",
           "index": false
         },
         {
           "name": "lendTenor",
-          "type": "i64",
+          "type": "u64",
           "index": false
         }
       ]
@@ -3203,16 +3153,6 @@ export type JetFixedTerm = {
           "name": "marginAccount",
           "type": "publicKey",
           "index": false
-        },
-        {
-          "name": "underlyingSettlement",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "ticketSettlement",
-          "type": "publicKey",
-          "index": false
         }
       ]
     },
@@ -3287,6 +3227,11 @@ export type JetFixedTerm = {
         },
         {
           "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "payer",
           "type": "publicKey",
           "index": false
         },
@@ -3392,6 +3337,11 @@ export type JetFixedTerm = {
         },
         {
           "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "payer",
           "type": "publicKey",
           "index": false
         },
@@ -3732,283 +3682,283 @@ export type JetFixedTerm = {
     },
     {
       "code": 6005,
-      "name": "EventQueueFull",
-      "msg": "queue does not have room for another event"
-    },
-    {
-      "code": 6006,
-      "name": "FailedToDeserializeTicket",
-      "msg": "failed to deserialize the SplitTicket or ClaimTicket"
-    },
-    {
-      "code": 6007,
-      "name": "ImmatureTicket",
-      "msg": "ticket is not mature and cannot be claimed"
-    },
-    {
-      "code": 6008,
-      "name": "InsufficientSeeds",
-      "msg": "not enough seeds were provided for the accounts that need to be initialized"
-    },
-    {
-      "code": 6009,
-      "name": "InvalidOrderPrice",
-      "msg": "order price is prohibited"
-    },
-    {
-      "code": 6010,
-      "name": "InvalidPosition",
-      "msg": "this token account is not a valid position for this margin user"
-    },
-    {
-      "code": 6011,
-      "name": "InvokeCreateAccount",
-      "msg": "failed to invoke account creation"
-    },
-    {
-      "code": 6012,
-      "name": "IoError",
-      "msg": "failed to properly serialize or deserialize a data structure"
-    },
-    {
-      "code": 6013,
-      "name": "MarketStateNotProgramOwned",
-      "msg": "this market state account is not owned by the current program"
-    },
-    {
-      "code": 6014,
-      "name": "MissingEventAdapter",
-      "msg": "tried to access a missing adapter account"
-    },
-    {
-      "code": 6015,
-      "name": "MissingSplitTicket",
-      "msg": "tried to access a missing split ticket account"
-    },
-    {
-      "code": 6016,
-      "name": "NoEvents",
-      "msg": "consume_events instruction failed to consume a single event"
-    },
-    {
-      "code": 6017,
-      "name": "NoMoreAccounts",
-      "msg": "expected additional remaining accounts, but there were none"
-    },
-    {
-      "code": 6018,
-      "name": "NonZeroDebt",
-      "msg": "the debt has a non-zero balance"
-    },
-    {
-      "code": 6019,
-      "name": "TermLoanHasWrongSequenceNumber",
-      "msg": "expected a term loan with a different sequence number"
-    },
-    {
-      "code": 6020,
-      "name": "TermDepositHasWrongSequenceNumber",
-      "msg": "expected a term deposit with a different sequence number"
-    },
-    {
-      "code": 6021,
-      "name": "OracleError",
-      "msg": "there was a problem loading the price oracle"
-    },
-    {
-      "code": 6022,
-      "name": "OrderNotFound",
-      "msg": "id was not found in the user's open orders"
-    },
-    {
-      "code": 6023,
-      "name": "OrderbookPaused",
-      "msg": "Orderbook is not taking orders"
-    },
-    {
-      "code": 6024,
-      "name": "OrderRejected",
-      "msg": "aaob did not match or post the order. either posting is disabled or the order was too small"
-    },
-    {
-      "code": 6025,
-      "name": "PriceMissing",
-      "msg": "price could not be accessed from oracle"
-    },
-    {
-      "code": 6026,
-      "name": "TicketNotFromManager",
-      "msg": "claim ticket is not from this manager"
-    },
-    {
-      "code": 6027,
-      "name": "TicketsPaused",
-      "msg": "tickets are paused"
-    },
-    {
-      "code": 6028,
-      "name": "UnauthorizedCaller",
-      "msg": "this signer is not authorized to place a permissioned order"
-    },
-    {
-      "code": 6029,
-      "name": "UserDoesNotOwnAccount",
-      "msg": "this user does not own the user account"
-    },
-    {
-      "code": 6030,
-      "name": "UserDoesNotOwnAdapter",
-      "msg": "this adapter does not belong to the user"
-    },
-    {
-      "code": 6031,
-      "name": "UserNotInMarket",
-      "msg": "this user account is not associated with this fixed term market"
-    },
-    {
-      "code": 6032,
-      "name": "WrongAdapter",
-      "msg": "the wrong adapter account was passed to this instruction"
-    },
-    {
-      "code": 6033,
-      "name": "WrongAsks",
-      "msg": "asks account does not belong to this market"
-    },
-    {
-      "code": 6034,
-      "name": "WrongAirspace",
-      "msg": "the market is configured for a different airspace"
-    },
-    {
-      "code": 6035,
-      "name": "WrongAirspaceAuthorization",
-      "msg": "the signer is not authorized to perform this action in the current airspace"
-    },
-    {
-      "code": 6036,
-      "name": "WrongBids",
-      "msg": "bids account does not belong to this market"
-    },
-    {
-      "code": 6037,
-      "name": "WrongMarket",
-      "msg": "adapter does not belong to given market"
-    },
-    {
-      "code": 6038,
-      "name": "WrongCrankAuthority",
-      "msg": "wrong authority for this crank instruction"
-    },
-    {
-      "code": 6039,
-      "name": "WrongEventQueue",
-      "msg": "event queue account does not belong to this market"
-    },
-    {
-      "code": 6040,
-      "name": "WrongMarketState",
-      "msg": "this market state is not associated with this market"
-    },
-    {
-      "code": 6041,
-      "name": "WrongTicketManager",
-      "msg": "wrong TicketManager account provided"
-    },
-    {
-      "code": 6042,
       "name": "DoesNotOwnMarket",
       "msg": "this market owner does not own this market"
     },
     {
-      "code": 6043,
-      "name": "WrongClaimAccount",
-      "msg": "the wrong account was provided for the token account that represents a user's claims"
+      "code": 6006,
+      "name": "EventQueueFull",
+      "msg": "queue does not have room for another event"
     },
     {
-      "code": 6044,
-      "name": "WrongTicketCollateralAccount",
-      "msg": "the wrong account was provided for the token account that represents a user's collateral"
+      "code": 6007,
+      "name": "FailedToDeserializeTicket",
+      "msg": "failed to deserialize the SplitTicket or ClaimTicket"
     },
     {
-      "code": 6045,
-      "name": "WrongClaimMint",
-      "msg": "the wrong account was provided for the claims token mint"
-    },
-    {
-      "code": 6046,
-      "name": "WrongCollateralMint",
-      "msg": "the wrong account was provided for the collateral token mint"
-    },
-    {
-      "code": 6047,
-      "name": "WrongFeeDestination",
-      "msg": "wrong fee destination"
-    },
-    {
-      "code": 6048,
-      "name": "WrongOracle",
-      "msg": "wrong oracle address was sent to instruction"
-    },
-    {
-      "code": 6049,
-      "name": "WrongMarginUser",
-      "msg": "wrong margin user account address was sent to instruction"
-    },
-    {
-      "code": 6050,
-      "name": "WrongMarginUserAuthority",
-      "msg": "wrong authority for the margin user account address was sent to instruction"
-    },
-    {
-      "code": 6051,
-      "name": "WrongProgramAuthority",
-      "msg": "incorrect authority account"
-    },
-    {
-      "code": 6052,
-      "name": "WrongTicketMint",
-      "msg": "not the ticket mint for this fixed term market"
-    },
-    {
-      "code": 6053,
-      "name": "WrongTicketSettlementAccount",
-      "msg": "wrong ticket settlement account"
-    },
-    {
-      "code": 6054,
-      "name": "WrongUnderlyingSettlementAccount",
-      "msg": "wrong underlying settlement account"
-    },
-    {
-      "code": 6055,
-      "name": "WrongUnderlyingTokenMint",
-      "msg": "wrong underlying token mint for this fixed term market"
-    },
-    {
-      "code": 6056,
-      "name": "WrongUserAccount",
-      "msg": "wrong user account address was sent to instruction"
-    },
-    {
-      "code": 6057,
-      "name": "WrongVault",
-      "msg": "wrong vault address was sent to instruction"
-    },
-    {
-      "code": 6058,
-      "name": "ZeroDivision",
-      "msg": "attempted to divide with zero"
-    },
-    {
-      "code": 6059,
+      "code": 6008,
       "name": "FailedToPushEvent",
       "msg": "failed to add event to the queue"
     },
     {
-      "code": 6060,
+      "code": 6009,
+      "name": "ImmatureTicket",
+      "msg": "ticket is not mature and cannot be claimed"
+    },
+    {
+      "code": 6010,
+      "name": "InsufficientSeeds",
+      "msg": "not enough seeds were provided for the accounts that need to be initialized"
+    },
+    {
+      "code": 6011,
       "name": "InvalidAutoRollConfig",
       "msg": "invalid auto roll configuration"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidOrderPrice",
+      "msg": "order price is prohibited"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidPosition",
+      "msg": "this token account is not a valid position for this margin user"
+    },
+    {
+      "code": 6014,
+      "name": "InvokeCreateAccount",
+      "msg": "failed to invoke account creation"
+    },
+    {
+      "code": 6015,
+      "name": "IoError",
+      "msg": "failed to properly serialize or deserialize a data structure"
+    },
+    {
+      "code": 6016,
+      "name": "MarketStateNotProgramOwned",
+      "msg": "this market state account is not owned by the current program"
+    },
+    {
+      "code": 6017,
+      "name": "MissingEventAdapter",
+      "msg": "tried to access a missing adapter account"
+    },
+    {
+      "code": 6018,
+      "name": "MissingSplitTicket",
+      "msg": "tried to access a missing split ticket account"
+    },
+    {
+      "code": 6019,
+      "name": "NoEvents",
+      "msg": "consume_events instruction failed to consume a single event"
+    },
+    {
+      "code": 6020,
+      "name": "NoMoreAccounts",
+      "msg": "expected additional remaining accounts, but there were none"
+    },
+    {
+      "code": 6021,
+      "name": "NonZeroDebt",
+      "msg": "the debt has a non-zero balance"
+    },
+    {
+      "code": 6022,
+      "name": "OracleError",
+      "msg": "there was a problem loading the price oracle"
+    },
+    {
+      "code": 6023,
+      "name": "OrderNotFound",
+      "msg": "id was not found in the user's open orders"
+    },
+    {
+      "code": 6024,
+      "name": "OrderbookPaused",
+      "msg": "Orderbook is not taking orders"
+    },
+    {
+      "code": 6025,
+      "name": "OrderRejected",
+      "msg": "aaob did not match or post the order. either posting is disabled or the order was too small"
+    },
+    {
+      "code": 6026,
+      "name": "PriceMissing",
+      "msg": "price could not be accessed from oracle"
+    },
+    {
+      "code": 6027,
+      "name": "TermDepositHasWrongSequenceNumber",
+      "msg": "expected a term deposit with a different sequence number"
+    },
+    {
+      "code": 6028,
+      "name": "TermLoanHasWrongSequenceNumber",
+      "msg": "expected a term loan with a different sequence number"
+    },
+    {
+      "code": 6029,
+      "name": "TicketNotFromManager",
+      "msg": "claim ticket is not from this manager"
+    },
+    {
+      "code": 6030,
+      "name": "TicketSettlementAccountNotRegistered",
+      "msg": "ticket settlement account is not registered as a position in the margin account"
+    },
+    {
+      "code": 6031,
+      "name": "TicketsPaused",
+      "msg": "tickets are paused"
+    },
+    {
+      "code": 6032,
+      "name": "UnauthorizedCaller",
+      "msg": "this signer is not authorized to place a permissioned order"
+    },
+    {
+      "code": 6033,
+      "name": "UnderlyingSettlementAccountNotRegistered",
+      "msg": "underlying settlement account is not registered as a position in the margin account"
+    },
+    {
+      "code": 6034,
+      "name": "UserDoesNotOwnAccount",
+      "msg": "this user does not own the user account"
+    },
+    {
+      "code": 6035,
+      "name": "UserDoesNotOwnAdapter",
+      "msg": "this adapter does not belong to the user"
+    },
+    {
+      "code": 6036,
+      "name": "UserNotInMarket",
+      "msg": "this user account is not associated with this fixed term market"
+    },
+    {
+      "code": 6037,
+      "name": "WrongAdapter",
+      "msg": "the wrong adapter account was passed to this instruction"
+    },
+    {
+      "code": 6038,
+      "name": "WrongAirspace",
+      "msg": "the market is configured for a different airspace"
+    },
+    {
+      "code": 6039,
+      "name": "WrongAirspaceAuthorization",
+      "msg": "the signer is not authorized to perform this action in the current airspace"
+    },
+    {
+      "code": 6040,
+      "name": "WrongAsks",
+      "msg": "asks account does not belong to this market"
+    },
+    {
+      "code": 6041,
+      "name": "WrongBids",
+      "msg": "bids account does not belong to this market"
+    },
+    {
+      "code": 6042,
+      "name": "WrongCrankAuthority",
+      "msg": "wrong authority for this crank instruction"
+    },
+    {
+      "code": 6043,
+      "name": "WrongEventQueue",
+      "msg": "event queue account does not belong to this market"
+    },
+    {
+      "code": 6044,
+      "name": "WrongMarket",
+      "msg": "adapter does not belong to given market"
+    },
+    {
+      "code": 6045,
+      "name": "WrongMarketState",
+      "msg": "this market state is not associated with this market"
+    },
+    {
+      "code": 6046,
+      "name": "WrongTicketManager",
+      "msg": "wrong TicketManager account provided"
+    },
+    {
+      "code": 6047,
+      "name": "WrongClaimAccount",
+      "msg": "the wrong account was provided for the token account that represents a user's claims"
+    },
+    {
+      "code": 6048,
+      "name": "WrongTicketCollateralAccount",
+      "msg": "the wrong account was provided for the token account that represents a user's collateral"
+    },
+    {
+      "code": 6049,
+      "name": "WrongClaimMint",
+      "msg": "the wrong account was provided for the claims token mint"
+    },
+    {
+      "code": 6050,
+      "name": "WrongCollateralMint",
+      "msg": "the wrong account was provided for the collateral token mint"
+    },
+    {
+      "code": 6051,
+      "name": "WrongFeeDestination",
+      "msg": "wrong fee destination"
+    },
+    {
+      "code": 6052,
+      "name": "WrongOracle",
+      "msg": "wrong oracle address was sent to instruction"
+    },
+    {
+      "code": 6053,
+      "name": "WrongMarginUser",
+      "msg": "wrong margin user account address was sent to instruction"
+    },
+    {
+      "code": 6054,
+      "name": "WrongMarginUserAuthority",
+      "msg": "wrong authority for the margin user account address was sent to instruction"
+    },
+    {
+      "code": 6055,
+      "name": "WrongProgramAuthority",
+      "msg": "incorrect authority account"
+    },
+    {
+      "code": 6056,
+      "name": "WrongTicketMint",
+      "msg": "not the ticket mint for this fixed term market"
+    },
+    {
+      "code": 6057,
+      "name": "WrongUnderlyingTokenMint",
+      "msg": "wrong underlying token mint for this fixed term market"
+    },
+    {
+      "code": 6058,
+      "name": "WrongUserAccount",
+      "msg": "wrong user account address was sent to instruction"
+    },
+    {
+      "code": 6059,
+      "name": "WrongVault",
+      "msg": "wrong vault address was sent to instruction"
+    },
+    {
+      "code": 6060,
+      "name": "ZeroDivision",
+      "msg": "attempted to divide with zero"
     }
   ]
 };
@@ -4019,87 +3969,63 @@ export const IDL: JetFixedTerm = {
   "constants": [
     {
       "name": "MARKET",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"market\""
+      "type": "bytes",
+      "value": "[109, 97, 114, 107, 101, 116]"
     },
     {
       "name": "TICKET_ACCOUNT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"ticket_account\""
+      "type": "bytes",
+      "value": "[116, 105, 99, 107, 101, 116, 95, 97, 99, 99, 111, 117, 110, 116]"
     },
     {
       "name": "TICKET_MINT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"ticket_mint\""
+      "type": "bytes",
+      "value": "[116, 105, 99, 107, 101, 116, 95, 109, 105, 110, 116]"
     },
     {
       "name": "CRANK_AUTHORIZATION",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"crank_authorization\""
+      "type": "bytes",
+      "value": "[99, 114, 97, 110, 107, 95, 97, 117, 116, 104, 111, 114, 105, 122, 97, 116, 105, 111, 110]"
     },
     {
       "name": "CLAIM_NOTES",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"claim_notes\""
+      "type": "bytes",
+      "value": "[99, 108, 97, 105, 109, 95, 110, 111, 116, 101, 115]"
     },
     {
       "name": "TICKET_COLLATERAL_NOTES",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"ticket_collateral_notes\""
+      "type": "bytes",
+      "value": "[116, 105, 99, 107, 101, 116, 95, 99, 111, 108, 108, 97, 116, 101, 114, 97, 108, 95, 110, 111, 116, 101, 115]"
     },
     {
       "name": "EVENT_ADAPTER",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"event_adapter\""
+      "type": "bytes",
+      "value": "[101, 118, 101, 110, 116, 95, 97, 100, 97, 112, 116, 101, 114]"
     },
     {
       "name": "TERM_LOAN",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"term_loan\""
+      "type": "bytes",
+      "value": "[116, 101, 114, 109, 95, 108, 111, 97, 110]"
     },
     {
       "name": "TERM_DEPOSIT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"term_deposit\""
+      "type": "bytes",
+      "value": "[116, 101, 114, 109, 95, 100, 101, 112, 111, 115, 105, 116]"
     },
     {
       "name": "ORDERBOOK_MARKET_STATE",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"orderbook_market_state\""
+      "type": "bytes",
+      "value": "[111, 114, 100, 101, 114, 98, 111, 111, 107, 95, 109, 97, 114, 107, 101, 116, 95, 115, 116, 97, 116, 101]"
     },
     {
       "name": "MARGIN_USER",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"margin_user\""
+      "type": "bytes",
+      "value": "[109, 97, 114, 103, 105, 110, 95, 117, 115, 101, 114]"
     },
     {
       "name": "UNDERLYING_TOKEN_VAULT",
-      "type": {
-        "defined": "&[u8]"
-      },
-      "value": "b\"underlying_token_vault\""
+      "type": "bytes",
+      "value": "[117, 110, 100, 101, 114, 108, 121, 105, 110, 103, 95, 116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116]"
     }
   ],
   "instructions": [
@@ -4661,16 +4587,6 @@ export const IDL: JetFixedTerm = {
           "isSigner": false
         },
         {
-          "name": "underlyingSettlement",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "ticketSettlement",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "payer",
           "isMut": true,
           "isSigner": true
@@ -4784,7 +4700,7 @@ export const IDL: JetFixedTerm = {
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "The market token vault"
+            "Where to receive borrowed tokens"
           ]
         },
         {
@@ -5378,6 +5294,14 @@ export const IDL: JetFixedTerm = {
           ]
         },
         {
+          "name": "marginAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "use accounting_invoke"
+          ]
+        },
+        {
           "name": "market",
           "isMut": false,
           "isSigner": false,
@@ -5432,12 +5356,18 @@ export const IDL: JetFixedTerm = {
         {
           "name": "underlyingSettlement",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "docs": [
+            "Where to receive owed tokens"
+          ]
         },
         {
           "name": "ticketSettlement",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "docs": [
+            "Where to receive owed tickets"
+          ]
         }
       ],
       "args": []
@@ -6293,14 +6223,14 @@ export const IDL: JetFixedTerm = {
             "docs": [
               "Length of time before a borrow is marked as due, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "lendTenor",
             "docs": [
               "Length of time before a claim is marked as mature, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "originationFee",
@@ -6391,22 +6321,6 @@ export const IDL: JetFixedTerm = {
               "Token account used by the margin program to track the collateral value of positions",
               "which are internal to fixed-term market, such as SplitTicket, ClaimTicket, and open orders.",
               "this does *not* represent underlying tokens or ticket tokens, those are registered independently in margin"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "underlyingSettlement",
-            "docs": [
-              "The `settle` instruction is permissionless, therefore the user must specify upon margin account creation",
-              "the address to send owed tokens"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "ticketSettlement",
-            "docs": [
-              "The `settle` instruction is permissionless, therefore the user must specify upon margin account creation",
-              "the address to send owed tickets"
             ],
             "type": "publicKey"
           },
@@ -6644,14 +6558,14 @@ export const IDL: JetFixedTerm = {
             "docs": [
               "Length of time before a borrow is marked as due, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "lendTenor",
             "docs": [
               "Length of time before a claim is marked as mature, in seconds"
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "originationFee",
@@ -7042,20 +6956,6 @@ export const IDL: JetFixedTerm = {
       }
     },
     {
-      "name": "EventTag",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Fill"
-          },
-          {
-            "name": "Out"
-          }
-        ]
-      }
-    },
-    {
       "name": "OrderbookEvent",
       "type": {
         "kind": "enum",
@@ -7116,12 +7016,12 @@ export const IDL: JetFixedTerm = {
         },
         {
           "name": "borrowTenor",
-          "type": "i64",
+          "type": "u64",
           "index": false
         },
         {
           "name": "lendTenor",
-          "type": "i64",
+          "type": "u64",
           "index": false
         }
       ]
@@ -7218,16 +7118,6 @@ export const IDL: JetFixedTerm = {
           "name": "marginAccount",
           "type": "publicKey",
           "index": false
-        },
-        {
-          "name": "underlyingSettlement",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "ticketSettlement",
-          "type": "publicKey",
-          "index": false
         }
       ]
     },
@@ -7302,6 +7192,11 @@ export const IDL: JetFixedTerm = {
         },
         {
           "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "payer",
           "type": "publicKey",
           "index": false
         },
@@ -7407,6 +7302,11 @@ export const IDL: JetFixedTerm = {
         },
         {
           "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "payer",
           "type": "publicKey",
           "index": false
         },
@@ -7747,283 +7647,283 @@ export const IDL: JetFixedTerm = {
     },
     {
       "code": 6005,
-      "name": "EventQueueFull",
-      "msg": "queue does not have room for another event"
-    },
-    {
-      "code": 6006,
-      "name": "FailedToDeserializeTicket",
-      "msg": "failed to deserialize the SplitTicket or ClaimTicket"
-    },
-    {
-      "code": 6007,
-      "name": "ImmatureTicket",
-      "msg": "ticket is not mature and cannot be claimed"
-    },
-    {
-      "code": 6008,
-      "name": "InsufficientSeeds",
-      "msg": "not enough seeds were provided for the accounts that need to be initialized"
-    },
-    {
-      "code": 6009,
-      "name": "InvalidOrderPrice",
-      "msg": "order price is prohibited"
-    },
-    {
-      "code": 6010,
-      "name": "InvalidPosition",
-      "msg": "this token account is not a valid position for this margin user"
-    },
-    {
-      "code": 6011,
-      "name": "InvokeCreateAccount",
-      "msg": "failed to invoke account creation"
-    },
-    {
-      "code": 6012,
-      "name": "IoError",
-      "msg": "failed to properly serialize or deserialize a data structure"
-    },
-    {
-      "code": 6013,
-      "name": "MarketStateNotProgramOwned",
-      "msg": "this market state account is not owned by the current program"
-    },
-    {
-      "code": 6014,
-      "name": "MissingEventAdapter",
-      "msg": "tried to access a missing adapter account"
-    },
-    {
-      "code": 6015,
-      "name": "MissingSplitTicket",
-      "msg": "tried to access a missing split ticket account"
-    },
-    {
-      "code": 6016,
-      "name": "NoEvents",
-      "msg": "consume_events instruction failed to consume a single event"
-    },
-    {
-      "code": 6017,
-      "name": "NoMoreAccounts",
-      "msg": "expected additional remaining accounts, but there were none"
-    },
-    {
-      "code": 6018,
-      "name": "NonZeroDebt",
-      "msg": "the debt has a non-zero balance"
-    },
-    {
-      "code": 6019,
-      "name": "TermLoanHasWrongSequenceNumber",
-      "msg": "expected a term loan with a different sequence number"
-    },
-    {
-      "code": 6020,
-      "name": "TermDepositHasWrongSequenceNumber",
-      "msg": "expected a term deposit with a different sequence number"
-    },
-    {
-      "code": 6021,
-      "name": "OracleError",
-      "msg": "there was a problem loading the price oracle"
-    },
-    {
-      "code": 6022,
-      "name": "OrderNotFound",
-      "msg": "id was not found in the user's open orders"
-    },
-    {
-      "code": 6023,
-      "name": "OrderbookPaused",
-      "msg": "Orderbook is not taking orders"
-    },
-    {
-      "code": 6024,
-      "name": "OrderRejected",
-      "msg": "aaob did not match or post the order. either posting is disabled or the order was too small"
-    },
-    {
-      "code": 6025,
-      "name": "PriceMissing",
-      "msg": "price could not be accessed from oracle"
-    },
-    {
-      "code": 6026,
-      "name": "TicketNotFromManager",
-      "msg": "claim ticket is not from this manager"
-    },
-    {
-      "code": 6027,
-      "name": "TicketsPaused",
-      "msg": "tickets are paused"
-    },
-    {
-      "code": 6028,
-      "name": "UnauthorizedCaller",
-      "msg": "this signer is not authorized to place a permissioned order"
-    },
-    {
-      "code": 6029,
-      "name": "UserDoesNotOwnAccount",
-      "msg": "this user does not own the user account"
-    },
-    {
-      "code": 6030,
-      "name": "UserDoesNotOwnAdapter",
-      "msg": "this adapter does not belong to the user"
-    },
-    {
-      "code": 6031,
-      "name": "UserNotInMarket",
-      "msg": "this user account is not associated with this fixed term market"
-    },
-    {
-      "code": 6032,
-      "name": "WrongAdapter",
-      "msg": "the wrong adapter account was passed to this instruction"
-    },
-    {
-      "code": 6033,
-      "name": "WrongAsks",
-      "msg": "asks account does not belong to this market"
-    },
-    {
-      "code": 6034,
-      "name": "WrongAirspace",
-      "msg": "the market is configured for a different airspace"
-    },
-    {
-      "code": 6035,
-      "name": "WrongAirspaceAuthorization",
-      "msg": "the signer is not authorized to perform this action in the current airspace"
-    },
-    {
-      "code": 6036,
-      "name": "WrongBids",
-      "msg": "bids account does not belong to this market"
-    },
-    {
-      "code": 6037,
-      "name": "WrongMarket",
-      "msg": "adapter does not belong to given market"
-    },
-    {
-      "code": 6038,
-      "name": "WrongCrankAuthority",
-      "msg": "wrong authority for this crank instruction"
-    },
-    {
-      "code": 6039,
-      "name": "WrongEventQueue",
-      "msg": "event queue account does not belong to this market"
-    },
-    {
-      "code": 6040,
-      "name": "WrongMarketState",
-      "msg": "this market state is not associated with this market"
-    },
-    {
-      "code": 6041,
-      "name": "WrongTicketManager",
-      "msg": "wrong TicketManager account provided"
-    },
-    {
-      "code": 6042,
       "name": "DoesNotOwnMarket",
       "msg": "this market owner does not own this market"
     },
     {
-      "code": 6043,
-      "name": "WrongClaimAccount",
-      "msg": "the wrong account was provided for the token account that represents a user's claims"
+      "code": 6006,
+      "name": "EventQueueFull",
+      "msg": "queue does not have room for another event"
     },
     {
-      "code": 6044,
-      "name": "WrongTicketCollateralAccount",
-      "msg": "the wrong account was provided for the token account that represents a user's collateral"
+      "code": 6007,
+      "name": "FailedToDeserializeTicket",
+      "msg": "failed to deserialize the SplitTicket or ClaimTicket"
     },
     {
-      "code": 6045,
-      "name": "WrongClaimMint",
-      "msg": "the wrong account was provided for the claims token mint"
-    },
-    {
-      "code": 6046,
-      "name": "WrongCollateralMint",
-      "msg": "the wrong account was provided for the collateral token mint"
-    },
-    {
-      "code": 6047,
-      "name": "WrongFeeDestination",
-      "msg": "wrong fee destination"
-    },
-    {
-      "code": 6048,
-      "name": "WrongOracle",
-      "msg": "wrong oracle address was sent to instruction"
-    },
-    {
-      "code": 6049,
-      "name": "WrongMarginUser",
-      "msg": "wrong margin user account address was sent to instruction"
-    },
-    {
-      "code": 6050,
-      "name": "WrongMarginUserAuthority",
-      "msg": "wrong authority for the margin user account address was sent to instruction"
-    },
-    {
-      "code": 6051,
-      "name": "WrongProgramAuthority",
-      "msg": "incorrect authority account"
-    },
-    {
-      "code": 6052,
-      "name": "WrongTicketMint",
-      "msg": "not the ticket mint for this fixed term market"
-    },
-    {
-      "code": 6053,
-      "name": "WrongTicketSettlementAccount",
-      "msg": "wrong ticket settlement account"
-    },
-    {
-      "code": 6054,
-      "name": "WrongUnderlyingSettlementAccount",
-      "msg": "wrong underlying settlement account"
-    },
-    {
-      "code": 6055,
-      "name": "WrongUnderlyingTokenMint",
-      "msg": "wrong underlying token mint for this fixed term market"
-    },
-    {
-      "code": 6056,
-      "name": "WrongUserAccount",
-      "msg": "wrong user account address was sent to instruction"
-    },
-    {
-      "code": 6057,
-      "name": "WrongVault",
-      "msg": "wrong vault address was sent to instruction"
-    },
-    {
-      "code": 6058,
-      "name": "ZeroDivision",
-      "msg": "attempted to divide with zero"
-    },
-    {
-      "code": 6059,
+      "code": 6008,
       "name": "FailedToPushEvent",
       "msg": "failed to add event to the queue"
     },
     {
-      "code": 6060,
+      "code": 6009,
+      "name": "ImmatureTicket",
+      "msg": "ticket is not mature and cannot be claimed"
+    },
+    {
+      "code": 6010,
+      "name": "InsufficientSeeds",
+      "msg": "not enough seeds were provided for the accounts that need to be initialized"
+    },
+    {
+      "code": 6011,
       "name": "InvalidAutoRollConfig",
       "msg": "invalid auto roll configuration"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidOrderPrice",
+      "msg": "order price is prohibited"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidPosition",
+      "msg": "this token account is not a valid position for this margin user"
+    },
+    {
+      "code": 6014,
+      "name": "InvokeCreateAccount",
+      "msg": "failed to invoke account creation"
+    },
+    {
+      "code": 6015,
+      "name": "IoError",
+      "msg": "failed to properly serialize or deserialize a data structure"
+    },
+    {
+      "code": 6016,
+      "name": "MarketStateNotProgramOwned",
+      "msg": "this market state account is not owned by the current program"
+    },
+    {
+      "code": 6017,
+      "name": "MissingEventAdapter",
+      "msg": "tried to access a missing adapter account"
+    },
+    {
+      "code": 6018,
+      "name": "MissingSplitTicket",
+      "msg": "tried to access a missing split ticket account"
+    },
+    {
+      "code": 6019,
+      "name": "NoEvents",
+      "msg": "consume_events instruction failed to consume a single event"
+    },
+    {
+      "code": 6020,
+      "name": "NoMoreAccounts",
+      "msg": "expected additional remaining accounts, but there were none"
+    },
+    {
+      "code": 6021,
+      "name": "NonZeroDebt",
+      "msg": "the debt has a non-zero balance"
+    },
+    {
+      "code": 6022,
+      "name": "OracleError",
+      "msg": "there was a problem loading the price oracle"
+    },
+    {
+      "code": 6023,
+      "name": "OrderNotFound",
+      "msg": "id was not found in the user's open orders"
+    },
+    {
+      "code": 6024,
+      "name": "OrderbookPaused",
+      "msg": "Orderbook is not taking orders"
+    },
+    {
+      "code": 6025,
+      "name": "OrderRejected",
+      "msg": "aaob did not match or post the order. either posting is disabled or the order was too small"
+    },
+    {
+      "code": 6026,
+      "name": "PriceMissing",
+      "msg": "price could not be accessed from oracle"
+    },
+    {
+      "code": 6027,
+      "name": "TermDepositHasWrongSequenceNumber",
+      "msg": "expected a term deposit with a different sequence number"
+    },
+    {
+      "code": 6028,
+      "name": "TermLoanHasWrongSequenceNumber",
+      "msg": "expected a term loan with a different sequence number"
+    },
+    {
+      "code": 6029,
+      "name": "TicketNotFromManager",
+      "msg": "claim ticket is not from this manager"
+    },
+    {
+      "code": 6030,
+      "name": "TicketSettlementAccountNotRegistered",
+      "msg": "ticket settlement account is not registered as a position in the margin account"
+    },
+    {
+      "code": 6031,
+      "name": "TicketsPaused",
+      "msg": "tickets are paused"
+    },
+    {
+      "code": 6032,
+      "name": "UnauthorizedCaller",
+      "msg": "this signer is not authorized to place a permissioned order"
+    },
+    {
+      "code": 6033,
+      "name": "UnderlyingSettlementAccountNotRegistered",
+      "msg": "underlying settlement account is not registered as a position in the margin account"
+    },
+    {
+      "code": 6034,
+      "name": "UserDoesNotOwnAccount",
+      "msg": "this user does not own the user account"
+    },
+    {
+      "code": 6035,
+      "name": "UserDoesNotOwnAdapter",
+      "msg": "this adapter does not belong to the user"
+    },
+    {
+      "code": 6036,
+      "name": "UserNotInMarket",
+      "msg": "this user account is not associated with this fixed term market"
+    },
+    {
+      "code": 6037,
+      "name": "WrongAdapter",
+      "msg": "the wrong adapter account was passed to this instruction"
+    },
+    {
+      "code": 6038,
+      "name": "WrongAirspace",
+      "msg": "the market is configured for a different airspace"
+    },
+    {
+      "code": 6039,
+      "name": "WrongAirspaceAuthorization",
+      "msg": "the signer is not authorized to perform this action in the current airspace"
+    },
+    {
+      "code": 6040,
+      "name": "WrongAsks",
+      "msg": "asks account does not belong to this market"
+    },
+    {
+      "code": 6041,
+      "name": "WrongBids",
+      "msg": "bids account does not belong to this market"
+    },
+    {
+      "code": 6042,
+      "name": "WrongCrankAuthority",
+      "msg": "wrong authority for this crank instruction"
+    },
+    {
+      "code": 6043,
+      "name": "WrongEventQueue",
+      "msg": "event queue account does not belong to this market"
+    },
+    {
+      "code": 6044,
+      "name": "WrongMarket",
+      "msg": "adapter does not belong to given market"
+    },
+    {
+      "code": 6045,
+      "name": "WrongMarketState",
+      "msg": "this market state is not associated with this market"
+    },
+    {
+      "code": 6046,
+      "name": "WrongTicketManager",
+      "msg": "wrong TicketManager account provided"
+    },
+    {
+      "code": 6047,
+      "name": "WrongClaimAccount",
+      "msg": "the wrong account was provided for the token account that represents a user's claims"
+    },
+    {
+      "code": 6048,
+      "name": "WrongTicketCollateralAccount",
+      "msg": "the wrong account was provided for the token account that represents a user's collateral"
+    },
+    {
+      "code": 6049,
+      "name": "WrongClaimMint",
+      "msg": "the wrong account was provided for the claims token mint"
+    },
+    {
+      "code": 6050,
+      "name": "WrongCollateralMint",
+      "msg": "the wrong account was provided for the collateral token mint"
+    },
+    {
+      "code": 6051,
+      "name": "WrongFeeDestination",
+      "msg": "wrong fee destination"
+    },
+    {
+      "code": 6052,
+      "name": "WrongOracle",
+      "msg": "wrong oracle address was sent to instruction"
+    },
+    {
+      "code": 6053,
+      "name": "WrongMarginUser",
+      "msg": "wrong margin user account address was sent to instruction"
+    },
+    {
+      "code": 6054,
+      "name": "WrongMarginUserAuthority",
+      "msg": "wrong authority for the margin user account address was sent to instruction"
+    },
+    {
+      "code": 6055,
+      "name": "WrongProgramAuthority",
+      "msg": "incorrect authority account"
+    },
+    {
+      "code": 6056,
+      "name": "WrongTicketMint",
+      "msg": "not the ticket mint for this fixed term market"
+    },
+    {
+      "code": 6057,
+      "name": "WrongUnderlyingTokenMint",
+      "msg": "wrong underlying token mint for this fixed term market"
+    },
+    {
+      "code": 6058,
+      "name": "WrongUserAccount",
+      "msg": "wrong user account address was sent to instruction"
+    },
+    {
+      "code": 6059,
+      "name": "WrongVault",
+      "msg": "wrong vault address was sent to instruction"
+    },
+    {
+      "code": 6060,
+      "name": "ZeroDivision",
+      "msg": "attempted to divide with zero"
     }
   ]
 };

--- a/programs/fixed-term/src/errors.rs
+++ b/programs/fixed-term/src/errors.rs
@@ -12,14 +12,20 @@ pub enum FixedTermErrorCode {
     DoesNotOwnTicket,
     #[msg("signer does not own the event adapter")]
     DoesNotOwnEventAdapter,
+    #[msg("this market owner does not own this market")]
+    DoesNotOwnMarket,
     #[msg("queue does not have room for another event")]
     EventQueueFull,
     #[msg("failed to deserialize the SplitTicket or ClaimTicket")]
     FailedToDeserializeTicket,
+    #[msg("failed to add event to the queue")]
+    FailedToPushEvent,
     #[msg("ticket is not mature and cannot be claimed")]
     ImmatureTicket,
     #[msg("not enough seeds were provided for the accounts that need to be initialized")]
     InsufficientSeeds,
+    #[msg("invalid auto roll configuration")]
+    InvalidAutoRollConfig,
     #[msg("order price is prohibited")]
     InvalidOrderPrice,
     #[msg("this token account is not a valid position for this margin user")]
@@ -40,10 +46,6 @@ pub enum FixedTermErrorCode {
     NoMoreAccounts,
     #[msg("the debt has a non-zero balance")]
     NonZeroDebt,
-    #[msg("expected a term loan with a different sequence number")]
-    TermLoanHasWrongSequenceNumber,
-    #[msg("expected a term deposit with a different sequence number")]
-    TermDepositHasWrongSequenceNumber,
     #[msg("there was a problem loading the price oracle")]
     OracleError,
     #[msg("id was not found in the user's open orders")]
@@ -54,12 +56,20 @@ pub enum FixedTermErrorCode {
     OrderRejected,
     #[msg("price could not be accessed from oracle")]
     PriceMissing,
+    #[msg("expected a term deposit with a different sequence number")]
+    TermDepositHasWrongSequenceNumber,
+    #[msg("expected a term loan with a different sequence number")]
+    TermLoanHasWrongSequenceNumber,
     #[msg("claim ticket is not from this manager")]
     TicketNotFromManager,
+    #[msg("ticket settlement account is not registered as a position in the margin account")]
+    TicketSettlementAccountNotRegistered,
     #[msg("tickets are paused")]
     TicketsPaused,
     #[msg("this signer is not authorized to place a permissioned order")]
     UnauthorizedCaller,
+    #[msg("underlying settlement account is not registered as a position in the margin account")]
+    UnderlyingSettlementAccountNotRegistered,
     #[msg("this user does not own the user account")]
     UserDoesNotOwnAccount,
     #[msg("this adapter does not belong to the user")]
@@ -68,26 +78,24 @@ pub enum FixedTermErrorCode {
     UserNotInMarket,
     #[msg("the wrong adapter account was passed to this instruction")]
     WrongAdapter,
-    #[msg("asks account does not belong to this market")]
-    WrongAsks,
     #[msg("the market is configured for a different airspace")]
     WrongAirspace,
     #[msg("the signer is not authorized to perform this action in the current airspace")]
     WrongAirspaceAuthorization,
+    #[msg("asks account does not belong to this market")]
+    WrongAsks,
     #[msg("bids account does not belong to this market")]
     WrongBids,
-    #[msg("adapter does not belong to given market")]
-    WrongMarket,
     #[msg("wrong authority for this crank instruction")]
     WrongCrankAuthority,
     #[msg("event queue account does not belong to this market")]
     WrongEventQueue,
+    #[msg("adapter does not belong to given market")]
+    WrongMarket,
     #[msg("this market state is not associated with this market")]
     WrongMarketState,
     #[msg("wrong TicketManager account provided")]
     WrongTicketManager,
-    #[msg("this market owner does not own this market")]
-    DoesNotOwnMarket,
     #[msg("the wrong account was provided for the token account that represents a user's claims")]
     WrongClaimAccount,
     #[msg(
@@ -110,10 +118,6 @@ pub enum FixedTermErrorCode {
     WrongProgramAuthority,
     #[msg("not the ticket mint for this fixed term market")]
     WrongTicketMint,
-    #[msg("wrong ticket settlement account")]
-    WrongTicketSettlementAccount,
-    #[msg("wrong underlying settlement account")]
-    WrongUnderlyingSettlementAccount,
     #[msg("wrong underlying token mint for this fixed term market")]
     WrongUnderlyingTokenMint,
     #[msg("wrong user account address was sent to instruction")]
@@ -122,8 +126,4 @@ pub enum FixedTermErrorCode {
     WrongVault,
     #[msg("attempted to divide with zero")]
     ZeroDivision,
-    #[msg("failed to add event to the queue")]
-    FailedToPushEvent,
-    #[msg("invalid auto roll configuration")]
-    InvalidAutoRollConfig,
 }

--- a/programs/fixed-term/src/margin/events.rs
+++ b/programs/fixed-term/src/margin/events.rs
@@ -8,8 +8,6 @@ pub struct MarginUserInitialized {
     pub market: Pubkey,
     pub margin_user: Pubkey,
     pub margin_account: Pubkey,
-    pub underlying_settlement: Pubkey,
-    pub ticket_settlement: Pubkey,
 }
 
 #[event]

--- a/programs/fixed-term/src/margin/instructions/initialize_margin_user.rs
+++ b/programs/fixed-term/src/margin/instructions/initialize_margin_user.rs
@@ -1,5 +1,5 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::{accessor::mint, Mint, Token, TokenAccount};
+use anchor_spl::token::{Mint, Token, TokenAccount};
 use jet_margin::{AdapterResult, PositionChange};
 
 use crate::{
@@ -69,9 +69,6 @@ pub struct InitializeMarginUser<'info> {
     pub ticket_collateral: Box<Account<'info, TokenAccount>>,
     pub ticket_collateral_mint: Box<Account<'info, Mint>>,
 
-    pub underlying_settlement: Box<Account<'info, TokenAccount>>,
-    pub ticket_settlement: Box<Account<'info, TokenAccount>>,
-
     #[account(mut)]
     pub payer: Signer<'info>,
     pub rent: Sysvar<'info, Rent>,
@@ -88,17 +85,6 @@ pub struct InitializeMarginUser<'info> {
 pub fn handler(ctx: Context<InitializeMarginUser>) -> Result<()> {
     let user = &mut ctx.accounts.margin_user;
 
-    require_eq!(
-        mint(&ctx.accounts.underlying_settlement.to_account_info())?,
-        ctx.accounts.market.load()?.underlying_token_mint,
-        FixedTermErrorCode::WrongUnderlyingTokenMint
-    );
-    require_eq!(
-        mint(&ctx.accounts.ticket_settlement.to_account_info())?,
-        ctx.accounts.market.load()?.ticket_mint,
-        FixedTermErrorCode::WrongTicketMint
-    );
-
     init! {
         user = MarginUser {
             version: MARGIN_USER_VERSION,
@@ -106,8 +92,6 @@ pub fn handler(ctx: Context<InitializeMarginUser>) -> Result<()> {
             market: ctx.accounts.market.key(),
             claims: ctx.accounts.claims.key(),
             ticket_collateral: ctx.accounts.ticket_collateral.key(),
-            underlying_settlement: ctx.accounts.underlying_settlement.key(),
-            ticket_settlement: ctx.accounts.ticket_settlement.key(),
             borrow_roll_config: Default::default(),
             lend_roll_config: Default::default(),
         } ignoring {
@@ -120,8 +104,6 @@ pub fn handler(ctx: Context<InitializeMarginUser>) -> Result<()> {
         market: ctx.accounts.market.key(),
         margin_user: ctx.accounts.margin_user.key(),
         margin_account: ctx.accounts.margin_account.key(),
-        underlying_settlement: ctx.accounts.underlying_settlement.key(),
-        ticket_settlement: ctx.accounts.ticket_settlement.key(),
     });
 
     return_to_margin(

--- a/programs/fixed-term/src/margin/instructions/margin_borrow_order.rs
+++ b/programs/fixed-term/src/margin/instructions/margin_borrow_order.rs
@@ -1,6 +1,6 @@
 use agnostic_orderbook::state::Side;
 use anchor_lang::prelude::*;
-use anchor_spl::token::Token;
+use anchor_spl::{associated_token::get_associated_token_address, token::Token};
 use jet_margin::{AdapterResult, PositionChange};
 use jet_program_common::traits::{SafeSub, TryAddAssign};
 use jet_program_proc_macros::MarketTokenManager;
@@ -59,8 +59,11 @@ pub struct MarginBorrowOrder<'info> {
     #[account(mut, address = orderbook_mut.vault() @ FixedTermErrorCode::WrongVault)]
     pub underlying_token_vault: AccountInfo<'info>,
 
-    /// The market token vault
-    #[account(mut, address = margin_user.underlying_settlement @ FixedTermErrorCode::WrongUnderlyingSettlementAccount)]
+    /// Where to receive borrowed tokens
+    #[account(mut, address = get_associated_token_address(
+        &margin_user.margin_account,
+        &orderbook_mut.underlying_mint(),
+    ))]
     pub underlying_settlement: AccountInfo<'info>,
 
     #[market]

--- a/programs/fixed-term/src/margin/state.rs
+++ b/programs/fixed-term/src/margin/state.rs
@@ -29,12 +29,6 @@ pub struct MarginUser {
     /// which are internal to fixed-term market, such as SplitTicket, ClaimTicket, and open orders.
     /// this does *not* represent underlying tokens or ticket tokens, those are registered independently in margin
     pub ticket_collateral: Pubkey,
-    /// The `settle` instruction is permissionless, therefore the user must specify upon margin account creation
-    /// the address to send owed tokens
-    pub underlying_settlement: Pubkey,
-    /// The `settle` instruction is permissionless, therefore the user must specify upon margin account creation
-    /// the address to send owed tickets
-    pub ticket_settlement: Pubkey,
     /// The amount of debt that must be collateralized or repaid
     /// This debt is expressed in terms of the underlying token - not tickets
     pub debt: Debt,

--- a/programs/margin/src/state/account.rs
+++ b/programs/margin/src/state/account.rs
@@ -259,7 +259,7 @@ impl MarginAccount {
         self.position_list().get_key(mint).copied()
     }
 
-    pub fn get_position(&mut self, mint: &Pubkey) -> Option<&AccountPosition> {
+    pub fn get_position(&self, mint: &Pubkey) -> Option<&AccountPosition> {
         self.position_list().get(mint)
     }
 

--- a/tests/hosted/src/bin/launch_fixed_term_market.rs
+++ b/tests/hosted/src/bin/launch_fixed_term_market.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use hosted_tests::fixed_term::TestManager;
 use hosted_tests::margin::MarginClient;
 use hosted_tests::solana_test_context;
-use jet_margin_sdk::ix_builder::get_metadata_address;
+use jet_margin_sdk::ix_builder::{derive_airspace, get_metadata_address};
 use solana_sdk::signer::Signer;
 
 lazy_static::lazy_static! {
@@ -25,6 +25,7 @@ async fn main() -> Result<()> {
 
     let x = TestManager::new(
         ctx,
+        derive_airspace("default"),
         &keys::mint(),
         &keys::event_queue(),
         &keys::bids(),

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -68,7 +68,7 @@ use spl_token::{instruction::initialize_mint, state::Mint};
 use crate::{
     context::MarginTestContext,
     runtime::{Keygen, SolanaTestContext},
-    setup_helper::setup_user,
+    setup_helper::{register_deposit, setup_user},
     tokens::TokenManager,
 };
 
@@ -115,6 +115,7 @@ pub struct TestManager {
     pub kps: Keys<Keypair>,
     pub keys: Keys<Pubkey>,
     pub margin_accounts_to_settle: AsyncNoDupeQueue<Pubkey>,
+    airspace: Pubkey,
 }
 
 impl Clone for TestManager {
@@ -133,14 +134,15 @@ impl Clone for TestManager {
             keys: self.keys.clone(),
             keygen: self.keygen.clone(),
             margin_accounts_to_settle: Default::default(),
+            airspace: self.airspace,
         }
     }
 }
 
 impl TestManager {
-    pub async fn full(client: SolanaTestContext) -> Result<Self> {
-        let mint = client.generate_key();
-        let oracle = TokenManager::new(client.clone())
+    pub async fn full(client: &MarginTestContext) -> Result<Self> {
+        let mint = client.solana.generate_key();
+        let oracle = TokenManager::new(client.solana.clone())
             .create_oracle(&mint.pubkey())
             .await?;
         let ticket_mint = fixed_term_address(&[
@@ -152,11 +154,12 @@ impl TestManager {
             )
             .as_ref(),
         ]);
-        let ticket_oracle = TokenManager::new(client.clone())
+        let ticket_oracle = TokenManager::new(client.solana.clone())
             .create_oracle(&ticket_mint)
             .await?;
         TestManager::new(
-            client.clone(),
+            client.solana.clone(),
+            client.margin.airspace(),
             &mint,
             &client.generate_key(),
             &client.generate_key(),
@@ -171,8 +174,10 @@ impl TestManager {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         client: SolanaTestContext,
+        airspace: Pubkey,
         mint: &Keypair,
         eq_kp: &Keypair,
         bids_kp: &Keypair,
@@ -194,7 +199,8 @@ impl TestManager {
 
         let ix_builder = FixedTermIxBuilder::new_from_seed(
             payer.pubkey(),
-            &Pubkey::default(),
+            // &airspace,
+            &Pubkey::default(), //todo airspace (i get a weird error in metadata program when this is set correctly)
             &mint.pubkey(),
             MARKET_SEED,
             payer.pubkey(),
@@ -215,6 +221,7 @@ impl TestManager {
             kps: Keys::new(),
             keys: Keys::new(),
             margin_accounts_to_settle: Default::default(),
+            airspace,
         };
         this.insert_kp("token_mint", clone(mint));
 
@@ -279,12 +286,15 @@ impl TestManager {
         Ok(self)
     }
 
-    /// set up metadata authorization for margin to invoke Jet market
+    /// set up metadata authorization for margin to invoke fixed term and
+    /// register relevant positions.
     pub async fn with_margin(self) -> Result<Self> {
         self.create_authority_if_missing().await?;
         self.register_adapter_if_unregistered(&jet_fixed_term::ID)
             .await?;
         self.register_tickets_position_metadatata().await?;
+        register_deposit(&self.client, self.airspace, self.ix_builder.token_mint()).await?;
+        register_deposit(&self.client, self.airspace, self.ix_builder.ticket_mint()).await?;
 
         Ok(self)
     }
@@ -881,7 +891,7 @@ impl<P: Proxy> FixedTermUser<P> {
     }
 
     pub async fn settle(&self) -> Result<Signature> {
-        let settle = self.manager.ix_builder.margin_settle(self.proxy.pubkey());
+        let settle = self.manager.ix_builder.settle(self.proxy.pubkey());
         self.client.send_and_confirm_1tx(&[settle], &[]).await
     }
 

--- a/tests/hosted/src/setup_helper.rs
+++ b/tests/hosted/src/setup_helper.rs
@@ -3,17 +3,18 @@ use std::sync::Arc;
 
 use anyhow::{Error, Result};
 
-use jet_margin::TokenKind;
-use jet_margin_sdk::solana::transaction::SendTransactionBuilder;
+use jet_margin::{TokenAdmin, TokenConfigUpdate, TokenKind, TokenOracle};
+use jet_margin_sdk::ix_builder::MarginConfigIxBuilder;
+use jet_margin_sdk::solana::transaction::{SendTransactionBuilder, WithSigner};
 use jet_margin_sdk::tokens::TokenPrice;
 use jet_margin_sdk::tx_builder::TokenDepositsConfig;
 use jet_margin_sdk::util::asynchronous::MapAsync;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Signer;
+use solana_sdk::signature::{Signature, Signer};
 
 use jet_margin_pool::{MarginPoolConfig, PoolFlags, TokenChange};
-use jet_simulation::create_wallet;
+use jet_simulation::{create_wallet, SolanaRpcClient};
 use tokio::try_join;
 
 use crate::margin_test_context;
@@ -183,6 +184,41 @@ pub async fn setup_user(
         .await?;
 
     Ok(test_user)
+}
+
+pub async fn register_deposit(
+    rpc: &Arc<dyn SolanaRpcClient>,
+    airspace: Pubkey,
+    mint: Pubkey,
+) -> Result<Signature> {
+    let config_builder = MarginConfigIxBuilder::new(airspace, rpc.payer().pubkey());
+    config_builder
+        .configure_token(
+            mint,
+            Some(TokenConfigUpdate {
+                underlying_mint: mint,
+                admin: TokenAdmin::Margin {
+                    oracle: TokenOracle::Pyth {
+                        price: Pubkey::find_program_address(
+                            &[mint.as_ref(), b"oracle:price".as_ref()],
+                            &jet_metadata::ID,
+                        )
+                        .0,
+                        product: Pubkey::find_program_address(
+                            &[mint.as_ref(), b"oracle:product".as_ref()],
+                            &jet_metadata::ID,
+                        )
+                        .0,
+                    },
+                },
+                token_kind: TokenKind::Collateral,
+                value_modifier: 100,
+                max_staleness: 0,
+            }),
+        )
+        .with_signers(&[])
+        .send_and_confirm(rpc)
+        .await
 }
 
 /// Environment where no user has a balance

--- a/tests/hosted/tests/fixed_term.rs
+++ b/tests/hosted/tests/fixed_term.rs
@@ -20,7 +20,10 @@ use jet_margin_sdk::{
     fixed_term::settler::SETTLES_PER_TX,
     ix_builder::MarginIxBuilder,
     margin_integrator::{NoProxy, Proxy},
-    solana::transaction::{InverseSendTransactionBuilder, SendTransactionBuilder},
+    solana::{
+        keypair::clone,
+        transaction::{InverseSendTransactionBuilder, SendTransactionBuilder, WithSigner},
+    },
     tx_builder::fixed_term::FixedTermPositionRefresher,
     util::data::Concat,
 };
@@ -28,18 +31,19 @@ use jet_margin_sdk::{margin_integrator::RefreshingProxy, tx_builder::MarginTxBui
 use jet_program_common::Fp32;
 
 use solana_sdk::signer::Signer;
+use spl_associated_token_account::instruction::create_associated_token_account;
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn non_margin_orders() -> Result<(), anyhow::Error> {
-    let manager = FixedTermTestManager::full(margin_test_context!().solana.clone()).await?;
+    let manager = FixedTermTestManager::full(&margin_test_context!()).await?;
     non_margin_orders_for_proxy::<NoProxy>(Arc::new(manager)).await
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn non_margin_orders_through_margin_account() -> Result<()> {
-    let manager = FixedTermTestManager::full(margin_test_context!().solana.clone()).await?;
+    let manager = FixedTermTestManager::full(&margin_test_context!()).await?;
     non_margin_orders_for_proxy::<MarginIxBuilder>(Arc::new(manager)).await
 }
 
@@ -303,11 +307,7 @@ async fn non_margin_orders_for_proxy<P: Proxy + GenerateProxy>(
 #[serial_test::serial]
 async fn margin_repay() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
 
@@ -429,8 +429,7 @@ async fn margin_repay() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[serial_test::serial]
 async fn can_consume_lots_of_events() -> Result<()> {
-    let manager =
-        Arc::new(FixedTermTestManager::full(margin_test_context!().solana.clone()).await?);
+    let manager = Arc::new(FixedTermTestManager::full(&margin_test_context!()).await?);
 
     // make and fund users
     let alice = FixedTermUser::<NoProxy>::new_funded(manager.clone()).await?;
@@ -460,11 +459,7 @@ async fn can_consume_lots_of_events() -> Result<()> {
 #[serial_test::serial]
 async fn settle_many_margin_accounts() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
     let set_prices = vec![
@@ -538,11 +533,7 @@ async fn settle_many_margin_accounts() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn margin_borrow() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
 
@@ -586,11 +577,7 @@ async fn margin_borrow() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn margin_borrow_fails_without_collateral() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
 
@@ -634,11 +621,7 @@ async fn margin_borrow_fails_without_collateral() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn margin_lend() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
 
@@ -675,11 +658,7 @@ async fn margin_lend() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn margin_borrow_then_margin_lend() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
 
@@ -689,6 +668,20 @@ async fn margin_borrow_then_margin_lend() -> Result<()> {
         vec![(collateral, 0, u64::MAX / 2)],
     )
     .await;
+    let mint = manager.ix_builder.token_mint();
+    vec![
+        create_associated_token_account(
+            &borrower.owner.pubkey(),
+            &borrower.owner.pubkey(),
+            &mint,
+            &spl_token::id(),
+        ),
+        borrower.proxy.proxy.create_deposit_position(mint),
+    ]
+    .with_signers(&[clone(&borrower.owner)])
+    .send_and_confirm(&ctx.rpc)
+    .await?;
+
     let lender = create_fixed_term_market_margin_user(&ctx, manager.clone(), vec![]).await;
 
     vec![
@@ -745,11 +738,7 @@ async fn margin_borrow_then_margin_lend() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn margin_lend_then_margin_borrow() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
 
@@ -828,11 +817,7 @@ async fn margin_lend_then_margin_borrow() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn margin_sell_tickets() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([], _, pricer) = tokens(&ctx).await.unwrap();
 
@@ -867,11 +852,7 @@ async fn margin_sell_tickets() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn auto_roll_settings_are_correct() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let ([collateral], _, _) = tokens(&ctx).await?;
 
     let user = create_fixed_term_market_margin_user(
@@ -916,11 +897,7 @@ async fn auto_roll_settings_are_correct() -> Result<()> {
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn auto_roll_borrow() -> Result<()> {
     let ctx = margin_test_context!();
-    let manager = Arc::new(
-        FixedTermTestManager::full(ctx.solana.clone())
-            .await
-            .unwrap(),
-    );
+    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     let client = manager.client.clone();
     let ([collateral], _, pricer) = tokens(&ctx).await.unwrap();
 

--- a/tools/ctl/src/actions/margin.rs
+++ b/tools/ctl/src/actions/margin.rs
@@ -136,7 +136,7 @@ pub async fn process_refresh_metadata(client: &Client, token: Pubkey) -> Result<
     println!("current config: {config:#?}");
     println!("found {} margin accounts", margin_accounts.len());
 
-    for (address, mut account) in margin_accounts {
+    for (address, account) in margin_accounts {
         let ix = MarginIxBuilder::new_with_payer(
             Pubkey::default(), // FIXME: read airspace from margin account
             account.owner,


### PR DESCRIPTION
This adds tighter constraints to the fixed term program. Standard practices for settlement are now hard requirements. This is to avoid accounting issues in margin. Libraries are updated to conform to new expectations.

Always use accounting invoke - reduces risk to user
- Settle can now only be invoked through margin, enforced by return to margin
- settler crank now uses accounting_invoke, previously it did not, which may have caused some confusion to users of the frontend who are relying on the crank

Always settle to ATAs - reduces risk to system
- no longer configurable, the ata is enforced at time of settle 
- Settle ix requires ATA to be registered as a position if its going to be moving anything in there

misc
- alphabetize errors
- fix issue in margin requiring mut self when not needed
- register underlying and ticket as deposits during fixed term tests
- update idl