### PR TITLE
Rename tokens on DexInfo to be consistent with DexConfig

### DIFF
--- a/libraries/rust/client/src/config.rs
+++ b/libraries/rust/client/src/config.rs
@@ -100,8 +100,8 @@ pub struct DexInfo {
     pub address: Pubkey,
 
     #[serde_as(as = "DisplayFromStr")]
-    pub token_a: Pubkey,
+    pub base: Pubkey,
 
     #[serde_as(as = "DisplayFromStr")]
-    pub token_b: Pubkey,
+    pub quote: Pubkey,
 }

--- a/tests/hosted/src/context.rs
+++ b/tests/hosted/src/context.rs
@@ -379,8 +379,8 @@ impl TestContextSetupInfo {
                     DexInfo {
                         program: ORCA_V2,
                         address: derive_spl_swap_pool(&ORCA_V2, &token_a, &token_b).state,
-                        token_a,
-                        token_b,
+                        base: token_a,
+                        quote: token_b,
                     }
                 })
                 .collect(),


### PR DESCRIPTION
There is a slight mismatch in DexInfo and DexConfig, where the former has base and quote variables as token_a and token_b. This is causing an error when parsing the config file from JSON.