### PR TITLE
Simple utility to strip IDL docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5727,6 +5727,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strip-idl-docs"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/scripts/localnet_lib.sh
+++ b/tests/scripts/localnet_lib.sh
@@ -60,12 +60,13 @@ run() {
 }
 
 init-idl() {
+    cargo run --bin strip-idl-docs
     anchor idl init -f ./target/idl/jet_metadata.json $META_PID --provider.cluster localnet
     anchor idl init -f ./target/idl/jet_control.json $CTRL_PID --provider.cluster localnet
-    # anchor idl init -f ./target/idl/jet_margin.json $MRGN_PID --provider.cluster localnet
+    anchor idl init -f ./target/idl/jet_margin.json $MRGN_PID --provider.cluster localnet
     anchor idl init -f ./target/idl/jet_margin_pool.json $POOL_PID --provider.cluster localnet
     anchor idl init -f ./target/idl/jet_margin_swap.json $MGNSWAP_PID --provider.cluster localnet
-    # anchor idl init -f ./target/idl/jet_bonds.json $BOND_PID --provider.cluster localnet
+    anchor idl init -f ./target/idl/jet_bonds.json $BOND_PID --provider.cluster localnet
 }
 
 start-validator() {

--- a/tools/strip-idl-docs/Cargo.toml
+++ b/tools/strip-idl-docs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "strip-idl-docs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde_json = "1"

--- a/tools/strip-idl-docs/src/main.rs
+++ b/tools/strip-idl-docs/src/main.rs
@@ -1,0 +1,74 @@
+//! Read all the IDL files and stip their docs out.
+//! This is a temporary measure until we can fix this in anchor-lang.
+
+fn main() {
+    let _ = strip();
+}
+
+fn strip() -> Option<()> {
+    let mut entries = std::fs::read_dir("./target/idl").ok()?;
+    while let Some(Ok(entry)) = entries.next() {
+        println!("Stripping docs from IDL {:?}", entry.path());
+        let file = std::fs::File::open(entry.path()).ok()?;
+        let mut idl = serde_json::from_reader::<_, serde_json::Value>(file).ok()?;
+
+        // Recursively strip out all the docs from the IDL
+        let val = idl.as_object_mut()?;
+        val.remove("docs");
+
+        // Remove in instructions
+        let instructions = val.get_mut("instructions")?.as_array_mut()?;
+        for ix in instructions {
+            let val = ix.as_object_mut()?;
+            val.remove("docs");
+
+            // Remove in instructions[].accounts
+            let accounts = val.get_mut("accounts")?.as_array_mut()?;
+            for account in accounts {
+                let val = account.as_object_mut()?;
+                val.remove("docs");
+            }
+        }
+
+        // Remove in accounts, some IDLs might not have top-level accounts
+        let Some(Some(accounts)) = val.get_mut("accounts").map(|v| v.as_array_mut()) else {
+            continue;
+        };
+
+        for account in accounts {
+            let val = account.as_object_mut()?;
+            val.remove("docs");
+            // Remove in type.fields
+            let type_ = val.get_mut("type")?;
+            let fields = type_.as_object_mut()?.get_mut("fields")?.as_array_mut()?;
+            for field in fields {
+                let val = field.as_object_mut()?;
+                val.remove("docs");
+            }
+        }
+
+        // Remove in types
+        let Some(types) = val.get_mut("types").and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+
+        for type_ in types {
+            let val = type_.as_object_mut()?;
+            val.remove("docs");
+            let type_ = val.get_mut("type")?;
+            let Some(fields) = type_.as_object_mut()?.get_mut("fields").and_then(|v| v.as_array_mut()) else {
+                continue
+            };
+            for field in fields {
+                let val = field.as_object_mut()?;
+                val.remove("docs");
+            }
+        }
+
+        // Write IDL out
+        let file = std::fs::File::create(entry.path()).ok()?;
+        serde_json::to_writer_pretty(file, &idl).ok()?
+    }
+
+    Some(())
+}


### PR DESCRIPTION
The fixed term and margin IDLs are huge because of docs. We can't upload them locally nor on devnet, and we'll waste SOL on mainnet on all IDLs with docs.

This utility strips out the docs from the JSON files and writes them back.

A correct solution would be to fix this in anchor-lang, however we're now using a released version from crates.io, so it'll take a while for us to pick up this fix.

I'm making this change now, and I'll fix it in anchor when I have some time later.