### PR TITLE
test service: create and balance saber swap pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,6 +2787,8 @@ dependencies = [
  "jet-program-common",
  "pyth-sdk-solana 0.7.0",
  "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable-swap-anchor",
+ "stable-swap-client",
 ]
 
 [[package]]

--- a/config/localnet/exchanges.toml
+++ b/config/localnet/exchanges.toml
@@ -7,3 +7,8 @@ quote = "USDC"
 program = "spl-swap"
 base = "BTC"
 quote = "USDT"
+
+[[dex]]
+program = "saber-swap"
+base = "USDT"
+quote = "USDC"

--- a/libraries/rust/environment/src/builder/swap.rs
+++ b/libraries/rust/environment/src/builder/swap.rs
@@ -2,12 +2,14 @@ use std::str::FromStr;
 
 use solana_sdk::pubkey::Pubkey;
 
-use jet_instructions::test_service::{derive_spl_swap_pool, spl_swap_pool_create};
+use jet_instructions::test_service::{
+    derive_spl_swap_pool, saber_swap_pool_create, spl_swap_pool_create,
+};
 use jet_solana_client::{network::NetworkKind, NetworkUserInterface};
 
 use crate::{
     config::EnvironmentConfig,
-    programs::{ORCA_V2, ORCA_V2_DEVNET},
+    programs::{ORCA_V2, ORCA_V2_DEVNET, SABER},
 };
 
 use super::{resolve_token_mint, Builder, BuilderError};
@@ -23,6 +25,9 @@ pub fn resolve_swap_program(network: NetworkKind, name: &str) -> Result<Pubkey, 
             _ => ORCA_V2,
         });
     }
+    if name == "saber-swap" {
+        return Ok(SABER);
+    }
 
     Err(BuilderError::UnknownSwapProgram(name.to_string()))
 }
@@ -36,30 +41,51 @@ pub async fn create_swap_pools<'a, I: NetworkUserInterface>(
     }
 
     for pool in &config.exchanges {
-        if pool.program != "spl-swap" {
-            log::warn!("ignoring unknown swap program {}", pool.program);
-            continue;
-        }
-
-        log::info!("create SPL swap pool for {}/{}", pool.base, pool.quote);
+        let swap_program = resolve_swap_program(builder.network, &pool.program)?;
         let token_a = resolve_token_mint(config, &pool.base)?;
         let token_b = resolve_token_mint(config, &pool.quote)?;
+        match &pool.program {
+            p if p == "spl-swap" => {
+                log::info!("create SPL swap pool for {}/{}", pool.base, pool.quote);
 
-        let swap_program = resolve_swap_program(builder.network, &pool.program)?;
-        let swap_info = derive_spl_swap_pool(&swap_program, &token_a, &token_b);
+                let swap_info = derive_spl_swap_pool(&swap_program, &token_a, &token_b);
 
-        if builder.account_exists(&swap_info.state).await? {
-            continue;
+                if builder.account_exists(&swap_info.state).await? {
+                    continue;
+                }
+
+                builder.setup([spl_swap_pool_create(
+                    &swap_program,
+                    &builder.payer(),
+                    &token_a,
+                    &token_b,
+                    8,
+                    500,
+                )])
+            }
+            p if p == "saber-swap" => {
+                log::info!("create Saber swap pool for {}/{}", pool.base, pool.quote);
+
+                let swap_info = derive_spl_swap_pool(&swap_program, &token_a, &token_b);
+
+                if builder.account_exists(&swap_info.state).await? {
+                    continue;
+                }
+
+                builder.setup([saber_swap_pool_create(
+                    &swap_program,
+                    &builder.payer(),
+                    &token_a,
+                    &token_b,
+                    8,
+                    500,
+                )])
+            }
+            p => {
+                log::warn!("ignoring unknown swap program {} {p}", pool.program);
+                continue;
+            }
         }
-
-        builder.setup([spl_swap_pool_create(
-            &swap_program,
-            &builder.payer(),
-            &token_a,
-            &token_b,
-            8,
-            500,
-        )])
     }
 
     Ok(())

--- a/libraries/rust/environment/src/programs.rs
+++ b/libraries/rust/environment/src/programs.rs
@@ -2,3 +2,4 @@ use solana_sdk::{pubkey, pubkey::Pubkey};
 
 pub const ORCA_V2: Pubkey = pubkey!("9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP");
 pub const ORCA_V2_DEVNET: Pubkey = pubkey!("3xQ8SWv2GaFXXpHZNqkXsdxq5DZciHBz6ZFoPPfbFd7U");
+pub const SABER: Pubkey = pubkey!("SSwpkEEcbUqx4vtoEByFjSkhKdCT862DNVb52nZg1UZ");

--- a/libraries/rust/instructions/src/test_service.rs
+++ b/libraries/rust/instructions/src/test_service.rs
@@ -269,7 +269,7 @@ pub fn saber_swap_pool_create(
         pool_token_b: addrs.token_b_account,
         pool_fee_a: addrs.fee_a,
         pool_fee_b: addrs.fee_b,
-        lp_destination: addrs.lp_destination,
+        lp_token: addrs.lp_token,
         swap_program: *swap_program,
         token_program: spl_token::ID,
         system_program: system_program::ID,
@@ -288,6 +288,50 @@ pub fn saber_swap_pool_create(
             },
         }
         .data(),
+    }
+}
+
+/// Balance a Saber swap pool
+pub fn saber_swap_pool_balance(
+    swap_program: &Pubkey,
+    token_a: &Pubkey,
+    token_b: &Pubkey,
+    scratch_a: &Pubkey,
+    scratch_b: &Pubkey,
+    payer: &Pubkey,
+) -> Instruction {
+    let pool = derive_saber_swap_pool(swap_program, token_a, token_b);
+
+    let accounts = jet_test_service::accounts::SaberSwapPoolBalance {
+        payer: *payer,
+        scratch_a: *scratch_a,
+        scratch_b: *scratch_b,
+        mint_a: *token_a,
+        mint_b: *token_b,
+        info_a: derive_token_info(token_a),
+        info_b: derive_token_info(token_b),
+        pyth_price_a: derive_pyth_price(token_a),
+        pyth_price_b: derive_pyth_price(token_b),
+        pool_info: pool.info,
+        pool_state: pool.state,
+        pool_authority: pool.authority,
+        pool_mint: pool.mint,
+        pool_token_a: pool.token_a_account,
+        pool_token_b: pool.token_b_account,
+        pool_fee_a: pool.fee_a,
+        pool_fee_b: pool.fee_b,
+        lp_token: pool.lp_token,
+        saber_program: *swap_program,
+        token_program: spl_token::ID,
+        system_program: system_program::ID,
+        rent: sysvar::rent::ID,
+    }
+    .to_account_metas(None);
+
+    Instruction {
+        program_id: jet_test_service::ID,
+        accounts,
+        data: jet_test_service::instruction::SaberSwapPoolBalance {}.data(),
     }
 }
 
@@ -394,22 +438,12 @@ pub fn derive_saber_swap_pool(
     token_b: &Pubkey,
 ) -> SaberSwapPoolAddress {
     let info = Pubkey::find_program_address(
-        &[
-            SWAP_POOL_INFO,
-            token_a.as_ref(),
-            token_b.as_ref(),
-            // b"saber".as_ref(),
-        ],
+        &[SWAP_POOL_INFO, token_a.as_ref(), token_b.as_ref()],
         &jet_test_service::ID,
     )
     .0;
     let state = Pubkey::find_program_address(
-        &[
-            SWAP_POOL_STATE,
-            token_a.as_ref(),
-            token_b.as_ref(),
-            // b"saber".as_ref(),
-        ],
+        &[SWAP_POOL_STATE, token_a.as_ref(), token_b.as_ref()],
         &jet_test_service::ID,
     )
     .0;
@@ -452,7 +486,7 @@ pub fn derive_saber_swap_pool(
         mint,
         fee_a,
         fee_b,
-        lp_destination,
+        lp_token: lp_destination,
         nonce,
     }
 }
@@ -510,8 +544,8 @@ pub struct SaberSwapPoolAddress {
     /// The account to collect fees from token B
     pub fee_b: Pubkey,
 
-    /// Destination to mint pool tokens when initialising
-    pub lp_destination: Pubkey,
+    /// The account to transfer liquiditity token to/from
+    pub lp_token: Pubkey,
 
     /// The pool nonce
     pub nonce: u8,

--- a/libraries/rust/instructions/src/test_service.rs
+++ b/libraries/rust/instructions/src/test_service.rs
@@ -26,9 +26,12 @@ use solana_sdk::{
     sysvar::{self, SysvarId},
 };
 
-use jet_test_service::seeds::{
-    SWAP_POOL_INFO, SWAP_POOL_MINT, SWAP_POOL_STATE, SWAP_POOL_TOKENS, TOKEN_INFO, TOKEN_MINT,
-    TOKEN_PYTH_PRICE, TOKEN_PYTH_PRODUCT,
+use jet_test_service::{
+    seeds::{
+        SWAP_POOL_FEES, SWAP_POOL_INFO, SWAP_POOL_MINT, SWAP_POOL_STATE, SWAP_POOL_TOKENS,
+        TOKEN_INFO, TOKEN_MINT, TOKEN_PYTH_PRICE, TOKEN_PYTH_PRODUCT,
+    },
+    SaberSwapPoolCreateParams,
 };
 
 pub use jet_test_service::{SplSwapPoolCreateParams, TokenCreateParams};
@@ -242,6 +245,52 @@ pub fn spl_swap_pool_balance(
     }
 }
 
+/// Create a Saber swap pool
+pub fn saber_swap_pool_create(
+    swap_program: &Pubkey,
+    payer: &Pubkey,
+    token_a: &Pubkey,
+    token_b: &Pubkey,
+    liquidity_level: u8,
+    price_threshold: u16,
+) -> Instruction {
+    let addrs = derive_saber_swap_pool(swap_program, token_a, token_b);
+    let accounts = jet_test_service::accounts::SaberSwapPoolCreate {
+        payer: *payer,
+        mint_a: *token_a,
+        mint_b: *token_b,
+        info_a: derive_token_info(token_a), // TODO: will clash
+        info_b: derive_token_info(token_b),
+        pool_info: addrs.info,
+        pool_state: addrs.state,
+        pool_authority: addrs.authority,
+        pool_mint: addrs.mint,
+        pool_token_a: addrs.token_a_account,
+        pool_token_b: addrs.token_b_account,
+        pool_fee_a: addrs.fee_a,
+        pool_fee_b: addrs.fee_b,
+        lp_destination: addrs.lp_destination,
+        swap_program: *swap_program,
+        token_program: spl_token::ID,
+        system_program: system_program::ID,
+        rent: sysvar::rent::ID,
+    }
+    .to_account_metas(None);
+
+    Instruction {
+        program_id: jet_test_service::ID,
+        accounts,
+        data: jet_test_service::instruction::SaberSwapPoolCreate {
+            params: SaberSwapPoolCreateParams {
+                nonce: addrs.nonce,
+                liquidity_level,
+                price_threshold,
+            },
+        }
+        .data(),
+    }
+}
+
 /// if the account is not initialized, invoke the instruction
 pub fn if_not_initialized(account_to_check: Pubkey, ix: Instruction) -> Instruction {
     let mut accounts = jet_test_service::accounts::IfNotInitialized {
@@ -338,6 +387,76 @@ pub fn derive_spl_swap_pool(
     }
 }
 
+/// Get the addresses for a Saber swap pool
+pub fn derive_saber_swap_pool(
+    program: &Pubkey,
+    token_a: &Pubkey,
+    token_b: &Pubkey,
+) -> SaberSwapPoolAddress {
+    let info = Pubkey::find_program_address(
+        &[
+            SWAP_POOL_INFO,
+            token_a.as_ref(),
+            token_b.as_ref(),
+            // b"saber".as_ref(),
+        ],
+        &jet_test_service::ID,
+    )
+    .0;
+    let state = Pubkey::find_program_address(
+        &[
+            SWAP_POOL_STATE,
+            token_a.as_ref(),
+            token_b.as_ref(),
+            // b"saber".as_ref(),
+        ],
+        &jet_test_service::ID,
+    )
+    .0;
+    let (authority, nonce) = Pubkey::find_program_address(&[state.as_ref()], program);
+    let token_a_account = Pubkey::find_program_address(
+        &[SWAP_POOL_TOKENS, state.as_ref(), token_a.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+    let token_b_account = Pubkey::find_program_address(
+        &[SWAP_POOL_TOKENS, state.as_ref(), token_b.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+    let mint =
+        Pubkey::find_program_address(&[SWAP_POOL_MINT, state.as_ref()], &jet_test_service::ID).0;
+    let fee_a = Pubkey::find_program_address(
+        &[SWAP_POOL_FEES, state.as_ref(), token_a.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+    let fee_b = Pubkey::find_program_address(
+        &[SWAP_POOL_FEES, state.as_ref(), token_b.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+
+    let lp_destination = Pubkey::find_program_address(
+        &[SWAP_POOL_FEES, state.as_ref(), mint.as_ref()],
+        &jet_test_service::ID,
+    )
+    .0;
+
+    SaberSwapPoolAddress {
+        info,
+        state,
+        authority,
+        token_a_account,
+        token_b_account,
+        mint,
+        fee_a,
+        fee_b,
+        lp_destination,
+        nonce,
+    }
+}
+
 /// Set of addresses for a test swap pool
 pub struct SwapPoolAddress {
     /// The test-service state about the pool
@@ -360,6 +479,39 @@ pub struct SwapPoolAddress {
 
     /// The account to collect fees
     pub fees: Pubkey,
+
+    /// The pool nonce
+    pub nonce: u8,
+}
+
+/// Set of addresses for a test Saber swap pool
+pub struct SaberSwapPoolAddress {
+    /// The test-service state about the pool
+    pub info: Pubkey,
+
+    /// The address of the swap pool state
+    pub state: Pubkey,
+
+    /// The authority
+    pub authority: Pubkey,
+
+    /// The token A vault
+    pub token_a_account: Pubkey,
+
+    /// The token B vault
+    pub token_b_account: Pubkey,
+
+    /// The LP token
+    pub mint: Pubkey,
+
+    /// The account to collect fees from token A
+    pub fee_a: Pubkey,
+
+    /// The account to collect fees from token B
+    pub fee_b: Pubkey,
+
+    /// Destination to mint pool tokens when initialising
+    pub lp_destination: Pubkey,
 
     /// The pool nonce
     pub nonce: u8,

--- a/programs/test-service/Cargo.toml
+++ b/programs/test-service/Cargo.toml
@@ -25,4 +25,7 @@ pyth-sdk-solana = "0.7"
 bytemuck = "1.7"
 
 spl-token-swap = { version = "2.1", features = ["no-entrypoint"] }
+saber-stable-swap = { package = "stable-swap-anchor", git = "https://github.com/jet-lab/stable-swap", branch = "master" }
+saber-stable-client = { package = "stable-swap-client", git = "https://github.com/jet-lab/stable-swap", branch = "master" }
+
 jet-program-common = { path = "../../libraries/rust/program-common" }

--- a/programs/test-service/src/instructions/swaps/mod.rs
+++ b/programs/test-service/src/instructions/swaps/mod.rs
@@ -1,7 +1,9 @@
+mod saber_swap_pool_balance;
 mod saber_swap_pool_create;
 mod spl_swap_pool_balance;
 mod spl_swap_pool_create;
 
+pub use saber_swap_pool_balance::*;
 pub use saber_swap_pool_create::*;
 pub use spl_swap_pool_balance::*;
 pub use spl_swap_pool_create::*;

--- a/programs/test-service/src/instructions/swaps/mod.rs
+++ b/programs/test-service/src/instructions/swaps/mod.rs
@@ -1,5 +1,7 @@
+mod saber_swap_pool_create;
 mod spl_swap_pool_balance;
 mod spl_swap_pool_create;
 
+pub use saber_swap_pool_create::*;
 pub use spl_swap_pool_balance::*;
 pub use spl_swap_pool_create::*;

--- a/programs/test-service/src/instructions/swaps/saber_swap_pool_balance.rs
+++ b/programs/test-service/src/instructions/swaps/saber_swap_pool_balance.rs
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2022 JET PROTOCOL HOLDINGS, LLC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use anchor_lang::prelude::*;
+use anchor_spl::token::{Mint, Token, TokenAccount};
+
+use jet_program_common::Number128;
+use saber_stable_swap::{SwapOutput, SwapToken, SwapUserContext};
+
+use crate::seeds::{SWAP_POOL_FEES, SWAP_POOL_INFO, SWAP_POOL_MINT, SWAP_POOL_TOKENS, TOKEN_INFO};
+use crate::state::{SaberSwapInfo, TokenInfo};
+
+#[derive(Accounts)]
+pub struct SaberSwapPoolBalance<'info> {
+    payer: Signer<'info>,
+
+    #[account(mut, token::authority = payer)]
+    scratch_a: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut, token::authority = payer)]
+    scratch_b: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut)]
+    mint_a: Box<Account<'info, Mint>>,
+
+    #[account(mut)]
+    mint_b: Box<Account<'info, Mint>>,
+
+    #[account(constraint = info_a.mint == mint_a.key(),
+              constraint = info_a.pyth_price == pyth_price_a.key()
+    )]
+    info_a: Box<Account<'info, TokenInfo>>,
+
+    #[account(constraint = info_b.mint == mint_b.key(),
+              constraint = info_b.pyth_price == pyth_price_b.key()
+    )]
+    info_b: Box<Account<'info, TokenInfo>>,
+
+    pyth_price_a: AccountInfo<'info>,
+    pyth_price_b: AccountInfo<'info>,
+
+    #[account(has_one = pool_state,
+              seeds = [
+                SWAP_POOL_INFO,
+                mint_a.key().as_ref(),
+                mint_b.key().as_ref()
+              ],
+              bump,
+    )]
+    pool_info: Box<Account<'info, SaberSwapInfo>>,
+
+    #[account(mut)]
+    pool_state: AccountInfo<'info>,
+
+    #[account(seeds = [pool_state.key().as_ref()],
+              bump,
+              seeds::program = saber_program
+    )]
+    pool_authority: AccountInfo<'info>,
+
+    #[account(mut,
+              seeds = [
+                SWAP_POOL_MINT,
+                pool_state.key().as_ref()
+              ],
+              bump,
+    )]
+    pool_mint: Box<Account<'info, Mint>>,
+
+    #[account(mut,
+              seeds = [
+                SWAP_POOL_TOKENS,
+                pool_state.key().as_ref(),
+                mint_a.key().as_ref()
+              ],
+              bump,
+    )]
+    pool_token_a: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut,
+              seeds = [
+                SWAP_POOL_TOKENS,
+                pool_state.key().as_ref(),
+                mint_b.key().as_ref()
+              ],
+              bump,
+    )]
+    pool_token_b: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut,
+              seeds = [
+                SWAP_POOL_FEES,
+                pool_state.key().as_ref(),
+                mint_a.key().as_ref()
+              ],
+              bump,
+    )]
+    pool_fee_a: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut,
+        seeds = [
+          SWAP_POOL_FEES,
+          pool_state.key().as_ref(),
+          mint_b.key().as_ref()
+        ],
+        bump,
+    )]
+    pool_fee_b: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut,
+        seeds = [
+          SWAP_POOL_FEES,
+          pool_state.key().as_ref(),
+          pool_mint.key().as_ref()
+        ],
+        bump,
+    )]
+    lp_token: Box<Account<'info, TokenAccount>>,
+
+    saber_program: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+    system_program: Program<'info, System>,
+    rent: Sysvar<'info, Rent>,
+}
+
+pub fn saber_swap_pool_balance_handler(ctx: Context<SaberSwapPoolBalance>) -> Result<()> {
+    let SaberSwapPoolBalance {
+        mint_a,
+        mint_b,
+        pool_info,
+        pyth_price_a,
+        pyth_price_b,
+        pool_token_a,
+        pool_token_b,
+        ..
+    } = &ctx.accounts;
+
+    let current_amount_a = Number128::from_decimal(pool_token_a.amount, -(mint_a.decimals as i32));
+    let current_amount_b = Number128::from_decimal(pool_token_b.amount, -(mint_b.decimals as i32));
+
+    let price_a = read_price(pyth_price_a);
+    let price_b = read_price(pyth_price_b);
+
+    let value_a = price_a * current_amount_a;
+    let value_b = price_b * current_amount_b;
+
+    let liquidity_factor = Number128::from_decimal(1, pool_info.liquidity_level);
+
+    let change_a = value_a - liquidity_factor;
+    let change_b = value_b - liquidity_factor;
+
+    apply_changes(&ctx, (change_a, price_a), (change_b, price_b))?;
+
+    Ok(())
+}
+
+fn apply_changes(
+    ctx: &Context<SaberSwapPoolBalance>,
+    values_a: (Number128, Number128),
+    values_b: (Number128, Number128),
+) -> Result<()> {
+    let (change_a, price_a) = values_a;
+    let (change_b, price_b) = values_b;
+    let mint_a_key = ctx.accounts.mint_a.key();
+    let mint_b_key = ctx.accounts.mint_b.key();
+    let pool_info_signer_seeds = [
+        SWAP_POOL_INFO,
+        mint_a_key.as_ref(),
+        mint_b_key.as_ref(),
+        &[*ctx.bumps.get("pool_info").unwrap()],
+    ];
+
+    let token_mint_a_signer_seeds = [
+        TOKEN_INFO,
+        mint_a_key.as_ref(),
+        &[ctx.accounts.info_a.bump_seed],
+    ];
+    let token_mint_b_signer_seeds = [
+        TOKEN_INFO,
+        mint_b_key.as_ref(),
+        &[ctx.accounts.info_b.bump_seed],
+    ];
+
+    let (deposit_a, withdraw_a) =
+        calculate_token_change(change_a, price_a, ctx.accounts.mint_a.decimals);
+    let (deposit_b, withdraw_b) =
+        calculate_token_change(change_b, price_b, ctx.accounts.mint_b.decimals);
+
+    if (withdraw_a + withdraw_b) > 0 {
+        let withdraw_ctx = CpiContext::new(
+            ctx.accounts.saber_program.to_account_info(),
+            saber_stable_swap::Withdraw {
+                user: SwapUserContext {
+                    token_program: ctx.accounts.token_program.to_account_info(),
+                    swap_authority: ctx.accounts.pool_authority.to_account_info(),
+                    user_authority: ctx.accounts.payer.to_account_info(),
+                    swap: ctx.accounts.pool_state.to_account_info(),
+                },
+                pool_mint: ctx.accounts.pool_mint.to_account_info(),
+                input_lp: ctx.accounts.lp_token.to_account_info(),
+                output_a: SwapOutput {
+                    user_token: SwapToken {
+                        user: ctx.accounts.scratch_a.to_account_info(),
+                        reserve: ctx.accounts.pool_token_a.to_account_info(),
+                    },
+                    fees: ctx.accounts.pool_fee_a.to_account_info(),
+                },
+                output_b: SwapOutput {
+                    user_token: SwapToken {
+                        user: ctx.accounts.scratch_b.to_account_info(),
+                        reserve: ctx.accounts.pool_token_b.to_account_info(),
+                    },
+                    fees: ctx.accounts.pool_fee_b.to_account_info(),
+                },
+            },
+        );
+
+        saber_stable_swap::withdraw(
+            withdraw_ctx.with_signer(&[&pool_info_signer_seeds]),
+            // We implicitly rely on the LP tokens being ~ vaults + fees,
+            // otherwise we'd have to calculate the precise LP tokens to withdraw.
+            // As the pool isn't really impacted by oracle changes as it's stable, this is fine.
+            withdraw_a + withdraw_b,
+            0,
+            0,
+        )?;
+
+        let scratch_a_remaining =
+            anchor_spl::token::accessor::amount(&ctx.accounts.scratch_a.to_account_info())?;
+        anchor_spl::token::burn(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::Burn {
+                    mint: ctx.accounts.mint_a.to_account_info(),
+                    from: ctx.accounts.scratch_a.to_account_info(),
+                    authority: ctx.accounts.payer.to_account_info(),
+                },
+            ),
+            scratch_a_remaining,
+        )?;
+        let scratch_b_remaining =
+            anchor_spl::token::accessor::amount(&ctx.accounts.scratch_b.to_account_info())?;
+        anchor_spl::token::burn(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::Burn {
+                    mint: ctx.accounts.mint_b.to_account_info(),
+                    from: ctx.accounts.scratch_b.to_account_info(),
+                    authority: ctx.accounts.payer.to_account_info(),
+                },
+            ),
+            scratch_b_remaining,
+        )?;
+    } else if (deposit_a + deposit_b) > 0 {
+        anchor_spl::token::mint_to(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::MintTo {
+                    mint: ctx.accounts.mint_a.to_account_info(),
+                    to: ctx.accounts.scratch_a.to_account_info(),
+                    authority: ctx.accounts.info_a.to_account_info(),
+                },
+            )
+            .with_signer(&[&token_mint_a_signer_seeds]),
+            deposit_a,
+        )?;
+        anchor_spl::token::mint_to(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::MintTo {
+                    mint: ctx.accounts.mint_b.to_account_info(),
+                    to: ctx.accounts.scratch_b.to_account_info(),
+                    authority: ctx.accounts.info_b.to_account_info(),
+                },
+            )
+            .with_signer(&[&token_mint_b_signer_seeds]),
+            deposit_b,
+        )?;
+
+        let deposit_ctx = CpiContext::new(
+            ctx.accounts.saber_program.to_account_info(),
+            saber_stable_swap::Deposit {
+                user: SwapUserContext {
+                    token_program: ctx.accounts.token_program.to_account_info(),
+                    swap_authority: ctx.accounts.pool_authority.to_account_info(),
+                    user_authority: ctx.accounts.payer.to_account_info(),
+                    swap: ctx.accounts.pool_state.to_account_info(),
+                },
+                input_a: SwapToken {
+                    user: ctx.accounts.scratch_a.to_account_info(),
+                    reserve: ctx.accounts.pool_token_a.to_account_info(),
+                },
+                input_b: SwapToken {
+                    user: ctx.accounts.scratch_b.to_account_info(),
+                    reserve: ctx.accounts.pool_token_b.to_account_info(),
+                },
+                pool_mint: ctx.accounts.pool_mint.to_account_info(),
+                output_lp: ctx.accounts.lp_token.to_account_info(),
+            },
+        );
+
+        saber_stable_swap::deposit(
+            deposit_ctx.with_signer(&[&pool_info_signer_seeds]),
+            deposit_a,
+            deposit_b,
+            1,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn read_price(pyth_price: &AccountInfo) -> Number128 {
+    let price_result = pyth_sdk_solana::load_price_feed_from_account_info(pyth_price).unwrap();
+    let price_value = price_result.get_price_unchecked();
+
+    Number128::from_decimal(price_value.price, price_value.expo)
+}
+
+/// Calculate the number of tokens to deposit or withdraw for a side of the pool.
+/// The tokens returned are expressed as (deposit, withdraw).
+fn calculate_token_change(change: Number128, price: Number128, decimals: u8) -> (u64, u64) {
+    match change {
+        a if a > Number128::ZERO => {
+            let tokens = (change / price).as_u64(-(decimals as i32));
+            if tokens == 0 {
+                (0, 0)
+            } else {
+                (0, tokens)
+            }
+        }
+        a if a == Number128::ZERO => (0, 0),
+        _ => {
+            let tokens =
+                ((change * Number128::from_decimal(-1, 0)) / price).as_u64(-(decimals as i32));
+            if tokens == 0 {
+                (0, 0)
+            } else {
+                (tokens, 0)
+            }
+        }
+    }
+}

--- a/programs/test-service/src/instructions/swaps/saber_swap_pool_create.rs
+++ b/programs/test-service/src/instructions/swaps/saber_swap_pool_create.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Copyright (C) 2022 JET PROTOCOL HOLDINGS, LLC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::BTreeMap;
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::program_pack::Pack;
+use anchor_spl::token::{Mint, Token, TokenAccount};
+use saber_stable_swap::InitToken;
+
+use crate::instructions::TokenRequest;
+use crate::seeds::{
+    SWAP_POOL_FEES, SWAP_POOL_INFO, SWAP_POOL_MINT, SWAP_POOL_STATE, SWAP_POOL_TOKENS,
+};
+use crate::state::{SaberSwapInfo, TokenInfo};
+
+#[derive(AnchorDeserialize, AnchorSerialize, Debug, Clone, Eq, PartialEq)]
+pub struct SaberSwapPoolCreateParams {
+    pub nonce: u8,
+    pub liquidity_level: u8,
+    pub price_threshold: u16,
+}
+
+#[derive(Accounts)]
+pub struct SaberSwapPoolCreate<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+
+    #[account(mut)]
+    mint_a: Box<Account<'info, Mint>>,
+
+    #[account(mut)]
+    mint_b: Box<Account<'info, Mint>>,
+
+    #[account(constraint = info_a.mint == mint_a.key())]
+    info_a: Box<Account<'info, TokenInfo>>,
+
+    #[account(constraint = info_b.mint == mint_b.key())]
+    info_b: Box<Account<'info, TokenInfo>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_INFO,
+                mint_a.key().as_ref(),
+                mint_b.key().as_ref(),
+                // b"saber".as_ref()
+              ],
+              bump,
+              space = 8 + std::mem::size_of::<SaberSwapInfo>(),
+              payer = payer
+    )]
+    pool_info: Box<Account<'info, SaberSwapInfo>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_STATE,
+                mint_a.key().as_ref(),
+                mint_b.key().as_ref(),
+                // b"saber".as_ref(), // TODO: reorder
+              ],
+              bump,
+              space = saber_stable_client::state::SwapInfo::LEN,
+              owner = saber_stable_swap::ID,
+              payer = payer
+    )]
+    pool_state: AccountInfo<'info>,
+
+    #[account(seeds = [pool_state.key().as_ref()],
+              bump,
+              seeds::program = saber_stable_swap::ID
+    )]
+    pool_authority: AccountInfo<'info>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_MINT,
+                pool_state.key().as_ref()
+              ],
+              bump,
+              mint::decimals = mint_a.decimals,
+              mint::authority = pool_authority,
+              payer = payer
+    )]
+    pool_mint: Box<Account<'info, Mint>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_TOKENS,
+                pool_state.key().as_ref(),
+                mint_a.key().as_ref()
+              ],
+              bump,
+              token::mint = mint_a,
+              token::authority = pool_authority,
+              payer = payer,
+    )]
+    pool_token_a: Box<Account<'info, TokenAccount>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_TOKENS,
+                pool_state.key().as_ref(),
+                mint_b.key().as_ref()
+              ],
+              bump,
+              token::mint = mint_b,
+              token::authority = pool_authority,
+              payer = payer,
+    )]
+    pool_token_b: Box<Account<'info, TokenAccount>>,
+
+    #[account(init,
+              seeds = [
+                SWAP_POOL_FEES,
+                pool_state.key().as_ref(),
+                mint_a.key().as_ref()
+              ],
+              bump,
+              token::mint = mint_a,
+              token::authority = pool_authority,
+              payer = payer,
+    )]
+    pool_fee_a: Box<Account<'info, TokenAccount>>,
+
+    #[account(init,
+        seeds = [
+          SWAP_POOL_FEES,
+          pool_state.key().as_ref(),
+          mint_b.key().as_ref()
+        ],
+        bump,
+        token::mint = mint_b,
+        token::authority = pool_authority,
+        payer = payer,
+    )]
+    pool_fee_b: Box<Account<'info, TokenAccount>>,
+
+    #[account(init,
+        seeds = [
+          SWAP_POOL_FEES,
+          pool_state.key().as_ref(),
+          pool_mint.key().as_ref()
+        ],
+        bump,
+        token::mint = pool_mint,
+        token::authority = pool_info,
+        payer = payer,
+    )]
+    lp_destination: Box<Account<'info, TokenAccount>>,
+
+    swap_program: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+    system_program: Program<'info, System>,
+    rent: Sysvar<'info, Rent>,
+}
+
+impl<'info> SaberSwapPoolCreate<'info> {
+    fn request_token_a(&self) -> Result<()> {
+        crate::token_request(
+            Context::new(
+                &crate::ID,
+                &mut TokenRequest {
+                    requester: self.payer.clone(),
+                    mint: (*self.mint_a).clone(),
+                    info: (*self.info_a).clone(),
+                    destination: (*self.pool_token_a).clone(),
+                    token_program: self.token_program.clone(),
+                },
+                &[],
+                BTreeMap::new(),
+            ),
+            1000,
+        )
+    }
+
+    fn request_token_b(&self) -> Result<()> {
+        crate::token_request(
+            Context::new(
+                &crate::ID,
+                &mut TokenRequest {
+                    requester: self.payer.clone(),
+                    mint: (*self.mint_b).clone(),
+                    info: (*self.info_b).clone(),
+                    destination: (*self.pool_token_b).clone(),
+                    token_program: self.token_program.clone(),
+                },
+                &[],
+                BTreeMap::new(),
+            ),
+            1000,
+        )
+    }
+}
+
+pub fn saber_swap_pool_create_handler(
+    ctx: Context<SaberSwapPoolCreate>,
+    params: SaberSwapPoolCreateParams,
+) -> Result<()> {
+    ctx.accounts.request_token_a()?;
+    ctx.accounts.request_token_b()?;
+
+    let pool_info = &mut ctx.accounts.pool_info;
+    pool_info.pool_state = ctx.accounts.pool_state.key();
+    pool_info.liquidity_level = params.liquidity_level;
+    pool_info.price_threshold = params.price_threshold;
+
+    let bump = *ctx.bumps.get("pool_state").unwrap();
+
+    let mint_a_key = ctx.accounts.mint_a.key();
+    let mint_b_key = ctx.accounts.mint_b.key();
+
+    let pool_signer_seeds = [
+        SWAP_POOL_STATE,
+        mint_a_key.as_ref(),
+        mint_b_key.as_ref(),
+        // b"saber".as_ref(), // TODO: don't hardcode
+        &[bump],
+    ];
+    let seeds = [&pool_signer_seeds[..]];
+
+    let swap_context = CpiContext::new_with_signer(
+        ctx.accounts.swap_program.to_account_info(),
+        saber_stable_swap::Initialize {
+            swap: ctx.accounts.pool_state.to_account_info(),
+            swap_authority: ctx.accounts.pool_authority.to_account_info(),
+            admin: ctx.accounts.payer.to_account_info(),
+            token_a: InitToken {
+                reserve: ctx.accounts.pool_token_a.to_account_info(),
+                fees: ctx.accounts.pool_fee_a.to_account_info(),
+                mint: ctx.accounts.mint_a.to_account_info(),
+            },
+            token_b: InitToken {
+                reserve: ctx.accounts.pool_token_b.to_account_info(),
+                fees: ctx.accounts.pool_fee_b.to_account_info(),
+                mint: ctx.accounts.mint_b.to_account_info(),
+            },
+            pool_mint: ctx.accounts.pool_mint.to_account_info(),
+            output_lp: ctx.accounts.lp_destination.to_account_info(),
+            token_program: ctx.accounts.token_program.to_account_info(),
+        },
+        &seeds,
+    );
+
+    saber_stable_swap::initialize(
+        swap_context,
+        bump,
+        100,
+        saber_stable_client::fees::Fees {
+            admin_trade_fee_numerator: 1,
+            admin_trade_fee_denominator: 400,
+            admin_withdraw_fee_numerator: 1,
+            admin_withdraw_fee_denominator: 200,
+            trade_fee_numerator: 1,
+            trade_fee_denominator: 100,
+            withdraw_fee_numerator: 1,
+            withdraw_fee_denominator: 100,
+        },
+    )?;
+
+    Ok(())
+}

--- a/programs/test-service/src/lib.rs
+++ b/programs/test-service/src/lib.rs
@@ -28,7 +28,7 @@ mod util;
 
 use instructions::*;
 
-pub use instructions::{SplSwapPoolCreateParams, TokenCreateParams};
+pub use instructions::{SaberSwapPoolCreateParams, SplSwapPoolCreateParams, TokenCreateParams};
 
 declare_id!("JPTSApMSqCHBww7vDhpaSmzipTV3qPg6vxub4qneKoy");
 
@@ -58,6 +58,9 @@ pub mod seeds {
 
     #[constant]
     pub const SWAP_POOL_TOKENS: &[u8] = b"swap-pool-tokens";
+
+    #[constant]
+    pub const SWAP_POOL_FEES: &[u8] = b"swap-pool-fees";
 }
 
 #[program]
@@ -125,5 +128,13 @@ pub mod jet_test_service {
     /// ensuring multiple initializations will not collide.
     pub fn if_not_initialized(ctx: Context<IfNotInitialized>, instruction: Vec<u8>) -> Result<()> {
         if_not_initialized_handler(ctx, instruction)
+    }
+
+    /// Create a Saber swap pool
+    pub fn saber_swap_pool_create(
+        ctx: Context<SaberSwapPoolCreate>,
+        params: SaberSwapPoolCreateParams,
+    ) -> Result<()> {
+        saber_swap_pool_create_handler(ctx, params)
     }
 }

--- a/programs/test-service/src/lib.rs
+++ b/programs/test-service/src/lib.rs
@@ -137,4 +137,9 @@ pub mod jet_test_service {
     ) -> Result<()> {
         saber_swap_pool_create_handler(ctx, params)
     }
+
+    /// Balance an SPL swap pool based on current oracle prices
+    pub fn saber_swap_pool_balance(ctx: Context<SaberSwapPoolBalance>) -> Result<()> {
+        saber_swap_pool_balance_handler(ctx)
+    }
 }

--- a/programs/test-service/src/state/swaps.rs
+++ b/programs/test-service/src/state/swaps.rs
@@ -26,3 +26,16 @@ pub struct SplSwapInfo {
     /// The allowance of price deviation before the pool may be rebalanced
     pub price_threshold: u16,
 }
+
+/// Information about a Saber swap pool
+#[account]
+pub struct SaberSwapInfo {
+    /// The address of the pool state
+    pub pool_state: Pubkey,
+
+    /// The magnitude of liquidity to provide the pool
+    pub liquidity_level: u8,
+
+    /// The allowance of price deviation before the pool may be rebalanced
+    pub price_threshold: u16,
+}


### PR DESCRIPTION
This has:

* Instructions to create and balance Saber pools on the test service
* Instruction builders
* Old config excludes non-SPL pools
* The oracle mirror also balances Saber pools