### PR TITLE
Modify `TermLoan` to allow calculation of annualized rates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,6 +2713,7 @@ dependencies = [
  "borsh 0.9.3",
  "bytemuck",
  "num-traits",
+ "rand_chacha 0.3.1",
  "solana-program",
  "static_assertions",
  "thiserror",

--- a/libraries/rust/program-common/Cargo.toml
+++ b/libraries/rust/program-common/Cargo.toml
@@ -22,3 +22,6 @@ borsh = "0.9.1"
 num-traits = "0.2"
 anchor-lang = "0.26"
 solana-program = "1.14"
+
+[dev-dependencies]
+rand_chacha = "0.3.1"

--- a/libraries/rust/program-common/src/interest_pricing.rs
+++ b/libraries/rust/program-common/src/interest_pricing.rs
@@ -28,10 +28,9 @@
 
 use std::f64::consts::E;
 
-use jet_program_common::{
+use crate::{
     Number, {Fp32, FP32_ONE},
 };
-use wasm_bindgen::prelude::wasm_bindgen;
 
 const SECONDS_PER_YEAR: u64 = 31_536_000;
 

--- a/libraries/rust/program-common/src/lib.rs
+++ b/libraries/rust/program-common/src/lib.rs
@@ -5,6 +5,7 @@ mod functions;
 mod number;
 mod number_128;
 
+pub mod interest_pricing;
 pub mod serialization;
 pub mod traits;
 

--- a/packages/margin/src/wasm-src/core/orderbook.rs
+++ b/packages/margin/src/wasm-src/core/orderbook.rs
@@ -1,10 +1,10 @@
 use agnostic_orderbook::state::critbit::Slab;
 use bonfida_utils::fp_math::{fp32_div, fp32_mul_ceil, fp32_mul_floor};
 use jet_fixed_term::orderbook::state::{CallbackInfo, OrderTag};
+use jet_program_common::interest_pricing::{f64_to_fp32, fp32_to_f64};
 use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-use crate::orderbook::interest_pricing::{f64_to_fp32, fp32_to_f64};
 use crate::orderbook::methods::price_to_rate;
 
 pub struct OrderbookModel {

--- a/packages/margin/src/wasm-src/orderbook/methods.rs
+++ b/packages/margin/src/wasm-src/orderbook/methods.rs
@@ -1,9 +1,11 @@
 use std::ops::Div;
 
+#[cfg(test)]
+use jet_program_common::interest_pricing::f64_to_fp32;
 use jet_program_common::Fp32;
 use wasm_bindgen::prelude::*;
 
-use super::interest_pricing::{fp32_to_f64, InterestPricer, PricerImpl};
+use jet_program_common::interest_pricing::{fp32_to_f64, InterestPricer, PricerImpl};
 
 /// Given some bytes, reconstruct the u128 order_id and pass it back as a string
 #[wasm_bindgen]
@@ -69,11 +71,7 @@ fn test_price_to_rate() {
 #[test]
 fn test_price_to_rate_2() {
     assert_eq!(
-        price_to_rate(
-            crate::orderbook::interest_pricing::f64_to_fp32(0.9980840295893417),
-            154828800
-        ) as f64
-            / 10_000_f64,
+        price_to_rate(f64_to_fp32(0.9980840295893417), 154828800) as f64 / 10_000_f64,
         0.0004
     );
 }
@@ -123,10 +121,7 @@ fn test_calculate_implied_price() {
         ((7834 * 10_000_000_000 / 23454) << 32) / 10_000_000_000
     );
 
-    assert_eq!(
-        calculate_implied_price(345, 3464),
-        crate::orderbook::interest_pricing::f64_to_fp32(10.04057971),
-    );
+    assert_eq!(calculate_implied_price(345, 3464), f64_to_fp32(10.04057971),);
 }
 
 /// This is meant to ensure that the api is using the PricerImpl type alias,

--- a/packages/margin/src/wasm-src/orderbook/mod.rs
+++ b/packages/margin/src/wasm-src/orderbook/mod.rs
@@ -1,4 +1,3 @@
-pub mod interest_pricing;
 pub mod methods;
 
 #[cfg(feature = "testing")]

--- a/programs/fixed-term/src/margin/instructions/margin_borrow_order.rs
+++ b/programs/fixed-term/src/margin/instructions/margin_borrow_order.rs
@@ -120,7 +120,8 @@ pub fn handler(ctx: Context<MarginBorrowOrder>, mut params: OrderParams) -> Resu
     debt.post_borrow_order(order_summary.base_posted())?;
     if order_summary.base_filled() > 0 {
         let manager = ctx.accounts.orderbook_mut.market.load()?;
-        let maturation_timestamp = manager.borrow_tenor as i64 + Clock::get()?.unix_timestamp;
+        let current_time = Clock::get()?.unix_timestamp;
+        let maturation_timestamp = manager.borrow_tenor as i64 + current_time;
         let sequence_number =
             debt.new_term_loan_without_posting(order_summary.base_filled(), maturation_timestamp)?;
 
@@ -151,6 +152,9 @@ pub fn handler(ctx: Context<MarginBorrowOrder>, mut params: OrderParams) -> Resu
             payer: ctx.accounts.payer.key(),
             order_tag: callback_info.order_tag,
             maturation_timestamp,
+            strike_timestamp: current_time,
+            principal: quote_filled,
+            interest: base_filled.safe_sub(quote_filled)?,
             balance: base_filled,
             flags: TermLoanFlags::default(),
         };

--- a/programs/fixed-term/src/margin/state.rs
+++ b/programs/fixed-term/src/margin/state.rs
@@ -3,7 +3,11 @@ use std::ops::Range;
 use anchor_lang::{prelude::*, solana_program::clock::UnixTimestamp};
 use bytemuck::Zeroable;
 use jet_margin::{AdapterResult, MarginAccount};
-use jet_program_common::traits::{SafeAdd, TryAddAssign, TrySubAssign};
+use jet_program_common::{
+    interest_pricing::{InterestPricer, PricerImpl},
+    traits::{SafeAdd, SafeSub, TryAddAssign, TrySubAssign},
+    Fp32,
+};
 
 use crate::{
     events::{AssetsUpdated, DebtUpdated},
@@ -335,11 +339,41 @@ pub struct TermLoan {
     /// The time that the term loan must be repaid
     pub maturation_timestamp: UnixTimestamp,
 
-    /// The remaining amount due by the end of the loan term
+    /// The slot at which the term loan was struck
+    pub strike_timestamp: UnixTimestamp,
+
+    /// The total principal of the loan
+    pub principal: u64,
+
+    /// The total interest owed on the loan
+    pub interest: u64,
+
+    /// The remaining balance to repay
     pub balance: u64,
 
     /// Any boolean flags for this data type compressed to a single byte
     pub flags: TermLoanFlags,
+}
+
+impl TermLoan {
+    /// The annualized interest rate for this loan
+    pub fn rate(&self) -> Result<u64> {
+        let tenor = self.tenor()? as u64;
+        let price = {
+            let base = self.principal.safe_add(self.interest)?;
+            let quote = self.principal;
+            let price = Fp32::from(base) / quote;
+            price
+                .downcast_u64()
+                .ok_or_else(|| error!(FixedTermErrorCode::FixedPointDivision))
+        }?;
+        Ok(PricerImpl::price_fp32_to_bps_yearly_interest(price, tenor))
+    }
+
+    /// Determines the loan tenor
+    pub fn tenor(&self) -> Result<UnixTimestamp> {
+        self.maturation_timestamp.safe_sub(self.strike_timestamp)
+    }
 }
 
 bitflags! {

--- a/programs/fixed-term/src/margin/state.rs
+++ b/programs/fixed-term/src/margin/state.rs
@@ -370,7 +370,7 @@ impl TermLoan {
     /// a fp32 value
     pub fn price(&self) -> Result<Fp32> {
         let base = self.principal.safe_add(self.interest)?;
-        Ok(Fp32::from(base) / self.principal)
+        Ok(Fp32::from(self.principal) / base)
     }
 
     /// Determines the loan tenor

--- a/programs/fixed-term/src/orderbook/state/mod.rs
+++ b/programs/fixed-term/src/orderbook/state/mod.rs
@@ -581,6 +581,12 @@ pub struct SensibleOrderSummary {
 // fixme i think most of these are wrong. there may be issues with the aaob
 // implementation which is a huge mess of spaghetti code
 impl SensibleOrderSummary {
+    pub fn new(limit_price: u64, order_summary: OrderSummary) -> Self {
+        Self {
+            limit_price,
+            summary: order_summary,
+        }
+    }
     pub fn summary(&self) -> OrderSummary {
         OrderSummary {
             posted_order_id: self.summary.posted_order_id,

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -1024,6 +1024,17 @@ impl<P: Proxy> FixedTermUser<P> {
             .await
     }
 
+    pub async fn get_active_term_loans(&self) -> Result<Vec<TermLoan>> {
+        let mut loans = vec![];
+
+        let user = self.load_margin_user().await?;
+        for seqno in user.debt.active_loans() {
+            loans.push(self.load_term_loan(seqno).await?);
+        }
+
+        Ok(loans)
+    }
+
     pub async fn load_anchor<T: AccountDeserialize>(&self, key: &Pubkey) -> Result<T> {
         let data = self
             .client

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -585,6 +585,26 @@ impl TestManager {
             )
             .map_err(anyhow::Error::new)
     }
+
+    pub async fn simulate_new_order_with_fees(
+        &self,
+        mut params: OrderParams,
+        side: agnostic_orderbook::state::Side,
+    ) -> Result<OrderSummary> {
+        let mut eq = self.load_event_queue().await?;
+        let mut orderbook = self.load_orderbook().await?;
+        let market = self.load_market().await?;
+        params.max_ticket_qty = market.borrow_order_qty(params.max_ticket_qty);
+        params.max_underlying_token_qty = market.borrow_order_qty(params.max_underlying_token_qty);
+        orderbook
+            .inner()?
+            .new_order(
+                params.as_new_order_params(side, CallbackInfo::default()),
+                &mut eq.inner()?,
+                MIN_ORDER_SIZE,
+            )
+            .map_err(anyhow::Error::new)
+    }
 }
 
 #[derive(Clone)]

--- a/tests/hosted/tests/fixed_term.rs
+++ b/tests/hosted/tests/fixed_term.rs
@@ -13,7 +13,7 @@ use hosted_tests::{
 };
 use jet_fixed_term::{
     margin::{instructions::MarketSide, state::AutoRollConfig},
-    orderbook::state::{CallbackFlags, MarginCallbackInfo, OrderParams},
+    orderbook::state::{CallbackFlags, MarginCallbackInfo, OrderParams, SensibleOrderSummary},
 };
 use jet_margin_sdk::{
     cat,
@@ -774,6 +774,9 @@ async fn margin_lend_then_margin_borrow() -> Result<()> {
     assert_eq!(0, lender.claims().await?);
 
     let borrow_params = underlying(1_000, 2_000);
+    let simulated_order = manager
+        .simulate_new_order_with_fees(borrow_params, agnostic_orderbook::state::Side::Ask)
+        .await?;
     vec![
         pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
         pricer
@@ -800,14 +803,21 @@ async fn margin_lend_then_margin_borrow() -> Result<()> {
     // FIXME: an exact number would be nice
     assert!(manager.collected_fees().await? > 0);
 
-    let loan = borrower.get_active_term_loans().await?[0].clone();
-    let expected_price = lend_params.limit_price;
+    let loan = borrower.load_term_loan(0).await?;
     let expected_tenor = manager.load_market().await?.borrow_tenor;
+    // FIXME
+    // to avoid subtle rounding issues, we calculate expected price manually, this is not as good as
+    // using the limit price of the order directly
+    let expected_price = {
+        let summary = SensibleOrderSummary::new(borrow_params.limit_price, simulated_order);
+        let price = Fp32::from(summary.quote_filled()?) / summary.base_filled();
+        price.downcast_u64().unwrap()
+    };
     let expected_rate =
         PricerImpl::price_fp32_to_bps_yearly_interest(expected_price, expected_tenor);
 
-    assert_eq!(loan.price()?.downcast_u64().unwrap(), expected_price);
     assert_eq!(loan.tenor()?, expected_tenor);
+    assert_eq!(loan.price()?.downcast_u64().unwrap(), expected_price);
     assert_eq!(loan.rate()?, expected_rate);
 
     manager.consume_events().await?;


### PR DESCRIPTION
Adds some fields to allow determination of the rate from only the `TermLoan` with no additional information. To accomplish this, because we allow users to incrementally repay the loan, I had to add `principal` and `interest` fields on top of the already extant `balance` field. I also added a `strike_timestamp` that specifies the moment at which the loan was minted, both in order to calculate tenor without downloading the market, as well as to provide information that may be useful. As these accounts are fairly transitory and rent gets returned, I figure the extra space should not be much of a burden.