### PR TITLE
test improvements

### DIFF
--- a/tests/hosted/src/context.rs
+++ b/tests/hosted/src/context.rs
@@ -22,7 +22,7 @@ use jet_instructions::margin::MarginConfigIxBuilder;
 use jet_instructions::test_service::{
     derive_pyth_price, derive_token_mint, token_update_pyth_price,
 };
-use jet_margin_pool::{MarginPoolConfig, PoolFlags};
+use jet_margin_pool::MarginPoolConfig;
 use jet_margin_sdk::ix_builder::test_service::derive_spl_swap_pool;
 use jet_margin_sdk::solana::keypair::clone;
 use jet_margin_sdk::solana::transaction::{
@@ -34,10 +34,14 @@ use jet_metadata::TokenKind;
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
 use jet_solana_client::{NetworkUserInterface, NetworkUserInterfaceExt};
 
+use crate::environment::TestToken;
 use crate::margin::MarginUser;
 use crate::runtime::SolanaTestContext;
+use crate::TestDefault;
 use crate::{margin::MarginClient, tokens::TokenManager};
 
+/// Instantiate an Arc<MarginTestContext>
+///
 /// If you don't provide a name, gets the name of the current function name and
 /// uses it to create a test context. Only use this way when called directly in
 /// the test function. If you want to call this in a helper function, pass a
@@ -45,7 +49,7 @@ use crate::{margin::MarginClient, tokens::TokenManager};
 #[macro_export]
 macro_rules! margin_test_context {
     () => {
-        $crate::margin_test_context!($crate::fn_name!())
+        $crate::margin_test_context!(&$crate::fn_name_and_try_num!())
     };
     ($name:expr) => {
         std::sync::Arc::new(
@@ -53,6 +57,46 @@ macro_rules! margin_test_context {
                 .await
                 .unwrap(),
         )
+    };
+}
+
+/// Instantiate a TestContext  
+/// Uses struct-like syntax. Fields may be omitted to use the default.
+/// ```ignore
+/// let ctx = test_context! {
+///     name: String,
+///     setup: &TestContextSetupInfo,
+/// };
+/// let ctx = test_context!();
+/// ```
+/// - name: Default gets the name of the current function name and uses it to
+///         create a test context. Only use this way when called directly in the
+///         test function. If you want to call this in a helper function, pass a
+///         name to the helper function that is unique to the individual test
+///         that called the helper function.
+///
+/// - setup: see the TestDefault implementation.
+#[macro_export]
+macro_rules! test_context {
+    () => {
+        $crate::context::TestContext::new(&$crate::fn_name_and_try_num!(), &$crate::test_default())
+            .await
+            .unwrap()
+    };
+    (name: $name:expr$(,)?) => {
+        $crate::context::TestContext::new(&name, &$crate::test_default())
+            .await
+            .unwrap()
+    };
+    (setup: $setup:expr$(,)?) => {
+        $crate::context::TestContext::new(&$crate::fn_name_and_try_num!(), setup)
+            .await
+            .unwrap()
+    };
+    (name: $name:expr, setup: $setup:expr$(,)?) => {
+        $crate::context::TestContext::new($name, $setup)
+            .await
+            .unwrap()
     };
 }
 
@@ -65,6 +109,8 @@ pub struct MarginPoolSetupInfo {
 }
 
 /// Utilities for testing things in the context of the margin system
+/// Sets up a barebones test environment that only initializes a blank airspace.
+/// Facilitates individual tests to set up their own state.
 pub struct MarginTestContext {
     pub rpc: Arc<dyn SolanaRpcClient>,
     pub tokens: TokenManager,
@@ -167,6 +213,8 @@ impl MarginTestContext {
     }
 }
 
+/// Sets up a comprehensive test environment with tokens, pools, markets, etc.
+/// as defined by the provided configuration.
 pub struct TestContext {
     pub config: JetAppConfig,
     inner: SolanaTestContext,
@@ -174,15 +222,10 @@ pub struct TestContext {
 
 impl TestContext {
     pub async fn new(name: &str, setup: &TestContextSetupInfo) -> Result<Self, Error> {
-        let mut seed = match cfg!(feature = "localnet") {
-            false => name.to_owned(),
-            true => format!("{name}_{}", rand::random::<u16>()),
-        };
-
-        seed.drain(0..seed.len().saturating_sub(24));
-
-        let inner = SolanaTestContext::new(&seed).await;
-        let setup_config = setup.to_config(&seed);
+        let inner = SolanaTestContext::new(name).await;
+        let mut airspace_name = name.to_owned();
+        airspace_name.drain(0..airspace_name.len().saturating_sub(24));
+        let setup_config = setup.to_config(&airspace_name);
 
         let init_env_config = EnvironmentConfig {
             network: NetworkKind::Localnet,
@@ -200,7 +243,7 @@ impl TestContext {
                 })
                 .collect(),
             airspaces: vec![AirspaceConfig {
-                name: seed.to_string(),
+                name: airspace_name.to_string(),
                 is_restricted: setup.is_restricted,
                 tokens: setup_config.tokens.clone(),
                 cranks: vec![],
@@ -301,52 +344,24 @@ pub struct PriceUpdate {
     pub exponent: i32,
 }
 
-pub const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
-    borrow_rate_0: 10,
-    borrow_rate_1: 20,
-    borrow_rate_2: 30,
-    borrow_rate_3: 40,
-    utilization_rate_1: 10,
-    utilization_rate_2: 20,
-    management_fee_rate: 10,
-    flags: PoolFlags::ALLOW_LENDING.bits(),
-    reserved: 0,
-};
-
-pub fn default_test_setup() -> TestContextSetupInfo {
-    TestContextSetupInfo {
-        is_restricted: false,
-        tokens: vec![
-            TokenDescription {
-                name: "TSOL".to_string(),
-                symbol: "TSOL".to_string(),
-                decimals: Some(9),
-                collateral_weight: 100,
-                max_leverage: 20_00,
-                margin_pool: Some(DEFAULT_POOL_CONFIG),
-                fixed_term_markets: vec![],
-                ..Default::default()
-            },
-            TokenDescription {
-                name: "USDC".to_string(),
-                symbol: "".to_string(),
-                decimals: Some(6),
-                collateral_weight: 100,
-                max_leverage: 20_00,
-                margin_pool: Some(DEFAULT_POOL_CONFIG),
-                fixed_term_markets: vec![],
-                ..Default::default()
-            },
-        ],
-        spl_swap_pools: vec!["TSOL/USDC"],
-    }
-}
-
 #[derive(Default, Clone)]
 pub struct TestContextSetupInfo {
     pub is_restricted: bool,
     pub tokens: Vec<TokenDescription>,
     pub spl_swap_pools: Vec<&'static str>,
+}
+
+impl TestDefault for TestContextSetupInfo {
+    fn test_default() -> Self {
+        TestContextSetupInfo {
+            is_restricted: false,
+            tokens: vec![
+                TestToken::with_pool("TSOL").into(),
+                TestToken::with_pool("USDC").into(),
+            ],
+            spl_swap_pools: vec!["TSOL/USDC"],
+        }
+    }
 }
 
 struct SetupOutput {
@@ -356,13 +371,13 @@ struct SetupOutput {
 }
 
 impl TestContextSetupInfo {
-    fn to_config(&self, seed: &str) -> SetupOutput {
-        let airspace = derive_airspace(seed);
+    fn to_config(&self, airspace_name: &str) -> SetupOutput {
+        let airspace = derive_airspace(airspace_name);
         let tokens = self
             .tokens
             .iter()
             .map(|t| TokenDescription {
-                name: format!("{seed}-{}", &t.name),
+                name: format!("{airspace_name}-{}", &t.name),
                 ..t.clone()
             })
             .collect::<Vec<_>>();
@@ -372,8 +387,8 @@ impl TestContextSetupInfo {
             .iter()
             .map(|pair_string| {
                 let (name_a, name_b) = pair_string.split_once('/').unwrap();
-                let token_a_name = format!("{seed}-{name_a}");
-                let token_b_name = format!("{seed}-{name_b}");
+                let token_a_name = format!("{airspace_name}-{name_a}");
+                let token_b_name = format!("{airspace_name}-{name_b}");
 
                 (token_a_name, token_b_name)
             })
@@ -395,7 +410,7 @@ impl TestContextSetupInfo {
                 })
                 .collect(),
             airspaces: vec![AirspaceInfo {
-                name: seed.to_string(),
+                name: airspace_name.to_string(),
                 tokens: tokens.iter().map(|t| t.name.clone()).collect(),
                 fixed_term_markets: tokens
                     .iter()

--- a/tests/hosted/src/environment.rs
+++ b/tests/hosted/src/environment.rs
@@ -1,0 +1,119 @@
+//! Test helpers for the `environment` crate.  
+//! Defines sane defaults that can be used by most tests.
+
+use jet_environment::config::{FixedTermMarketConfig, TokenDescription};
+use jet_margin_pool::{MarginPoolConfig, PoolFlags};
+
+use crate::{test_default, TestDefault};
+
+/// High level token definition to simplify test setup when you only care about:
+/// - token name
+/// - whether there is a lending pool
+/// - tenors for any fixed term markets, if any
+///
+/// Easily converted into a TokenDescription for use with TestContext.
+///
+/// If you have more complex requirements for your test, you may want to
+/// manually create the TokenDescriptions with assistance from the
+/// `test_default()` function to fill in the fields you don't care about.
+#[derive(Clone)]
+pub struct TestToken {
+    pub name: String,
+    pub margin_pool: bool,
+    pub fixed_term_tenors: Vec<u64>,
+}
+
+impl From<TestToken> for TokenDescription {
+    fn from(value: TestToken) -> Self {
+        TokenDescription {
+            symbol: value.name.clone(),
+            name: value.name,
+            margin_pool: value.margin_pool.then_some(test_default()),
+            fixed_term_markets: value
+                .fixed_term_tenors
+                .into_iter()
+                .map(|tenor| FixedTermMarketConfig {
+                    borrow_tenor: tenor,
+                    lend_tenor: tenor,
+                    ..test_default()
+                })
+                .collect(),
+            ..test_default()
+        }
+    }
+}
+
+impl TestToken {
+    /// just a token - no pool or fixed term
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            margin_pool: false,
+            fixed_term_tenors: vec![],
+        }
+    }
+
+    /// token with a pool - no fixed term
+    pub fn with_pool(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            margin_pool: true,
+            fixed_term_tenors: vec![],
+        }
+    }
+
+    pub fn description(self) -> TokenDescription {
+        self.into()
+    }
+}
+
+impl TestDefault for FixedTermMarketConfig {
+    fn test_default() -> Self {
+        FixedTermMarketConfig {
+            borrow_tenor: 3600,
+            lend_tenor: 3600,
+            origination_fee: 0,
+            min_order_size: 100,
+            paused: false,
+            ticket_price: Some(0.9),
+            ticket_collateral_weight: 90,
+            ticket_pyth_price: None,
+            ticket_pyth_product: None,
+        }
+    }
+}
+
+impl TestDefault for MarginPoolConfig {
+    fn test_default() -> Self {
+        MarginPoolConfig {
+            borrow_rate_0: 10,
+            borrow_rate_1: 20,
+            borrow_rate_2: 30,
+            borrow_rate_3: 40,
+            utilization_rate_1: 10,
+            utilization_rate_2: 20,
+            management_fee_rate: 10,
+            flags: PoolFlags::ALLOW_LENDING.bits(),
+            reserved: 0,
+        }
+    }
+}
+
+impl TestDefault for TokenDescription {
+    fn test_default() -> Self {
+        TokenDescription {
+            name: String::from("Default"),
+            symbol: String::from("Default"),
+            decimals: Some(6),
+            precision: 6,
+            mint: None,
+            pyth_price: None,
+            pyth_product: None,
+            max_test_amount: None,
+            collateral_weight: 100,
+            max_leverage: 20_00,
+            margin_pool: None,
+            fixed_term_markets: vec![],
+        }
+    }
+}

--- a/tests/hosted/src/lib.rs
+++ b/tests/hosted/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod actions;
 pub mod context;
+pub mod environment;
 pub mod fixed_term;
 pub mod load;
 pub mod margin;
@@ -12,3 +13,12 @@ pub mod spl_swap;
 pub mod test_user;
 pub mod tokens;
 pub mod util;
+
+pub fn test_default<T: TestDefault>() -> T {
+    TestDefault::test_default()
+}
+
+/// Sane defaults that can be used for fields you don't care about.
+pub trait TestDefault {
+    fn test_default() -> Self;
+}

--- a/tests/hosted/tests/client_fixed_term.rs
+++ b/tests/hosted/tests/client_fixed_term.rs
@@ -1,15 +1,15 @@
 use std::time::SystemTime;
 
+use hosted_tests::environment::TestToken;
 use hosted_tests::util::assert_program_error;
 use jet_client::fixed_term::MarketInfo;
 
 use jet_client::margin::MarginAccountClient;
 use jet_client_native::{JetSimulationClient, SimulationClient};
-use jet_environment::config::{FixedTermMarketConfig, TokenDescription};
 use jet_instructions::fixed_term::derive;
 
 use hosted_tests::actions::*;
-use hosted_tests::context::{TestContext, TestContextSetupInfo, DEFAULT_POOL_CONFIG};
+use hosted_tests::context::{TestContext, TestContextSetupInfo};
 
 type MarginSimulationClient = MarginAccountClient<SimulationClient>;
 
@@ -26,36 +26,13 @@ async fn setup_context(name: &str, tenor: u64) -> TestEnv {
     let setup_config = TestContextSetupInfo {
         is_restricted: false,
         tokens: vec![
-            TokenDescription {
-                name: "TSOL".to_string(),
-                symbol: "TSOL".to_string(),
-                decimals: Some(9),
-                collateral_weight: 100,
-                max_leverage: 20_00,
-                margin_pool: Some(DEFAULT_POOL_CONFIG),
-                fixed_term_markets: vec![],
-                ..Default::default()
-            },
-            TokenDescription {
+            TestToken::new("TSOL").into(),
+            TestToken {
                 name: "USDC".to_string(),
-                symbol: "".to_string(),
-                decimals: Some(6),
-                collateral_weight: 100,
-                max_leverage: 20_00,
-                margin_pool: Some(DEFAULT_POOL_CONFIG),
-                fixed_term_markets: vec![FixedTermMarketConfig {
-                    borrow_tenor: tenor,
-                    lend_tenor: tenor,
-                    origination_fee: 0,
-                    min_order_size: 1_000_000,
-                    paused: false,
-                    ticket_price: Some(0.9),
-                    ticket_collateral_weight: 90,
-                    ticket_pyth_price: None,
-                    ticket_pyth_product: None,
-                }],
-                ..Default::default()
-            },
+                margin_pool: true,
+                fixed_term_tenors: vec![tenor],
+            }
+            .into(),
         ],
         spl_swap_pools: vec!["TSOL/USDC"],
     };
@@ -115,7 +92,7 @@ async fn setup_context(name: &str, tenor: u64) -> TestEnv {
 
 macro_rules! setup_context {
     ($tenor:expr) => {{
-        let name = format!("{}_{}", module_path!(), line!());
+        let name = hosted_tests::fn_name_and_try_num!();
         setup_context(&name, $tenor).await
     }};
 }

--- a/tests/hosted/tests/liquidate_with_swap.rs
+++ b/tests/hosted/tests/liquidate_with_swap.rs
@@ -16,9 +16,10 @@ use jet_margin_pool::TokenChange;
 /// it isn't using the scenario in that file and instead uses these helper
 /// methods to do additional and more generic setup, plus executes an actual
 /// swap, which the other liquidate tests are not equipped to do.
-#[cfg(not(feature = "localnet"))]
-// Note: this requires a lookup table to run on localnet as the transaction is otherwise too large
+///
+/// Note: this requires a lookup table to run on localnet as the transaction is otherwise too large
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(feature = "localnet", ignore = "does not run on localnet")]
 async fn liquidate_with_swap() -> Result<()> {
     let ctx = margin_test_context!();
     let ([usdc, sol], swaps, pricer) = tokens(&ctx).await.unwrap();

--- a/tests/hosted/tests/pools.rs
+++ b/tests/hosted/tests/pools.rs
@@ -1,15 +1,9 @@
-use hosted_tests::{
-    actions::*,
-    context::{default_test_setup, TestContext},
-    util::assert_program_error,
-};
+use hosted_tests::{actions::*, test_context, util::assert_program_error};
 use jet_client::state::margin_pool::MarginPoolCacheExt;
 
 #[tokio::test]
 async fn simple_pool_lend_borrow_workflow() -> anyhow::Result<()> {
-    let ctx = TestContext::new("simple-pool-lend-borrow", &default_test_setup())
-        .await
-        .unwrap();
+    let ctx = test_context!();
 
     // derive mints for default config tokens
     let usdc = Token::from_context(&ctx, "USDC");
@@ -107,9 +101,7 @@ async fn simple_pool_lend_borrow_workflow() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn max_pool_util_ratio_after_borrow() -> anyhow::Result<()> {
-    let ctx = TestContext::new("max-pool-util-ratio-after-borrow", &default_test_setup())
-        .await
-        .unwrap();
+    let ctx = test_context!();
 
     // derive mints for default config tokens
     let usdc = Token::from_context(&ctx, "USDC");

--- a/tests/hosted/tests/route_swap.rs
+++ b/tests/hosted/tests/route_swap.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(feature = "localnet"), allow(unused))]
-
 use std::{collections::HashSet, num::NonZeroU64, sync::Arc, time::Duration};
 
 use anchor_lang::Id;
@@ -132,7 +130,6 @@ async fn setup_environment(ctx: &MarginTestContext) -> Result<TestEnv, Error> {
 }
 
 async fn setup_swap_accounts<'a>(
-    ctx: &Arc<MarginTestContext>,
     pool: &impl SwapAccounts,
     margin_user: &MarginUser,
 ) -> anyhow::Result<()> {
@@ -150,7 +147,7 @@ async fn setup_swap_accounts<'a>(
     }
 }
 
-#[cfg(feature = "localnet")]
+#[cfg_attr(not(feature = "localnet"), ignore = "only runs on localnet")]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn route_swap() -> anyhow::Result<()> {
@@ -416,8 +413,8 @@ async fn single_leg_swap_margin(
     let user_b = ctx.margin.user(&wallet_b, 0).created().await?;
 
     // Perform any setup required based on pool type (e.g. create open_orders)
-    setup_swap_accounts(ctx, &pool, &user_a).await?;
-    setup_swap_accounts(ctx, &pool, &user_b).await?;
+    setup_swap_accounts(&pool, &user_a).await?;
+    setup_swap_accounts(&pool, &user_b).await?;
 
     let user_a_msol_account = ctx
         .tokens
@@ -528,7 +525,7 @@ async fn single_leg_swap(
     let user_a = ctx.margin.user(&wallet_a, 0).created().await?;
 
     // Perform any setup required based on pool type (e.g. create open_orders)
-    setup_swap_accounts(ctx, &pool, &user_a).await?;
+    setup_swap_accounts(&pool, &user_a).await?;
 
     ctx.tokens
         .set_price(
@@ -590,7 +587,7 @@ async fn single_leg_swap(
 
 // The tests create duplicate accounts, causing failures in localnet.
 // They are however useful for coverage and testing logic, so we run them on the sim.
-#[cfg(not(feature = "localnet"))]
+#[cfg_attr(feature = "localnet", ignore = "does not run on localnet")]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn route_spl_swap() -> anyhow::Result<()> {
@@ -630,7 +627,7 @@ async fn route_spl_swap() -> anyhow::Result<()> {
 
 // The tests create duplicate accounts, causing failures in localnet.
 // They are however useful for coverage and testing logic, so we run them on the sim.
-#[cfg(not(feature = "localnet"))]
+#[cfg_attr(feature = "localnet", ignore = "does not run on localnet")]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn route_saber_swap() -> anyhow::Result<()> {
@@ -665,7 +662,7 @@ async fn route_saber_swap() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "localnet"))]
+#[cfg_attr(feature = "localnet", ignore = "does not run on localnet")]
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn route_openbook_swap() -> anyhow::Result<()> {

--- a/tests/hosted/tests/swap.rs
+++ b/tests/hosted/tests/swap.rs
@@ -11,8 +11,8 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 
 use hosted_tests::{
-    context::MarginTestContext, fn_name, margin::MarginPoolSetupInfo, margin_test_context,
-    spl_swap::SwapPoolConfig,
+    context::MarginTestContext, fn_name_and_try_num, margin::MarginPoolSetupInfo,
+    margin_test_context, spl_swap::SwapPoolConfig,
 };
 
 use jet_margin::TokenKind;
@@ -38,7 +38,7 @@ const DEFAULT_POOL_CONFIG: MarginPoolConfig = MarginPoolConfig {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn spl_swap_v2() -> Result<(), anyhow::Error> {
-    let result = swap_test_impl(fn_name!(), spl_token_swap_v2::id()).await;
+    let result = swap_test_impl(&fn_name_and_try_num!(), spl_token_swap_v2::id()).await;
     println!("{:#?}", &result);
 
     result
@@ -48,14 +48,14 @@ async fn spl_swap_v2() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn orca_swap_v1() -> Result<(), anyhow::Error> {
-    swap_test_impl(fn_name!(), orca_swap_v1::id()).await
+    swap_test_impl(&fn_name_and_try_num!(), orca_swap_v1::id()).await
 }
 
 /// Test token swaps for orca v2
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
 async fn orca_swap_v2() -> Result<(), anyhow::Error> {
-    swap_test_impl(fn_name!(), orca_swap_v2::id()).await
+    swap_test_impl(&fn_name_and_try_num!(), orca_swap_v2::id()).await
 }
 
 struct TestEnv {


### PR DESCRIPTION
- better namespacing for test contexts that is safe across retries
- use deterministic keygen in localnet tests
- better hash for deterministic keygen
- helpers for default inputs to TestContext to reduce boilerplate
- less selective compilation for localnet/simulation so all the code is checked properly every time. this gets rid of lint warnings when running localnet tests