### PR TITLE
make repo vendorable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tests/oracle-mirror.pid
 .terraform*
 *.tgz
 target
+vendor
 **/*.rs.bk
 node_modules
 lcov.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
-name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
@@ -631,16 +625,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b13fa9bf62be34702e5ee4526aff22530ae22fe34a0c4290d30d5e4e782e6"
 dependencies = [
  "borsh-derive 0.7.2",
-]
-
-[[package]]
-name = "borsh"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a7111f797cc721407885a323fb071636aee57f750b1a4ddc27397eba168a74"
-dependencies = [
- "borsh-derive 0.8.2",
- "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -1941,20 +1925,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.7",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
 ]
 
 [[package]]
@@ -1963,7 +1938,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
 ]
 
 [[package]]
@@ -2478,7 +2453,6 @@ dependencies = [
  "solana-sdk",
  "spl-governance",
  "spl-token 3.5.0",
- "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "toml 0.5.11",
 ]
@@ -2493,6 +2467,7 @@ dependencies = [
  "jet-margin-pool",
  "jet-metadata",
  "jet-solana-client",
+ "jet-static-program-registry",
  "log",
  "serde",
  "serde_json",
@@ -2501,7 +2476,6 @@ dependencies = [
  "spl-associated-token-account",
  "spl-governance",
  "spl-token 3.5.0",
- "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "toml 0.5.11",
 ]
@@ -2576,7 +2550,6 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-token 3.5.0",
- "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -2657,7 +2630,6 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account",
  "spl-token 3.5.0",
- "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable-swap-client",
  "thiserror",
  "tokio",
@@ -2705,7 +2677,6 @@ dependencies = [
  "solana-client",
  "solana-sdk",
  "spl-token 3.5.0",
- "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 
@@ -2783,8 +2754,7 @@ dependencies = [
  "anchor-lang",
  "paste",
  "spl-token-swap 0.1.0",
- "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-swap 2.1.0 (git+https://github.com/solana-labs/solana-program-library?rev=813aa3304022528cbf3cf7a3d32bca339194a492)",
+ "spl-token-swap 2.1.0",
 ]
 
 [[package]]
@@ -2795,8 +2765,8 @@ dependencies = [
  "anchor-spl",
  "bytemuck",
  "jet-program-common",
+ "jet-static-program-registry",
  "pyth-sdk-solana 0.7.0",
- "spl-token-swap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable-swap-anchor",
  "stable-swap-client",
 ]
@@ -4886,7 +4856,7 @@ version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44a019070a6cec4d3ad8605c5caa65bdaa13f00b5f1849340f44ffea63b625b"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
  "blake3",
  "block-buffer 0.9.0",
  "bs58 0.4.0",
@@ -4989,7 +4959,7 @@ version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc742f8d53f0a6e6f3a27ed11c1d0764b5486813c721d625c56094fcd14e984"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
  "bincode",
  "bv",
  "caps",
@@ -5557,20 +5527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-math"
-version = "0.1.0"
-source = "git+https://github.com/solana-labs/solana-program-library?rev=813aa3304022528cbf3cf7a3d32bca339194a492#813aa3304022528cbf3cf7a3d32bca339194a492"
-dependencies = [
- "borsh 0.8.2",
- "borsh-derive 0.8.2",
- "num-derive",
- "num-traits",
- "solana-program",
- "thiserror",
- "uint 0.8.5",
-]
-
-[[package]]
 name = "spl-memo"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "spl-token"
 version = "3.1.1"
-source = "git+https://github.com/solana-labs/solana-program-library?rev=813aa3304022528cbf3cf7a3d32bca339194a492#813aa3304022528cbf3cf7a3d32bca339194a492"
+source = "git+https://github.com/jet-lab/solana-program-library?rev=629a8d5524944b1c0b33651db72d3da64ed04bac#629a8d5524944b1c0b33651db72d3da64ed04bac"
 dependencies = [
  "arrayref",
  "num-derive",
@@ -5669,30 +5625,14 @@ dependencies = [
 [[package]]
 name = "spl-token-swap"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63b79be6174568e8724912b15e62d0c6b0424ac98397e9a5a867ac2881553af"
+source = "git+https://github.com/jet-lab/solana-program-library?rev=629a8d5524944b1c0b33651db72d3da64ed04bac#629a8d5524944b1c0b33651db72d3da64ed04bac"
 dependencies = [
  "arrayref",
  "enum_dispatch",
  "num-derive",
  "num-traits",
  "solana-program",
- "spl-math 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 3.5.0",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-swap"
-version = "2.1.0"
-source = "git+https://github.com/solana-labs/solana-program-library?rev=813aa3304022528cbf3cf7a3d32bca339194a492#813aa3304022528cbf3cf7a3d32bca339194a492"
-dependencies = [
- "arrayref",
- "enum_dispatch",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-math 0.1.0 (git+https://github.com/solana-labs/solana-program-library?rev=813aa3304022528cbf3cf7a3d32bca339194a492)",
+ "spl-math",
  "spl-token 3.1.1",
  "thiserror",
 ]
@@ -5708,7 +5648,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "solana-program",
- "spl-math 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-math",
  "spl-token 3.5.0",
  "thiserror",
 ]

--- a/libraries/rust/environment/Cargo.toml
+++ b/libraries/rust/environment/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1.0", features = ["derive"] }
 
 solana-sdk = "1.14"
 spl-token = { version = "3", features = ["no-entrypoint"] }
-spl-token-swap = { version = "2.1", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1", features = ["no-entrypoint"] }
 
 spl-governance = { git = "https://github.com/jet-lab/solana-program-library", branch = "temp-fix-spl-deps", features = ["no-entrypoint"] }
@@ -25,3 +24,4 @@ jet-margin = { path = "../../../programs/margin", features = ["no-entrypoint"]}
 jet-fixed-term = { path = "../../../programs/fixed-term", features = ["no-entrypoint"]}
 jet-margin-pool = { path = "../../../programs/margin-pool", features = ["no-entrypoint"]}
 jet-metadata = { path = "../../../programs/metadata", features = ["no-entrypoint"]}
+jet-static-program-registry = { path = "../static-program-registry" }

--- a/libraries/rust/environment/src/client_config.rs
+++ b/libraries/rust/environment/src/client_config.rs
@@ -225,6 +225,7 @@ pub mod legacy {
 
     use jet_instructions::{fixed_term::Market, margin_swap::derive_spl_swap_authority};
     use jet_solana_client::{NetworkUserInterface, NetworkUserInterfaceExt};
+    use jet_static_program_registry::orca_swap_v2;
 
     use crate::programs::{ORCA_V2, ORCA_V2_DEVNET};
 
@@ -304,7 +305,7 @@ pub mod legacy {
                     continue;
                 }
 
-                Some(d) => spl_token_swap::state::SwapVersion::unpack(&d.data)
+                Some(d) => orca_swap_v2::state::SwapVersion::unpack(&d.data)
                     .map_err(|e| ConfigError::UnpackError(e))?,
             };
 

--- a/libraries/rust/instructions/Cargo.toml
+++ b/libraries/rust/instructions/Cargo.toml
@@ -12,7 +12,6 @@ anchor-lang = "0.26"
 anchor-spl = "0.26"
 
 spl-token = "3"
-spl-token-swap = "2"
 spl-associated-token-account = "1"
 
 jet-program-common = { path = "../program-common" }

--- a/libraries/rust/margin/Cargo.toml
+++ b/libraries/rust/margin/Cargo.toml
@@ -53,12 +53,9 @@ jet-metadata = { path = "../../../programs/metadata", features = ["no-entrypoint
 jet-margin-pool = { path = "../../../programs/margin-pool", features = ["no-entrypoint"] }
 jet-margin-swap = { path = "../../../programs/margin-swap", features = ["no-entrypoint"] }
 jet-solana-client  = { path = "../solana-client" }
+jet-static-program-registry = { path = "../static-program-registry" }
 
 # Token swaps
 spl-token = "3"
-spl-token-swap = { version = "2", features = ["no-entrypoint"] }
 spl-associated-token-account = "1"
 saber-client = { package = "stable-swap-client", git = "https://github.com/jet-lab/stable-swap", branch = "master" }
-
-[dev-dependencies]
-jet-static-program-registry = { path = "../static-program-registry" }

--- a/libraries/rust/margin/src/swap/spl_swap.rs
+++ b/libraries/rust/margin/src/swap/spl_swap.rs
@@ -25,8 +25,8 @@ use std::{
 use anchor_lang::ToAccountMetas;
 use jet_margin_swap::{accounts as ix_accounts, SwapRouteIdentifier};
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
+use jet_static_program_registry::orca_swap_v2::state::SwapV1;
 use solana_sdk::{instruction::AccountMeta, program_pack::Pack, pubkey::Pubkey};
-use spl_token_swap::state::SwapV1;
 
 use crate::ix_builder::SwapAccounts;
 

--- a/libraries/rust/static-program-registry/Cargo.toml
+++ b/libraries/rust/static-program-registry/Cargo.toml
@@ -15,11 +15,6 @@ devnet = []
 paste = "1.0"
 anchor-lang = "0.26"
 
-[dependencies.spl-token-swap-v200]
-package = "spl-token-swap"
-version = "2.0.0"
-features = ["no-entrypoint"]
-
 # https://docs.orca.so/#has-orca-been-audited
 [dependencies.spl-token-swap-3613cea3c]
 package = "spl-token-swap"
@@ -27,9 +22,13 @@ git = "https://github.com/solana-labs/solana-program-library"
 rev = "3613cea3cabbb5f7e4445d6203b7292d413732da"
 features = ["no-entrypoint"]
 
-# https://docs.orca.so/#has-orca-been-audited
+# https://docs.orca.so/#has-orca-been-audited  
+# The actual deployed commit is: 813aa3304022528cbf3cf7a3d32bca339194a492  
+# The only diff in this commit 629a8 is that it uses the crates.io version of
+# spl-math 0.1 instead of the repo version, so this repo can be more easily
+# vendored with other crates that rely on spl-math 0.1.0.
 [dependencies.spl-token-swap-813aa3]
 package = "spl-token-swap"
-git = "https://github.com/solana-labs/solana-program-library"
-rev = "813aa3304022528cbf3cf7a3d32bca339194a492"
+git = "https://github.com/jet-lab/solana-program-library"
+rev = "629a8d5524944b1c0b33651db72d3da64ed04bac"
 features = ["no-entrypoint"]

--- a/libraries/rust/static-program-registry/src/programs.rs
+++ b/libraries/rust/static-program-registry/src/programs.rs
@@ -1,5 +1,6 @@
+/// uses the same code as orca swap v2
 pub mod spl_token_swap_v2 {
-    pub use spl_token_swap_v200::*;
+    pub use spl_token_swap_813aa3::*;
 
     crate::program!(Spl2, "SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8");
 }

--- a/programs/test-service/Cargo.toml
+++ b/programs/test-service/Cargo.toml
@@ -24,8 +24,8 @@ anchor-spl = "0.26"
 pyth-sdk-solana = "0.7"
 bytemuck = "1.7"
 
-spl-token-swap = { version = "2.1", features = ["no-entrypoint"] }
 saber-stable-swap = { package = "stable-swap-anchor", git = "https://github.com/jet-lab/stable-swap", branch = "master" }
 saber-stable-client = { package = "stable-swap-client", git = "https://github.com/jet-lab/stable-swap", branch = "master" }
 
 jet-program-common = { path = "../../libraries/rust/program-common" }
+jet-static-program-registry = { path = "../../libraries/rust/static-program-registry" }

--- a/programs/test-service/src/instructions/swaps/spl_swap_pool_balance.rs
+++ b/programs/test-service/src/instructions/swaps/spl_swap_pool_balance.rs
@@ -20,6 +20,7 @@ use anchor_lang::{prelude::*, solana_program::program::invoke_signed};
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
 use jet_program_common::Number128;
+use jet_static_program_registry::orca_swap_v2;
 
 use crate::seeds::{SWAP_POOL_INFO, SWAP_POOL_MINT, SWAP_POOL_TOKENS, TOKEN_INFO};
 use crate::state::{SplSwapInfo, TokenInfo};
@@ -180,7 +181,7 @@ fn apply_change<'info>(
             return Ok(());
         }
 
-        let ix = spl_token_swap::instruction::withdraw_single_token_type_exact_amount_out(
+        let ix = orca_swap_v2::instruction::withdraw_single_token_type_exact_amount_out(
             ctx.accounts.swap_program.key,
             ctx.accounts.token_program.key,
             ctx.accounts.pool_state.key,
@@ -192,7 +193,7 @@ fn apply_change<'info>(
             &ctx.accounts.pool_token_a.key(),
             &ctx.accounts.pool_token_b.key(),
             &scratch.key(),
-            spl_token_swap::instruction::WithdrawSingleTokenTypeExactAmountOut {
+            orca_swap_v2::instruction::WithdrawSingleTokenTypeExactAmountOut {
                 destination_token_amount: tokens,
                 maximum_pool_token_amount: u64::MAX,
             },
@@ -248,7 +249,7 @@ fn apply_change<'info>(
             tokens,
         )?;
 
-        let ix = spl_token_swap::instruction::deposit_single_token_type_exact_amount_in(
+        let ix = orca_swap_v2::instruction::deposit_single_token_type_exact_amount_in(
             ctx.accounts.swap_program.key,
             ctx.accounts.token_program.key,
             ctx.accounts.pool_state.key,
@@ -259,7 +260,7 @@ fn apply_change<'info>(
             &ctx.accounts.pool_token_b.key(),
             &ctx.accounts.pool_mint.key(),
             &ctx.accounts.pool_fees.key(),
-            spl_token_swap::instruction::DepositSingleTokenTypeExactAmountIn {
+            orca_swap_v2::instruction::DepositSingleTokenTypeExactAmountIn {
                 source_token_amount: tokens,
                 minimum_pool_token_amount: 0,
             },

--- a/programs/test-service/src/instructions/swaps/spl_swap_pool_create.rs
+++ b/programs/test-service/src/instructions/swaps/spl_swap_pool_create.rs
@@ -20,6 +20,7 @@ use std::collections::BTreeMap;
 use anchor_lang::solana_program::program_pack::Pack;
 use anchor_lang::{prelude::*, solana_program::program::invoke_signed};
 use anchor_spl::token::{Mint, Token, TokenAccount};
+use jet_static_program_registry::orca_swap_v2;
 
 use crate::instructions::TokenRequest;
 use crate::seeds::{SWAP_POOL_INFO, SWAP_POOL_MINT, SWAP_POOL_STATE, SWAP_POOL_TOKENS};
@@ -68,7 +69,7 @@ pub struct SplSwapPoolCreate<'info> {
                 mint_b.key().as_ref()
               ],
               bump,
-              space = 1 + spl_token_swap::state::SwapV1::LEN,
+              space = 1 + orca_swap_v2::state::SwapV1::LEN,
               owner = swap_program.key(),
               payer = payer
     )]
@@ -189,7 +190,7 @@ pub fn spl_swap_pool_create_handler(
 
     let bump = *ctx.bumps.get("pool_state").unwrap();
 
-    let ix = spl_token_swap::instruction::initialize(
+    let ix = orca_swap_v2::instruction::initialize(
         ctx.accounts.swap_program.key,
         ctx.accounts.token_program.key,
         ctx.accounts.pool_state.key,
@@ -200,7 +201,7 @@ pub fn spl_swap_pool_create_handler(
         &ctx.accounts.pool_fees.key(),
         &ctx.accounts.pool_fees.key(),
         params.nonce,
-        spl_token_swap::curve::fees::Fees {
+        orca_swap_v2::curve::fees::Fees {
             // The fee parameters are taken from one of spl-token-swap tests
             trade_fee_numerator: 1,
             trade_fee_denominator: 400,
@@ -211,9 +212,9 @@ pub fn spl_swap_pool_create_handler(
             host_fee_numerator: 1,
             host_fee_denominator: 100,
         },
-        spl_token_swap::curve::base::SwapCurve {
-            curve_type: spl_token_swap::curve::base::CurveType::ConstantProduct,
-            calculator: Box::new(spl_token_swap::curve::constant_product::ConstantProductCurve),
+        orca_swap_v2::curve::base::SwapCurve {
+            curve_type: orca_swap_v2::curve::base::CurveType::ConstantProduct,
+            calculator: Box::new(orca_swap_v2::curve::constant_product::ConstantProductCurve),
         },
     )?;
 

--- a/tools/ctl/Cargo.toml
+++ b/tools/ctl/Cargo.toml
@@ -44,7 +44,6 @@ solana-cli-config = "1.14"
 solana-client = "1.14"
 solana-sdk = "1.14"
 spl-token = "3"
-spl-token-swap = { version = "2.1", features = ["no-entrypoint"] }
 
 # not used directly, but indirectly to enable ledger support via `solana-clap-utils`
 solana-remote-wallet = "1.14"

--- a/tools/oracle-mirror/Cargo.toml
+++ b/tools/oracle-mirror/Cargo.toml
@@ -16,7 +16,6 @@ solana-cli-config = "1.14"
 solana-client = "1.14"
 solana-sdk = "1.14"
 
-spl-token-swap = { version = "2.1", features = ["no-entrypoint"] }
 spl-token = "3"
 
 anchor-lang = "0.26"


### PR DESCRIPTION
`cargo vendor` allows you to download all of a workspace's dependencies locally so you can reliably compile the code without an internet connection. `cargo vendor` has a bug that causes an error if you try to vendor the jet-v2 repo. I've made some changes to work around the issue.

The issue is that it cannot deal with multiple versions of the same crate and version number. Normally cargo doesn't mind this, but it breaks vendoring. https://github.com/rust-lang/cargo/issues/10310

This was a problem in jet-v2 because we're pulling in spl-token-swap 2.1.0 from both github and crates.io. The problem is compounded because it relies on spl-math 0.1.0 which was likewise also coming from both github and crates.io.

I consolidated spl-token-swap 2.1.0 down to the github dependency in jet-static-program-registry because it is the commit used by orca v2 which is the most likely version of spl-token-swap v2.1.0 that we will interact with. There are no longer any dependencies on spl-token-swap 2.1.0 coming from crates.io. It all uses the program registry.

Note the registry claims to support v2.0.0 but that was actually wrong. It was using v2.1.0 from crates.io. It's not even possible to support v2.0.0 since the solana version is incompatible. So since it was already using v2.1.0 I just changed it to use the same one as elsewhere.

This left one more issue to resolve. I didn't remove the dependency on spl-token-swap 3.0.0 from crates.io, which depends on spl-math 0.1.0 from crates.io. Meanwhile the github version of spl-token-swap v2.1.0 also depends on the spl-math 0.1.0 that exists in its very same git commit. So I forked from that commit of spl-token-swap and modified its Cargo.toml to use spl-math 0.1.0 from crates.io instead of the local path. Here's the change: https://github.com/solana-labs/solana-program-library/commit/629a8d5524944b1c0b33651db72d3da64ed04bac

Now there are no errors. `cargo vendor` works.