### PR TITLE
logging improvements

### DIFF
--- a/check
+++ b/check
@@ -43,9 +43,9 @@ cargo-lint() {
 
 cargo-test() {
     if [[ ${CODECOV:-false} == true ]]; then
-        cargo llvm-cov --workspace --lcov --output-path lcov.info nextest
+        cargo llvm-cov --workspace --lcov --output-path lcov.info nextest --features debug-msg
     else 
-        cargo nextest run
+        cargo nextest run --features debug-msg
     fi
 }
 

--- a/libraries/rust/program-common/Cargo.toml
+++ b/libraries/rust/program-common/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/jet-lab/jet-v2"
 
 [features]
 devnet = []
+debug-msg = []
 
 [dependencies]
 uint = "0.9"

--- a/libraries/rust/program-common/src/lib.rs
+++ b/libraries/rust/program-common/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod fp32;
 mod functions;
+pub mod log;
 mod number;
 mod number_128;
 

--- a/libraries/rust/program-common/src/log.rs
+++ b/libraries/rust/program-common/src/log.rs
@@ -1,0 +1,22 @@
+#[cfg(any(test, feature = "debug-msg"))]
+pub mod _internal {
+    pub use solana_program::log::sol_log;
+
+    /// Sends messages to the solana logs, only if debug-msg feature is enabled
+    #[macro_export]
+    macro_rules! debug_msg {
+        ($msg:literal) => {
+            $crate::log::_internal::sol_log(concat!("debug: ", $msg))
+        };
+        ($msg:literal, $($arg:tt)*) => {
+            $crate::log::_internal::sol_log(&format!(concat!("debug: ", $msg), $($arg)*))
+        };
+    }
+}
+
+/// Sends messages to the solana logs, only if debug-msg feature is enabled
+#[cfg(not(any(test, feature = "debug-msg")))]
+#[macro_export]
+macro_rules! debug_msg {
+    ($msg:literal $(, $($arg:tt)*)?) => {};
+}

--- a/libraries/rust/simulation/src/lib.rs
+++ b/libraries/rust/simulation/src/lib.rs
@@ -29,6 +29,7 @@ use solana_sdk::{
     pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::TransactionError,
 };
 
+mod log;
 #[doc(hidden)]
 pub mod runtime;
 

--- a/libraries/rust/simulation/src/log.rs
+++ b/libraries/rust/simulation/src/log.rs
@@ -1,0 +1,32 @@
+/// Declare a custom logging target hierarchy, where the modules may use
+/// different names from the log targets.
+macro_rules! declare_logging {
+    ($parent_mod:ident = $parent_target:literal {
+        $($mod:ident = $target:literal);+$(;)?
+    }) => {
+        mod $parent_mod {
+            $(pub mod $mod {
+                use super::super::declare_logging;
+                declare_logging!(target: concat!($parent_target, "::", $target));
+            })+
+        }
+    };
+    (target: $target:expr) => {
+        declare_logging!(($) trace as trace, $target);
+        declare_logging!(($) debug as debug, $target);
+        declare_logging!(($) info as info, $target);
+        declare_logging!(($) _warn as warn, $target);
+        declare_logging!(($) error as error, $target);
+    };
+    (($dollar:tt) $internal_name:ident as $log_macro:ident, $target:expr) => {
+        #[allow(unused_macros)]
+        macro_rules! $internal_name {
+            ($dollar($arg:tt)+) => {
+                ::log::$log_macro!(target: $target, $dollar($arg)*)
+            };
+        }
+        #[allow(unused_imports)]
+        pub(crate) use $internal_name as $log_macro;
+    };
+}
+pub(crate)use declare_logging;

--- a/libraries/rust/simulation/src/log.rs
+++ b/libraries/rust/simulation/src/log.rs
@@ -29,4 +29,4 @@ macro_rules! declare_logging {
         pub(crate) use $internal_name as $log_macro;
     };
 }
-pub(crate)use declare_logging;
+pub(crate) use declare_logging;

--- a/libraries/rust/simulation/src/runtime.rs
+++ b/libraries/rust/simulation/src/runtime.rs
@@ -58,7 +58,7 @@ thread_local! {
 }
 
 declare_logging! {
-    logging = "sim" {
+    logging = "jet_simulation" {
         program         = "program";
         account_loader  = "acctldr";
         account_realloc = "realloc";

--- a/libraries/rust/simulation/src/runtime.rs
+++ b/libraries/rust/simulation/src/runtime.rs
@@ -36,7 +36,7 @@ use solana_sdk::{
 };
 use solana_transaction_status::{TransactionConfirmationStatus, TransactionStatus};
 
-use crate::solana_rpc_api::SolanaRpcClient;
+use crate::{log::declare_logging, solana_rpc_api::SolanaRpcClient};
 
 #[doc(hidden)]
 pub use solana_sdk::entrypoint::ProcessInstruction;
@@ -56,6 +56,23 @@ lazy_static! {
 thread_local! {
     static LOCAL_CONTEXTS: RefCell<Vec<LocalContext>> = RefCell::new(Vec::new());
 }
+
+declare_logging! {
+    logging = "sim" {
+        program         = "program";
+        account_loader  = "acctldr";
+        account_realloc = "realloc";
+        program_data    = "pgmdata";
+        program_return  = "pgmrtrn";
+        instruction     = "ixhndlr";
+        transaction     = "txhndlr";
+        custom          = "_custom"; // for logs that are specific to the 
+                                     // simulated runtime, that you wouldn't
+                                     // normally expect from a real validator.
+    }
+}
+// intentionally shadows the crate to force proper logging
+use logging as log;
 
 #[derive(Clone, Copy)]
 struct LocalContext {
@@ -211,7 +228,7 @@ fn global_instruction_handler(
         .get(program_id)
         .ok_or(InstructionError::IncorrectProgramId)?;
 
-    log::debug!(
+    log::instruction::debug!(
         "Program {} invoke [{}]",
         program_id,
         get_local_context_height()
@@ -224,7 +241,7 @@ fn global_instruction_handler(
         let signer_text = account.is_signer.then_some("SIGNER").unwrap_or_default();
         let mut_text = account.is_writable.then_some("MUTABLE").unwrap_or_default();
 
-        log::debug!(
+        log::account_loader::debug!(
             "Loaded Account {}: {} lamports, {} bytes, {} {}",
             account.key,
             account.lamports(),
@@ -237,13 +254,13 @@ fn global_instruction_handler(
     let result = program_entrypoint(program_id, &accounts, instruction_data);
     match result {
         Ok(()) => {
-            log::debug!("Program {} success", program_id);
+            log::instruction::debug!("Program {} success", program_id);
             stable_log::program_success(&context.get_log_collector(), program_id)
         }
         Err(err) => {
             let new_err = u64::from(err).into();
 
-            log::debug!("Program {} failed: {}", program_id, &new_err);
+            log::instruction::debug!("Program {} failed: {}", program_id, &new_err);
             stable_log::program_failure(&context.get_log_collector(), program_id, &new_err);
             return Err(new_err);
         }
@@ -268,7 +285,7 @@ struct LocalRuntimeSyscallStub;
 
 impl SyscallStubs for LocalRuntimeSyscallStub {
     fn sol_log(&self, message: &str) {
-        log::debug!("Program log: {}", message);
+        log::program::debug!("Program log: {}", message);
         ic_logger_msg!(
             get_local_context().invoke_context().get_log_collector(),
             "Program log: {}",
@@ -279,7 +296,7 @@ impl SyscallStubs for LocalRuntimeSyscallStub {
     fn sol_log_data(&self, fields: &[&[u8]]) {
         for field in fields {
             let data = base64::encode(field);
-            log::debug!("Program data: {}", data);
+            log::program_data::debug!("Program data: {}", data);
             ic_logger_msg!(
                 get_local_context().invoke_context().get_log_collector(),
                 "Program data: {}",
@@ -358,7 +375,7 @@ impl SyscallStubs for LocalRuntimeSyscallStub {
             if account_info.data_len() != acc_data.len()
                 && tx_account.can_data_be_resized(acc_data.len()).is_ok()
             {
-                log::debug!(
+                log::account_realloc::debug!(
                     "acc realloc {}: {} -> {}",
                     account_info.key,
                     account_info.data_len(),
@@ -410,7 +427,7 @@ impl SyscallStubs for LocalRuntimeSyscallStub {
 
         if data.is_empty() {
             let encoded = base64::encode(data);
-            log::debug!("Program return: {}", encoded);
+            log::program_return::debug!("Program return: {}", encoded);
 
             ic_logger_msg!(
                 get_local_context().invoke_context().get_log_collector(),
@@ -505,7 +522,7 @@ impl SolanaRpcClient for TestRuntimeRpcClient {
         let signature = transaction.signatures[0];
         let tx = SanitizedTransaction::from_transaction_for_tests(transaction.clone());
 
-        log::info!("processing transaction {}", transaction.signatures[0]);
+        log::transaction::info!("processing transaction {}", transaction.signatures[0]);
         transaction.verify()?;
 
         let sim_result = self.bank.simulate_transaction_unchecked(tx);
@@ -517,8 +534,8 @@ impl SolanaRpcClient for TestRuntimeRpcClient {
                 .unwrap(),
 
             Err(e) => {
-                log::error!("tx error {signature}: {e:?}");
-                log::error!("{:#?}", sim_result.logs);
+                log::transaction::error!("tx error {signature}: {e:?}");
+                log::transaction::error!("{:#?}", sim_result.logs);
 
                 if let TransactionError::InstructionError(_, error) = &e {
                     if let Ok(error) = ProgramError::try_from(error.clone()) {
@@ -580,7 +597,7 @@ impl SolanaRpcClient for TestRuntimeRpcClient {
 
         let clock = bincode::deserialize(sysvar.data())?;
 
-        log::debug!("time is {:?}", &clock);
+        log::custom::debug!("time is {:?}", &clock);
 
         Ok(clock)
     }

--- a/libraries/rust/simulation/src/runtime.rs
+++ b/libraries/rust/simulation/src/runtime.rs
@@ -66,7 +66,7 @@ declare_logging! {
         program_return  = "pgmrtrn";
         instruction     = "ixhndlr";
         transaction     = "txhndlr";
-        custom          = "_custom"; // for logs that are specific to the 
+        custom          = "_custom"; // for logs that are specific to the
                                      // simulated runtime, that you wouldn't
                                      // normally expect from a real validator.
     }

--- a/programs/fixed-term/src/margin/repay.rs
+++ b/programs/fixed-term/src/margin/repay.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{burn, transfer, Burn, Transfer};
-use jet_program_common::traits::TrySubAssign;
+use jet_program_common::{debug_msg, traits::TrySubAssign};
 
 use crate::{
     control::state::Market,
@@ -30,6 +30,12 @@ impl<'a, 'info> RepayAccounts<'a, 'info> {
     /// Use caution to prevent leaking funds
     pub fn repay(&mut self, amount: u64, skip_token_transfer: bool) -> Result<()> {
         let amount = std::cmp::min(amount, self.term_loan.balance);
+        debug_msg!(
+            "Repaying {} out of {} towards term loan {}",
+            amount,
+            self.term_loan.balance,
+            self.term_loan.key()
+        );
 
         // return payment to market vault
         if !skip_token_transfer {


### PR DESCRIPTION
- debug_msg macro for programs to log in tests when feature is enabled (currently only used in fixed term repay)
- more granular logging targets in simulation to enable filtering

codecov must have a bug, its results are incorrect