### PR TITLE
stop using deprecated Pubkey::new

### DIFF
--- a/libraries/rust/margin/src/swap/openbook_swap.rs
+++ b/libraries/rust/margin/src/swap/openbook_swap.rs
@@ -159,7 +159,8 @@ impl OpenBookMarket {
 
 #[inline]
 fn pubkey_from_slice(slice: [u64; 4]) -> Pubkey {
-    Pubkey::new(bytemuck::cast_slice(&slice))
+    let address_bytes: [u8; 32] = bytemuck::cast_slice(&slice).try_into().unwrap();
+    Pubkey::from(address_bytes)
 }
 
 impl SwapAccounts for OpenBookMarket {

--- a/programs/margin-swap/src/instructions/openbook_swap.rs
+++ b/programs/margin-swap/src/instructions/openbook_swap.rs
@@ -83,7 +83,10 @@ impl<'info> OpenbookSwapInfo<'info> {
             let market =
                 anchor_openbook::serum_dex::state::Market::load(&self.market, self.dex_program.key)
                     .unwrap();
-            let base_mint = Pubkey::new(bytemuck::cast_slice(&{ market.coin_mint }));
+            let address_bytes: [u8; 32] = bytemuck::cast_slice(&{ market.coin_mint })
+                .try_into()
+                .unwrap();
+            let base_mint = Pubkey::from(address_bytes);
             (market.coin_lot_size, base_mint)
         };
 


### PR DESCRIPTION
minor refactor. behavior is unchanged.

I see warnings for this every time I build the code.

Stop using Pubkey::new, which panics on failure, and instead use infallible Pubkey::from, moving the explicit panic to the calling code. The code will never actually panic because the input size is known to be correct.