### PR TITLE
add verify_unhealthy instruction to margin

### DIFF
--- a/libraries/rust/instructions/src/margin.rs
+++ b/libraries/rust/instructions/src/margin.rs
@@ -485,6 +485,20 @@ impl MarginIxBuilder {
         }
     }
 
+    /// Verify that an account is unhealthy
+    ///
+    pub fn verify_unhealthy(&self) -> Instruction {
+        let accounts = ix_account::VerifyUnhealthy {
+            margin_account: self.address,
+        };
+
+        Instruction {
+            program_id: JetMargin::id(),
+            accounts: accounts.to_account_metas(None),
+            data: ix_data::VerifyUnhealthy.data(),
+        }
+    }
+
     /// Peform an administrative transfer for a position
     pub fn admin_transfer_position_to(
         &self,

--- a/libraries/rust/margin/src/tx_builder/user.rs
+++ b/libraries/rust/margin/src/tx_builder/user.rs
@@ -711,6 +711,12 @@ impl MarginTxBuilder {
             .await
     }
 
+    /// Verify that the margin account is unhealthy
+    pub async fn verify_unhealthy(&self) -> Result<Transaction> {
+        self.create_unsigned_transaction(&[self.ix.verify_unhealthy()])
+            .await
+    }
+
     /// Refresh a user's position in a margin pool
     pub async fn refresh_pool_position(&self, token_mint: &Pubkey) -> Result<Instruction> {
         let ix_builder = MarginPoolIxBuilder::new(*token_mint);

--- a/programs/margin/src/events.rs
+++ b/programs/margin/src/events.rs
@@ -29,6 +29,11 @@ pub struct VerifiedHealthy {
 }
 
 #[event]
+pub struct VerifiedUnealthy {
+    pub margin_account: Pubkey,
+}
+
+#[event]
 pub struct PositionRegistered {
     pub margin_account: Pubkey,
     pub authority: Pubkey,

--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -248,6 +248,31 @@ pub mod jet_margin {
         verify_healthy_handler(ctx)
     }
 
+    /// Verify that the account is unhealthy, by validating the collateralization
+    /// ratio is below the minimum.
+    ///
+    /// There's no real reason to call this instruction, outside of wanting to simulate
+    /// the health check for a margin account.
+    ///
+    ///
+    /// # [Accounts](jet_margin::accounts::VerifyUnhealthy)
+    ///
+    /// |     |     |     |
+    /// | --- | --- | --- |
+    /// | **Name** | **Type** | **Description** |
+    /// | `margin_account` | `read_only` | The account to verify the health of. |
+    ///
+    /// # Events
+    ///
+    /// |     |     |
+    /// | --- | --- |
+    /// | **Event Name** | **Description** |
+    /// | [`events::VerifiedUnhealthy`] | Marks the verification of the position. |
+    ///
+    pub fn verify_unhealthy(ctx: Context<VerifyUnhealthy>) -> Result<()> {
+        verify_unhealthy_handler(ctx)
+    }
+
     /// Perform an action by invoking other programs, allowing them to alter
     /// the balances of the token accounts belonging to this margin account.
     ///

--- a/tests/hosted/src/margin.rs
+++ b/tests/hosted/src/margin.rs
@@ -673,6 +673,11 @@ impl MarginUser {
         self.send_confirm_tx(self.tx.verify_healthy().await?).await
     }
 
+    pub async fn verify_unhealthy(&self) -> Result<(), Error> {
+        self.send_confirm_tx(self.tx.verify_unhealthy().await?)
+            .await
+    }
+
     /// Close a user's empty positions.
     pub async fn close_empty_positions(
         &self,

--- a/tests/hosted/src/test_user.rs
+++ b/tests/hosted/src/test_user.rs
@@ -192,6 +192,10 @@ impl TestUser {
         self.user.verify_healthy().await
     }
 
+    pub async fn verify_unhealthy(&self) -> Result<()> {
+        self.user.verify_unhealthy().await
+    }
+
     pub async fn liquidate_end(&self, liquidator: Option<Pubkey>) -> Result<()> {
         self.user.liquidate_end(liquidator).await
     }

--- a/tests/hosted/tests/liquidate.rs
+++ b/tests/hosted/tests/liquidate.rs
@@ -173,7 +173,7 @@ async fn liquidator_can_repay_from_unhealthy_to_healthy_state() -> Result<()> {
     let scen = scenario1!().unwrap().1;
 
     let liq = scen.liquidator.begin(&scen.user_b, true).await.unwrap();
-    liq.verify_healthy().await.err().unwrap();
+    liq.verify_unhealthy().await.unwrap();
 
     // Execute a repayment on behalf of the user
     liq.margin_repay(&scen.usdc, 1_000_000 * ONE_USDC)
@@ -195,7 +195,7 @@ async fn liquidator_can_end_liquidation_when_unhealthy() -> Result<()> {
     let scen = scenario1!().unwrap().1;
 
     let liq = scen.liquidator.begin(&scen.user_b, true).await.unwrap();
-    liq.verify_healthy().await.err().unwrap();
+    liq.verify_unhealthy().await.unwrap();
     liq.liquidate_end(None).await.unwrap();
 
     Ok(())


### PR DESCRIPTION
useful for the liquidator and to improve assertions in tests. sometimes verify_healthy returns err for other reasons than the account being unhealthy.