### PR TITLE
Setup and override the lookup authority on localnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tsconfig.tsbuildinfo
 !package.json
 localnet.config.json
 localnet.config.legacy.json
+lookup-authority.json
 
 .env
 .localnet

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -52,6 +52,10 @@ program = "./deps/saber_stable_swap.so"
 address = "SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8"
 program = "./deps/spl-token-swap/crates.io-spl_token_swap==2.0.0.so"
 
+[[test.genesis]]
+address = "LTR8xXcSrEDsCbTWPY4JmJREFdMz4uYh65uajkVjzru"
+program = "./deps/lookup_table_registry.so"
+
 [test]
 startup_wait = 10000
 

--- a/libraries/rust/environment/src/client_config.rs
+++ b/libraries/rust/environment/src/client_config.rs
@@ -55,7 +55,7 @@ impl JetAppConfig {
     pub async fn from_env_config<I: NetworkUserInterface>(
         env: EnvironmentConfig,
         network: &I,
-        default_lookup_authority: Option<Pubkey>,
+        override_lookup_authority: Option<Pubkey>,
     ) -> Result<Self, ConfigError<I>> {
         let mut seen = HashSet::new();
         let mut tokens = vec![];
@@ -72,8 +72,8 @@ impl JetAppConfig {
             }
             // Override the airspace config address if a default is provided
             let mut airspace = airspace.clone();
-            if let Some(default_lookup_authority) = default_lookup_authority {
-                airspace.lookup_registry_authority = Some(default_lookup_authority);
+            if let Some(override_lookup_authority) = override_lookup_authority {
+                airspace.lookup_registry_authority = Some(override_lookup_authority);
             }
 
             airspaces.push(airspace.clone().into());

--- a/libraries/rust/environment/src/client_config.rs
+++ b/libraries/rust/environment/src/client_config.rs
@@ -55,6 +55,7 @@ impl JetAppConfig {
     pub async fn from_env_config<I: NetworkUserInterface>(
         env: EnvironmentConfig,
         network: &I,
+        default_lookup_authority: Option<Pubkey>,
     ) -> Result<Self, ConfigError<I>> {
         let mut seen = HashSet::new();
         let mut tokens = vec![];
@@ -68,6 +69,11 @@ impl JetAppConfig {
 
                 seen.insert(token.name.clone());
                 tokens.push(TokenInfo::from_desc(network, token).await?);
+            }
+            // Override the airspace config address if a default is provided
+            let mut airspace = airspace.clone();
+            if let Some(default_lookup_authority) = default_lookup_authority {
+                airspace.lookup_registry_authority = Some(default_lookup_authority);
             }
 
             airspaces.push(airspace.clone().into());

--- a/tests/scripts/anchor.sh
+++ b/tests/scripts/anchor.sh
@@ -7,7 +7,11 @@ if [[ ${SOLANA_LOGS:-false} == true ]]; then
 fi
 
 cargo run --bin jetctl -- apply -ul --no-confirm config/localnet/
-cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet -o apps/react-app/public/localnet.config.json
+solana-keygen new --no-bip39-passphrase -o apps/react-app/public/lookup-authority.json --force
+solana airdrop -k apps/react-app/public/lookup-authority.json -ul 5
+cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet -o apps/react-app/public/localnet.config.json --default-lookup-keypair apps/react-app/public/lookup-authority.json
+cargo run --bin jet-alt-registry-client -- create-registry -ul --no-confirm --authority-path apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json
+cargo run --bin jet-alt-registry-client -- update-registry -ul --no-confirm --authority-path apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json --airspace-name default
 cargo run --bin jet-oracle-mirror -- -s ${SOLANA_MAINNET_RPC:='https://solana-api.projectserum.com'} -tl &
 
 echo "waiting for oracles ..."

--- a/tests/scripts/anchor.sh
+++ b/tests/scripts/anchor.sh
@@ -9,7 +9,7 @@ fi
 cargo run --bin jetctl -- apply -ul --no-confirm config/localnet/
 solana-keygen new --no-bip39-passphrase -o apps/react-app/public/lookup-authority.json --force
 solana airdrop -k apps/react-app/public/lookup-authority.json -ul 5
-cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet -o apps/react-app/public/localnet.config.json --default-lookup-keypair apps/react-app/public/lookup-authority.json
+cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet/ -o apps/react-app/public/localnet.config.json --override-lookup-authority $(solana-keygen pubkey apps/react-app/public/lookup-authority.json)
 cargo run --bin jet-alt-registry-client -- create-registry -ul --no-confirm --authority-path apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json
 cargo run --bin jet-alt-registry-client -- update-registry -ul --no-confirm --authority-path apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json --airspace-name default
 cargo run --bin jet-oracle-mirror -- -s ${SOLANA_MAINNET_RPC:='https://solana-api.projectserum.com'} -tl &

--- a/tests/scripts/on_localnet.sh
+++ b/tests/scripts/on_localnet.sh
@@ -122,8 +122,12 @@ resume-validator() {
 
 start-new-validator() {
     start-validator -r
+    solana-keygen new --no-bip39-passphrase -o apps/react-app/public/lookup-authority.json --force
+    solana airdrop -k apps/react-app/public/lookup-authority.json -ul 5
     cargo run --bin jetctl -- apply -ul --no-confirm config/localnet/
-    cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet/ -o apps/react-app/public/localnet.config.json
+    cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet/ -o apps/react-app/public/localnet.config.json --default-lookup-keypair apps/react-app/public/lookup-authority.json
+    cargo run --bin jet-alt-registry-client -- create-registry -ul --no-confirm -a apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json
+    cargo run --bin jet-alt-registry-client -- update-registry -ul --no-confirm -a apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json --airspace-name default
     start-crank-service
     start-oracle
     init-idl &

--- a/tests/scripts/on_localnet.sh
+++ b/tests/scripts/on_localnet.sh
@@ -125,7 +125,7 @@ start-new-validator() {
     solana-keygen new --no-bip39-passphrase -o apps/react-app/public/lookup-authority.json --force
     solana airdrop -k apps/react-app/public/lookup-authority.json -ul 5
     cargo run --bin jetctl -- apply -ul --no-confirm config/localnet/
-    cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet/ -o apps/react-app/public/localnet.config.json --default-lookup-keypair apps/react-app/public/lookup-authority.json
+    cargo run --bin jetctl -- generate-app-config -ul --no-confirm config/localnet/ -o apps/react-app/public/localnet.config.json --override-lookup-authority $(solana-keygen pubkey apps/react-app/public/lookup-authority.json)
     cargo run --bin jet-alt-registry-client -- create-registry -ul --no-confirm -a apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json
     cargo run --bin jet-alt-registry-client -- update-registry -ul --no-confirm -a apps/react-app/public/lookup-authority.json -k apps/react-app/public/lookup-authority.json --airspace-name default
     start-crank-service

--- a/tools/ctl/src/actions/global.rs
+++ b/tools/ctl/src/actions/global.rs
@@ -75,13 +75,13 @@ pub async fn process_generate_app_config(
     client: &Client,
     config_dir: &Path,
     output_path: &Path,
-    default_lookup_authority: Option<Pubkey>,
+    override_lookup_authority: Option<Pubkey>,
 ) -> Result<Plan> {
     let config = jet_environment::config::read_env_config_dir(config_dir)?;
     let app_config = JetAppConfig::from_env_config(
         config.clone(),
         &client.network_interface(),
-        default_lookup_authority,
+        override_lookup_authority,
     )
     .await
     .unwrap();

--- a/tools/ctl/src/actions/global.rs
+++ b/tools/ctl/src/actions/global.rs
@@ -75,11 +75,16 @@ pub async fn process_generate_app_config(
     client: &Client,
     config_dir: &Path,
     output_path: &Path,
+    default_lookup_authority: Option<Pubkey>,
 ) -> Result<Plan> {
     let config = jet_environment::config::read_env_config_dir(config_dir)?;
-    let app_config = JetAppConfig::from_env_config(config.clone(), &client.network_interface())
-        .await
-        .unwrap();
+    let app_config = JetAppConfig::from_env_config(
+        config.clone(),
+        &client.network_interface(),
+        default_lookup_authority,
+    )
+    .await
+    .unwrap();
     let legacy_app_config = jet_environment::client_config::legacy::from_config(
         &client.network_interface(),
         &app_config,


### PR DESCRIPTION
- Add a lookup authority keypair as part of the localnet setup.
- Create and populate a registry for the authority
- Update the localnet config to use this authority

Tested locally by starting up the validator and confirming that:
- the config is updated
- the lookup registry and 2 lookup tables are created