### PR TITLE
fixed term crank improvements + liquidator testing

### DIFF
--- a/libraries/rust/margin/src/fixed_term/event_consumer.rs
+++ b/libraries/rust/margin/src/fixed_term/event_consumer.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use agnostic_orderbook::state::{
@@ -8,6 +9,7 @@ use agnostic_orderbook::state::{
     AccountTag,
 };
 use anchor_lang::AccountDeserialize;
+use futures::{future::join_all, lock::Mutex as AsyncMutex};
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction, packet::PACKET_DATA_SIZE, pubkey::Pubkey,
     signer::Signer, transaction::Transaction,
@@ -48,7 +50,7 @@ pub enum EventConsumerError {
 /// Utility for running consume-events for fixed term markets
 pub struct EventConsumer {
     rpc: Arc<dyn SolanaRpcClient>,
-    markets: Mutex<HashMap<Pubkey, Arc<Mutex<MarketState>>>>,
+    markets: Mutex<HashMap<Pubkey, Arc<AsyncMutex<MarketState>>>>,
 }
 
 /// does not guarantee successful downloads, some may be omitted
@@ -100,7 +102,7 @@ impl EventConsumer {
         let builder = FixedTermIxBuilder::new_from_state(self.rpc.payer().pubkey(), &market);
         self.markets.lock().unwrap().insert(
             builder.market(),
-            Arc::new(Mutex::new(MarketState {
+            Arc::new(AsyncMutex::new(MarketState {
                 market_address: builder.market(),
                 market,
                 queue: Vec::new(),
@@ -109,6 +111,27 @@ impl EventConsumer {
                 margin_accounts_to_settle: margin_account_settlement_sink,
             })),
         );
+    }
+
+    /// Start a loop to continuously consume events. Never returns. Logs errors
+    pub async fn sync_and_consume_forever(&self, targets: &[Pubkey], delay: Duration) {
+        loop {
+            if let Err(e) = self.sync_and_consume_all(targets).await {
+                tracing::error!("Error while consuming events: {e:?}");
+            }
+            tokio::time::sleep(delay).await;
+        }
+    }
+
+    pub async fn sync_and_consume_all(&self, targets: &[Pubkey]) -> Result<(), EventConsumerError> {
+        self.sync_queues().await?;
+        while self.total_pending_events(targets).await? > 0 {
+            self.sync_users().await?;
+            self.consume().await?;
+            self.sync_queues().await?;
+        }
+
+        Ok(())
     }
 
     /// Sync state for all users in the market
@@ -132,8 +155,8 @@ impl EventConsumer {
                 }
             };
 
-            if let Some(state) = self.markets.lock().unwrap().get_mut(&structure.market) {
-                let mut state = state.lock().unwrap();
+            if let Some(state) = self.get_market(&structure.market) {
+                let mut state = state.lock().await;
 
                 if state.users.insert(address, structure.clone()).is_none() {
                     tracing::trace!(
@@ -146,9 +169,8 @@ impl EventConsumer {
         }
 
         if tracing::enabled!(tracing::Level::TRACE) {
-            for (market, state) in self.markets.lock().unwrap().iter() {
-                let state = state.lock().unwrap();
-
+            for (market, state) in self.markets() {
+                let state = state.lock().await;
                 tracing::trace!(?market, "sync {} total users", state.users.len());
             }
         }
@@ -156,25 +178,38 @@ impl EventConsumer {
         Ok(())
     }
 
+    fn get_market(&self, market: &Pubkey) -> Option<Arc<AsyncMutex<MarketState>>> {
+        self.markets.lock().unwrap().get(market).cloned()
+    }
+
+    fn markets(&self) -> impl Iterator<Item = (Pubkey, Arc<AsyncMutex<MarketState>>)> {
+        self.markets
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(x, y)| (*x, y.clone()))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
     /// Sync the event queues
     pub async fn sync_queues(&self) -> Result<(), EventConsumerError> {
         tracing::trace!("sync event queues");
 
-        let (markets, addresses): (Vec<_>, Vec<_>) = self
-            .markets
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(addr, state)| {
-                let state = state.lock().unwrap();
-                (*addr, state.market.event_queue)
-            })
+        let (markets, addresses): (Vec<_>, Vec<_>) =
+            join_all(self.markets().map(|(addr, state)| async move {
+                let state = state.lock().await;
+                (addr, state.market.event_queue)
+            }))
+            .await
+            .into_iter()
             .unzip();
+
         let accounts = self.rpc.get_multiple_accounts(&addresses).await?;
 
         for (market, account) in markets.into_iter().zip(accounts) {
-            let mut map = self.markets.lock().unwrap();
-            let mut market_state = map.get_mut(&market).unwrap().lock().unwrap();
+            let mkt = self.get_market(&market).unwrap();
+            let mut market_state = mkt.lock().await;
 
             if let Some(account) = account {
                 market_state.queue = account.data;
@@ -199,8 +234,7 @@ impl EventConsumer {
             .iter()
             .map(|(address, state)| (*address, state.clone()))
             .map(|(address, state)| async move {
-                let mut state = state.lock().unwrap();
-
+                let mut state = state.lock().await;
                 state
                     .consume_next(&*self.rpc)
                     .await
@@ -227,14 +261,26 @@ impl EventConsumer {
     }
 
     /// Count the events waiting to be consumed in a market
-    pub fn pending_events(&self, market: &Pubkey) -> Result<usize, EventConsumerError> {
-        let map = self.markets.lock().unwrap();
-        let state = match map.get(market) {
-            Some(state) => state.lock().unwrap(),
-            None => return Ok(0),
-        };
+    pub async fn pending_events(&self, market: &Pubkey) -> Result<usize, EventConsumerError> {
+        match self.get_market(market) {
+            Some(state) => state.lock().await.pending_events(),
+            None => Ok(0),
+        }
+    }
 
-        state.pending_events()
+    /// Count the total events waiting to be consumed in all provided market
+    pub async fn total_pending_events(
+        &self,
+        targets: &[Pubkey],
+    ) -> Result<usize, EventConsumerError> {
+        Ok(join_all(
+            targets
+                .iter()
+                .map(|market| async { self.pending_events(market).await.unwrap() }),
+        )
+        .await
+        .into_iter()
+        .sum::<usize>())
     }
 }
 
@@ -261,7 +307,7 @@ impl MarketState {
         let mut consume_tx = Transaction::default();
         let mut margin_accounts_to_settle = Vec::new();
 
-        tracing::trace!(
+        tracing::debug!(
             "processing queue of length {}",
             queue.inner().unwrap().len()
         );

--- a/libraries/rust/margin/src/fixed_term/mod.rs
+++ b/libraries/rust/margin/src/fixed_term/mod.rs
@@ -5,12 +5,20 @@ pub mod event_consumer;
 mod ix_builder;
 pub mod settler;
 
+use futures::future::try_join_all;
 pub use ix_builder::*;
 
 use anchor_lang::AccountDeserialize;
 use jet_simulation::SolanaRpcClient;
-use solana_sdk::pubkey::Pubkey;
-use std::{collections::HashMap, sync::Arc};
+use solana_sdk::{pubkey::Pubkey, signer::Signer};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use crate::util::no_dupe_queue::AsyncNoDupeQueue;
+
+use self::{
+    event_consumer::{download_markets, EventConsumer},
+    settler::Settler,
+};
 
 /// Find all the fixed term markets.
 /// TODO: generalize this to rpc client, code from liquidator may be useful
@@ -28,4 +36,59 @@ pub async fn find_markets(
             }
         })
         .collect())
+}
+
+pub struct Crank {
+    pub consumer: EventConsumer,
+    pub settlers: Vec<Settler>,
+    pub market_addrs: Vec<Pubkey>,
+    pub consumer_delay: Duration,
+}
+
+impl Crank {
+    pub async fn new(
+        rpc: Arc<dyn SolanaRpcClient>,
+        market_addrs: &[Pubkey],
+    ) -> anyhow::Result<Self> {
+        let markets = download_markets(rpc.as_ref(), market_addrs).await?;
+        let consumer = EventConsumer::new(rpc.clone());
+        let mut settlers = vec![];
+        for market in markets {
+            let margin_accounts = AsyncNoDupeQueue::new();
+            let ix = FixedTermIxBuilder::new_from_state(rpc.payer().pubkey(), &market);
+            consumer.insert_market(market, Some(margin_accounts.clone()));
+            let settler = Settler::new(rpc.clone(), ix, margin_accounts, Default::default())?;
+            settlers.push(settler);
+        }
+
+        Ok(Self {
+            consumer,
+            settlers,
+            market_addrs: market_addrs.to_vec(),
+            consumer_delay: Duration::from_secs(2),
+        })
+    }
+
+    /// Consumes all events that are currently in the queue, then settles any
+    /// accounts that need to be settled due to those events, then returns.
+    pub async fn run_once(&self) -> anyhow::Result<()> {
+        self.consumer
+            .sync_and_consume_all(&self.market_addrs)
+            .await?;
+        try_join_all(self.settlers.iter().map(|s| s.settle_all())).await?;
+        Ok(())
+    }
+
+    /// Continuously consumes any events and settles any accounts as they need
+    /// to be processed.
+    pub async fn run_forever(self) {
+        let mut jobs = vec![];
+        for settler in self.settlers {
+            jobs.push(tokio::spawn(async move { settler.run_forever().await }));
+        }
+        self.consumer
+            .sync_and_consume_forever(&self.market_addrs, self.consumer_delay)
+            .await;
+        try_join_all(jobs).await.unwrap();
+    }
 }

--- a/libraries/rust/margin/src/fixed_term/settler.rs
+++ b/libraries/rust/margin/src/fixed_term/settler.rs
@@ -1,21 +1,37 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use futures::{
-    future::{join_all, try_join_all},
-    join, Future,
-};
+use async_trait::async_trait;
 use jet_instructions::margin::accounting_invoke;
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
-use jet_solana_client::clone_to_async;
 use solana_sdk::pubkey::Pubkey;
 
 use super::FixedTermIxBuilder;
 use crate::{
     solana::transaction::{InverseSendTransactionBuilder, WithSigner},
-    util::no_dupe_queue::AsyncNoDupeQueue,
+    util::{
+        no_dupe_queue::AsyncNoDupeQueue,
+        queue_processor::{ChunkProcessor, QueueProcessorConfig, StaticQueueProcessor},
+    },
 };
 
 pub const SETTLES_PER_TX: usize = 3;
+
+pub type Settler = StaticQueueProcessor<Pubkey, ChunkSettler>;
+pub fn settler(
+    rpc: Arc<dyn SolanaRpcClient>,
+    builder: impl Into<FixedTermIxBuilder>,
+    margin_accounts: AsyncNoDupeQueue<Pubkey>,
+    config: QueueProcessorConfig,
+) -> anyhow::Result<StaticQueueProcessor<Pubkey, ChunkSettler>> {
+    StaticQueueProcessor::new(
+        margin_accounts,
+        config,
+        ChunkSettler {
+            rpc,
+            builder: Arc::new(builder.into()),
+        },
+    )
+}
 
 /// Attempt to settle the provided margin accounts, return error on failure.
 async fn try_settle(
@@ -41,165 +57,14 @@ async fn try_settle(
     Ok(())
 }
 
-/// Performance settings for the Settler. Use the default to process
-/// settlements at a relaxed pace.
-#[derive(Clone, Copy, Debug)]
-pub struct SettleMarginUsersConfig {
-    /// Number of margin users to process simultaneously. All settle
-    /// instructions will be sent at once.
-    pub batch_size: usize,
-
-    /// Time to wait between batches when the previous batch maxed out the
-    /// batch_size and there are still more accounts to settle.
-    pub batch_delay: Duration,
-
-    /// Time to wait between batches when the previous batch cleared the entire
-    /// queue and there are no more accounts to settle at this time.
-    pub wait_for_more_delay: Duration,
-}
-
-impl Default for SettleMarginUsersConfig {
-    /// Attempts to set a conservative default that can safely coexist with an
-    /// event consumer that deserves higher CPU priority since its tasks are
-    /// more important.
-    fn default() -> Self {
-        Self {
-            batch_size: 10,
-            batch_delay: Duration::from_secs(1),
-            wait_for_more_delay: Duration::from_secs(5),
-        }
-    }
-}
-
-/// Tracks margin accounts in a queue and exposes functions to settle the
-/// accounts in that queue.
 #[derive(Clone)]
-pub struct Settler {
+pub struct ChunkSettler {
     rpc: Arc<dyn SolanaRpcClient>,
     builder: Arc<FixedTermIxBuilder>,
-    margin_accounts: AsyncNoDupeQueue<Pubkey>,
-    retry_queue: AsyncNoDupeQueue<Pubkey>,
-    config: SettleMarginUsersConfig,
 }
-
-impl Settler {
-    pub fn new(
-        rpc: Arc<dyn SolanaRpcClient>,
-        builder: impl Into<FixedTermIxBuilder>,
-        margin_accounts: AsyncNoDupeQueue<Pubkey>,
-        config: SettleMarginUsersConfig,
-    ) -> anyhow::Result<Settler> {
-        if config.batch_size == 0 {
-            anyhow::bail!("invalid settler batch size of 0");
-        }
-
-        Ok(Settler {
-            rpc,
-            builder: Arc::new(builder.into()),
-            margin_accounts,
-            retry_queue: Default::default(),
-            config,
-        })
-    }
-
-    /// Settles all accounts that currently need to be settled. Returns after
-    /// all settlement attempts have completed and there are no accounts
-    /// remaining in the queue. If any new accounts appear in the queue while
-    /// this is processing, it will also attempt to settle those accounts.
-    /// Returns error if any attempts fail.
-    pub async fn settle_all(&self) -> anyhow::Result<()> {
-        self.process_all(clone_to_async! { me = self
-            |addrs| { try_settle(me.rpc.clone(), me.builder.clone(), &addrs).await }
-        })
-        .await
-    }
-
-    /// Loops forever to keep checking the queue for margin accounts. Sends a
-    /// separate Settle transaction for each without blocking. Limits rate based
-    /// on config. Any margin accounts that failed to settle are retried
-    /// indefinitely.
-    pub async fn run_forever(&self) {
-        tracing::info!(
-            "starting settler crank for fixed term market {}",
-            self.builder.market()
-        );
-        loop {
-            let me = self.clone();
-            join!(
-                tokio::time::sleep(self.config.wait_for_more_delay),
-                async move {
-                    me.process_all(clone_to_async! { me
-                        |mut addrs| {
-                            if let Err(e) = try_settle(me.rpc.clone(), me.builder.clone(), &addrs).await {
-                                tracing::error!("failed to settle margin accounts {addrs:?} - {e}");
-                                addrs.reverse();
-                                me.retry_queue.push_many(addrs).await;
-                            }
-                            Ok(())
-                        }
-                    })
-                    .await
-                    .expect("settle_with_recovery is infallible")
-                }
-            );
-        }
-    }
-
-    /// Apply the processor function to margin accounts in the queue until both
-    /// the primary and the retry queues are empty.
-    async fn process_all<F, Fut>(&self, f: F) -> anyhow::Result<()>
-    where
-        F: Fn(Vec<Pubkey>) -> Fut + Send + Sync + 'static + Clone,
-        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
-    {
-        let mut remaining = self.margin_accounts.len().await;
-        while remaining > 0 {
-            let mut spawned = vec![];
-            while remaining > 0 {
-                let me = self.clone();
-                let processor = f.clone();
-                spawned.push(tokio::spawn(
-                    async move { me.process_batch(processor).await },
-                ));
-                remaining = self.margin_accounts.len().await;
-                if remaining > 0 {
-                    tokio::time::sleep(self.config.batch_delay).await;
-                }
-            }
-            try_join_all(spawned).await?;
-            if !self.retry_queue.is_empty().await {
-                // Just grab a single batch of retries so they don't get cause a
-                // DoS for new accounts that appear in the main queue.
-                self.margin_accounts
-                    .push_many(self.retry_queue.pop_many(self.config.batch_size).await)
-                    .await;
-            }
-            remaining = self.margin_accounts.len().await;
-        }
-
-        Ok(())
-    }
-
-    /// Apply the processor function to a group of margin accounts from the
-    /// primary queue, equal to batch_size.
-    async fn process_batch<F, Fut>(&self, processor: F) -> anyhow::Result<()>
-    where
-        F: Fn(Vec<Pubkey>) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = anyhow::Result<()>> + Send,
-    {
-        join_all(
-            self.margin_accounts
-                .pop_many(self.config.batch_size)
-                .await
-                .chunks(SETTLES_PER_TX)
-                .map(|addrs| {
-                    let addrs = addrs.to_vec();
-                    processor(addrs)
-                }),
-        )
-        .await
-        .into_iter()
-        .collect::<anyhow::Result<Vec<_>>>()?;
-        Ok(())
+#[async_trait]
+impl ChunkProcessor<Pubkey> for ChunkSettler {
+    async fn process(&self, chunk: Vec<Pubkey>) -> anyhow::Result<()> {
+        try_settle(self.rpc.clone(), self.builder.clone(), &chunk).await
     }
 }

--- a/libraries/rust/margin/src/fixed_term/settler.rs
+++ b/libraries/rust/margin/src/fixed_term/settler.rs
@@ -1,8 +1,12 @@
 use std::{sync::Arc, time::Duration};
 
-use futures::future::join_all;
+use futures::{
+    future::{join_all, try_join_all},
+    join, Future,
+};
 use jet_instructions::margin::accounting_invoke;
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
+use jet_solana_client::clone_to_async;
 use solana_sdk::pubkey::Pubkey;
 
 use super::FixedTermIxBuilder;
@@ -13,62 +17,14 @@ use crate::{
 
 pub const SETTLES_PER_TX: usize = 3;
 
-/// Loops forever to keep checking the queue for margin accounts.
-/// Sends a separate Settle transaction for each without blocking.
-/// Limits rate based on config.
-pub async fn settle_margin_users_loop(
-    rpc: Arc<dyn SolanaRpcClient>,
-    builder: FixedTermIxBuilder,
-    margin_accounts: AsyncNoDupeQueue<Pubkey>,
-    config: SettleMarginUsersConfig,
-) {
-    tracing::info!(
-        "starting settler crank for fixed term market {}",
-        builder.market()
-    );
-    if config.batch_size == 0 {
-        panic!("invalid settler batch size of 0");
-    }
-    let ix = Arc::new(builder);
-    let mut spawned = vec![];
-    loop {
-        let to_settle = margin_accounts.pop_many(config.batch_size).await;
-        let has_more = to_settle.len() == config.batch_size;
-        for accounts_chunk in to_settle.chunks(SETTLES_PER_TX) {
-            let fut = tokio::spawn(settle_with_recovery(
-                rpc.clone(),
-                ix.clone(),
-                accounts_chunk.to_owned(),
-                Some(margin_accounts.clone()),
-            ));
-            if config.exit_when_done {
-                spawned.push(fut);
-            }
-        }
-        if has_more {
-            tokio::time::sleep(config.batch_delay).await;
-        } else if config.exit_when_done {
-            for item in join_all(spawned).await {
-                item.unwrap();
-            }
-            break;
-        } else {
-            tokio::time::sleep(config.wait_for_more_delay).await;
-        }
-    }
-}
-
-/// Attempts to settle a margin user. Does not return an error on failure.
-/// Instead, it logs an error and then pushes the margin account back to the end
-/// of the queue.
-async fn settle_with_recovery(
+/// Attempt to settle the provided margin accounts, return error on failure.
+async fn try_settle(
     rpc: Arc<dyn SolanaRpcClient>,
     builder: Arc<FixedTermIxBuilder>,
-    mut margin_accounts: Vec<Pubkey>,
-    retry_queue: Option<AsyncNoDupeQueue<Pubkey>>,
-) {
+    margin_accounts: &[Pubkey],
+) -> anyhow::Result<()> {
     tracing::debug!("sending settle tx for margin accounts {margin_accounts:?}");
-    match margin_accounts
+    margin_accounts
         .iter()
         .map(|margin_account| {
             vec![accounting_invoke(
@@ -80,21 +36,14 @@ async fn settle_with_recovery(
         })
         .collect::<Vec<_>>()
         .send_and_confirm_condensed(&rpc)
-        .await
-    {
-        Ok(_) => tracing::debug!("settled margin accounts {margin_accounts:?}"),
-        Err(e) => {
-            tracing::error!("failed to settle margin accounts {margin_accounts:?} - {e}");
-            if let Some(q) = retry_queue {
-                margin_accounts.reverse();
-                q.push_many(margin_accounts).await
-            }
-        }
-    }
+        .await?;
+    tracing::debug!("settled margin accounts {margin_accounts:?}");
+    Ok(())
 }
 
-/// Performance settings for the settlement loop. Use the default to process
+/// Performance settings for the Settler. Use the default to process
 /// settlements at a relaxed pace.
+#[derive(Clone, Copy, Debug)]
 pub struct SettleMarginUsersConfig {
     /// Number of margin users to process simultaneously. All settle
     /// instructions will be sent at once.
@@ -107,14 +56,6 @@ pub struct SettleMarginUsersConfig {
     /// Time to wait between batches when the previous batch cleared the entire
     /// queue and there are no more accounts to settle at this time.
     pub wait_for_more_delay: Duration,
-
-    /// The loop will exit when there are no more events in the queue. Usually
-    /// you probably want this to be false. Some scenarios where you may want
-    /// this to be true:
-    /// - unit tests
-    /// - ad hoc or emergency executions that are intended to allocate some
-    ///   extra resources when the standard settler isn't moving fast enough.
-    pub exit_when_done: bool,
 }
 
 impl Default for SettleMarginUsersConfig {
@@ -126,7 +67,139 @@ impl Default for SettleMarginUsersConfig {
             batch_size: 10,
             batch_delay: Duration::from_secs(1),
             wait_for_more_delay: Duration::from_secs(5),
-            exit_when_done: false,
         }
+    }
+}
+
+/// Tracks margin accounts in a queue and exposes functions to settle the
+/// accounts in that queue.
+#[derive(Clone)]
+pub struct Settler {
+    rpc: Arc<dyn SolanaRpcClient>,
+    builder: Arc<FixedTermIxBuilder>,
+    margin_accounts: AsyncNoDupeQueue<Pubkey>,
+    retry_queue: AsyncNoDupeQueue<Pubkey>,
+    config: SettleMarginUsersConfig,
+}
+
+impl Settler {
+    pub fn new(
+        rpc: Arc<dyn SolanaRpcClient>,
+        builder: impl Into<FixedTermIxBuilder>,
+        margin_accounts: AsyncNoDupeQueue<Pubkey>,
+        config: SettleMarginUsersConfig,
+    ) -> anyhow::Result<Settler> {
+        if config.batch_size == 0 {
+            anyhow::bail!("invalid settler batch size of 0");
+        }
+
+        Ok(Settler {
+            rpc,
+            builder: Arc::new(builder.into()),
+            margin_accounts,
+            retry_queue: Default::default(),
+            config,
+        })
+    }
+
+    /// Settles all accounts that currently need to be settled. Returns after
+    /// all settlement attempts have completed and there are no accounts
+    /// remaining in the queue. If any new accounts appear in the queue while
+    /// this is processing, it will also attempt to settle those accounts.
+    /// Returns error if any attempts fail.
+    pub async fn settle_all(&self) -> anyhow::Result<()> {
+        self.process_all(clone_to_async! { me = self
+            |addrs| { try_settle(me.rpc.clone(), me.builder.clone(), &addrs).await }
+        })
+        .await
+    }
+
+    /// Loops forever to keep checking the queue for margin accounts. Sends a
+    /// separate Settle transaction for each without blocking. Limits rate based
+    /// on config. Any margin accounts that failed to settle are retried
+    /// indefinitely.
+    pub async fn run_forever(&self) {
+        tracing::info!(
+            "starting settler crank for fixed term market {}",
+            self.builder.market()
+        );
+        loop {
+            let me = self.clone();
+            join!(
+                tokio::time::sleep(self.config.wait_for_more_delay),
+                async move {
+                    me.process_all(clone_to_async! { me
+                        |mut addrs| {
+                            if let Err(e) = try_settle(me.rpc.clone(), me.builder.clone(), &addrs).await {
+                                tracing::error!("failed to settle margin accounts {addrs:?} - {e}");
+                                addrs.reverse();
+                                me.retry_queue.push_many(addrs).await;
+                            }
+                            Ok(())
+                        }
+                    })
+                    .await
+                    .expect("settle_with_recovery is infallible")
+                }
+            );
+        }
+    }
+
+    /// Apply the processor function to margin accounts in the queue until both
+    /// the primary and the retry queues are empty.
+    async fn process_all<F, Fut>(&self, f: F) -> anyhow::Result<()>
+    where
+        F: Fn(Vec<Pubkey>) -> Fut + Send + Sync + 'static + Clone,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let mut remaining = self.margin_accounts.len().await;
+        while remaining > 0 {
+            let mut spawned = vec![];
+            while remaining > 0 {
+                let me = self.clone();
+                let processor = f.clone();
+                spawned.push(tokio::spawn(
+                    async move { me.process_batch(processor).await },
+                ));
+                remaining = self.margin_accounts.len().await;
+                if remaining > 0 {
+                    tokio::time::sleep(self.config.batch_delay).await;
+                }
+            }
+            try_join_all(spawned).await?;
+            if !self.retry_queue.is_empty().await {
+                // Just grab a single batch of retries so they don't get cause a
+                // DoS for new accounts that appear in the main queue.
+                self.margin_accounts
+                    .push_many(self.retry_queue.pop_many(self.config.batch_size).await)
+                    .await;
+            }
+            remaining = self.margin_accounts.len().await;
+        }
+
+        Ok(())
+    }
+
+    /// Apply the processor function to a group of margin accounts from the
+    /// primary queue, equal to batch_size.
+    async fn process_batch<F, Fut>(&self, processor: F) -> anyhow::Result<()>
+    where
+        F: Fn(Vec<Pubkey>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send,
+    {
+        join_all(
+            self.margin_accounts
+                .pop_many(self.config.batch_size)
+                .await
+                .chunks(SETTLES_PER_TX)
+                .map(|addrs| {
+                    let addrs = addrs.to_vec();
+                    processor(addrs)
+                }),
+        )
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(())
     }
 }

--- a/libraries/rust/margin/src/lib.rs
+++ b/libraries/rust/margin/src/lib.rs
@@ -49,7 +49,7 @@
 //! }
 //! ```
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 /// retrieve on-chain state
 pub mod get_state;

--- a/libraries/rust/margin/src/util/mod.rs
+++ b/libraries/rust/margin/src/util/mod.rs
@@ -3,5 +3,7 @@ pub mod asynchronous;
 /// non-blocking communication between threads through a queue that prevents
 /// message duplication.
 pub mod no_dupe_queue;
+/// Data structure to simplify handling of no_dupe_queue items
+pub mod queue_processor;
 
 pub use jet_solana_client::util::data; // TODO: remove

--- a/libraries/rust/margin/src/util/no_dupe_queue.rs
+++ b/libraries/rust/margin/src/util/no_dupe_queue.rs
@@ -7,7 +7,7 @@ use std::{
 use tokio::sync::RwLock;
 
 /// Atomic version of NoDupeQueue that uses async tokio mutexes.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct AsyncNoDupeQueue<T: Hash + Eq>(Arc<RwLock<NoDupeQueue<T>>>);
 
 impl<T: Hash + Eq> AsyncNoDupeQueue<T> {
@@ -56,6 +56,12 @@ impl<T: Hash + Eq> AsyncNoDupeQueue<T> {
             }
         }
         ret
+    }
+}
+
+impl<T: Hash + Eq> Default for AsyncNoDupeQueue<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/libraries/rust/margin/src/util/queue_processor.rs
+++ b/libraries/rust/margin/src/util/queue_processor.rs
@@ -1,0 +1,207 @@
+use std::{fmt::Debug, hash::Hash, time::Duration};
+
+use async_trait::async_trait;
+use futures::{
+    future::{join_all, try_join_all},
+    join, Future,
+};
+use jet_solana_client::clone_to_async;
+
+use crate::util::no_dupe_queue::AsyncNoDupeQueue;
+
+/// Performance settings for the QueueProcessor. The defaults are designed for
+/// use as a Settler.
+#[derive(Clone, Copy, Debug)]
+pub struct QueueProcessorConfig {
+    /// Number of items to process simultaneously. This will be broken down into
+    /// multiple instructions of chunk_size that are executed simultaneously.
+    pub batch_size: usize,
+
+    /// Quantity to send to the processor with a single call.
+    pub chunk_size: usize,
+
+    /// Time to wait between batches when the previous batch maxed out the
+    /// batch_size and there are still more items to process.
+    pub batch_delay: Duration,
+
+    /// Time to wait between batches when the previous batch cleared the entire
+    /// queue and there are no more items to process at this time.
+    pub wait_for_more_delay: Duration,
+}
+impl Default for QueueProcessorConfig {
+    /// Attempts to set a conservative default that can safely coexist with an
+    /// event consumer that deserves higher CPU priority since its tasks are
+    /// more important.
+    fn default() -> Self {
+        Self {
+            batch_size: 10,
+            chunk_size: 3,
+            batch_delay: Duration::from_secs(1),
+            wait_for_more_delay: Duration::from_secs(5),
+        }
+    }
+}
+
+/// A QueueProcessor that always uses the same function to process its items.
+pub struct StaticQueueProcessor<T: Processable, C: ChunkProcessor<T>> {
+    queue_processor: QueueProcessor<T>,
+    chunk_processor: C,
+}
+/// Implement this to use StaticQueueProcesso
+#[async_trait]
+pub trait ChunkProcessor<T>: Clone + Send + Sync + 'static {
+    /// process a single chunk of chunk_size
+    async fn process(&self, chunk: Vec<T>) -> anyhow::Result<()>;
+}
+
+impl<T: Processable, C: ChunkProcessor<T>> StaticQueueProcessor<T, C> {
+    /// constructor
+    pub fn new(
+        input_queue: AsyncNoDupeQueue<T>,
+        config: QueueProcessorConfig,
+        chunk_processor: C,
+    ) -> anyhow::Result<Self> {
+        if config.batch_size == 0 {
+            anyhow::bail!("invalid queue processor batch size of 0");
+        }
+
+        Ok(Self {
+            queue_processor: QueueProcessor::new(input_queue, config)?,
+            chunk_processor,
+        })
+    }
+
+    /// see QueueProcessor::process_forever
+    pub async fn process_forever(&self) {
+        self.queue_processor
+            .process_forever(clone_to_async! { (p = self.chunk_processor) |x| p.process(x).await  })
+            .await
+    }
+
+    /// see QueueProcessor::process_all
+    pub async fn process_all(&self) -> anyhow::Result<()> {
+        self.queue_processor
+            .process_all(clone_to_async! { (p = self.chunk_processor) |x| p.process(x).await })
+            .await
+    }
+}
+
+/// Keeps track of a queue and exposes functions to process the events in that
+/// queue
+#[derive(Clone)]
+pub struct QueueProcessor<T: Processable> {
+    input_queue: AsyncNoDupeQueue<T>,
+    retry_queue: AsyncNoDupeQueue<T>,
+    config: QueueProcessorConfig,
+}
+
+impl<T: Processable> QueueProcessor<T> {
+    /// constructor
+    pub fn new(
+        input_queue: AsyncNoDupeQueue<T>,
+        config: QueueProcessorConfig,
+    ) -> anyhow::Result<Self> {
+        if config.batch_size == 0 {
+            anyhow::bail!("invalid queue processor batch size of 0");
+        }
+
+        Ok(Self {
+            input_queue,
+            retry_queue: Default::default(),
+            config,
+        })
+    }
+
+    /// Loops forever to keep checking the queue for items. Sends a separate
+    /// Settle transaction for each without blocking. Limits rate based on
+    /// config. Any items that failed to process retried indefinitely.
+    pub async fn process_forever<F, Fut>(&self, f: F)
+    where
+        F: Fn(Vec<T>) -> Fut + Send + Sync + 'static + Clone,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        loop {
+            let me = self.clone();
+            let f = f.clone();
+            join!(
+                tokio::time::sleep(self.config.wait_for_more_delay),
+                async move {
+                    me.process_all(clone_to_async! { (f, me)
+                        |mut items| {
+                            if let Err(e) = f(items.clone()).await {
+                                tracing::error!("failed to process {items:?} - {e}");
+                                items.reverse();
+                                me.retry_queue.push_many(items).await;
+                            }
+                            Ok(())
+                        }
+                    })
+                    .await
+                    .expect("recovery makes this is infallible")
+                }
+            );
+        }
+    }
+
+    /// Apply the processor function to items in the queue until both the
+    /// primary and the retry queues are empty.
+    pub async fn process_all<F, Fut>(&self, f: F) -> anyhow::Result<()>
+    where
+        F: Fn(Vec<T>) -> Fut + Send + Sync + 'static + Clone,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let mut remaining = self.input_queue.len().await;
+        while remaining > 0 {
+            let mut spawned = vec![];
+            while remaining > 0 {
+                let me = self.clone();
+                let processor = f.clone();
+                spawned.push(tokio::spawn(
+                    async move { me.process_batch(processor).await },
+                ));
+                remaining = self.input_queue.len().await;
+                if remaining > 0 {
+                    tokio::time::sleep(self.config.batch_delay).await;
+                }
+            }
+            try_join_all(spawned).await?;
+            if !self.retry_queue.is_empty().await {
+                // Just grab a single batch of retries so they don't get cause a
+                // DoS for new items that appear in the main queue.
+                self.input_queue
+                    .push_many(self.retry_queue.pop_many(self.config.batch_size).await)
+                    .await;
+            }
+            remaining = self.input_queue.len().await;
+        }
+
+        Ok(())
+    }
+
+    /// Apply the processor function to a group of items from the primary queue,
+    /// equal to batch_size, chunked in sizes of chunk_size
+    async fn process_batch<F, Fut>(&self, f: F) -> anyhow::Result<()>
+    where
+        F: Fn(Vec<T>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send,
+    {
+        join_all(
+            self.input_queue
+                .pop_many(self.config.batch_size)
+                .await
+                .chunks(self.config.chunk_size)
+                .map(|items| {
+                    let items = items.to_vec();
+                    f(items)
+                }),
+        )
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(())
+    }
+}
+
+/// Everything that needs to be implemented to be used with QueueProcessor
+pub trait Processable: Clone + Debug + Hash + Eq + Send + Sync + 'static {}
+impl<T> Processable for T where T: Clone + Debug + Hash + Eq + Send + Sync + 'static {}

--- a/libraries/rust/solana-client/src/transaction.rs
+++ b/libraries/rust/solana-client/src/transaction.rs
@@ -286,7 +286,7 @@ macro_rules! transactions {
     ($($item:expr),*$(,)?) => {{
         use jet_solana_client::transaction::TransactionBuilder;
         use jet_solana_client::transaction::ToTransactionBuilderVec;
-        let x: Vec<TransactionBuilder> = cat![$(
+        let x: Vec<TransactionBuilder> = $crate::cat![$(
             $item.to_tx_builder_vec(),
         )*];
         x

--- a/libraries/rust/solana-client/src/util/data.rs
+++ b/libraries/rust/solana-client/src/util/data.rs
@@ -52,7 +52,7 @@ macro_rules! cat {
     };
     ($concattable:expr, $($therest:expr),+$(,)?) => {{
         use $crate::util::data::Concat;
-        $concattable.cat(cat![$($therest),+])
+        $concattable.cat($crate::cat![$($therest),+])
     }};
 }
 

--- a/libraries/rust/solana-client/src/util/mod.rs
+++ b/libraries/rust/solana-client/src/util/mod.rs
@@ -69,12 +69,12 @@ impl Key for Keypair {
 #[macro_export]
 macro_rules! clone_to_async {
     (
-        $($to_move:ident $(= $orig_name:ident)?),*
+        ($($to_move:ident $(= $orig_name:expr)?),*)
         |$(mut $arg:ident),*|
-        $blk:block
+        $blk:expr
     ) => {{
         $(
-            $(let $to_move = $orig_name;)?
+            $(let $to_move = $orig_name.clone();)?
             let $to_move = $to_move.clone();
         )*
         move |$(mut $arg),*| {
@@ -83,12 +83,12 @@ macro_rules! clone_to_async {
         }
     }};
     (
-        $($to_move:ident $(= $orig_name:ident)?),*
+        ($($to_move:ident $(= $orig_name:expr)?),*)
         |$($arg:ident),*|
-        $blk:block
+        $blk:expr
     ) => {{
         $(
-            $(let $to_move = $orig_name;)?
+            $(let $to_move = $orig_name.clone();)?
             let $to_move = $to_move.clone();
         )*
         move |$($arg),*| {

--- a/libraries/rust/solana-client/src/util/mod.rs
+++ b/libraries/rust/solana-client/src/util/mod.rs
@@ -64,3 +64,36 @@ impl Key for Keypair {
         self.pubkey()
     }
 }
+
+/// Clone the item and move it into the async closure.
+#[macro_export]
+macro_rules! clone_to_async {
+    (
+        $($to_move:ident $(= $orig_name:ident)?),*
+        |$(mut $arg:ident),*|
+        $blk:block
+    ) => {{
+        $(
+            $(let $to_move = $orig_name;)?
+            let $to_move = $to_move.clone();
+        )*
+        move |$(mut $arg),*| {
+            $(let $to_move = $to_move.clone();)*
+            async move { $blk }
+        }
+    }};
+    (
+        $($to_move:ident $(= $orig_name:ident)?),*
+        |$($arg:ident),*|
+        $blk:block
+    ) => {{
+        $(
+            $(let $to_move = $orig_name;)?
+            let $to_move = $to_move.clone();
+        )*
+        move |$($arg),*| {
+            $(let $to_move = $to_move.clone();)*
+            async move { $blk }
+        }
+    }};
+}

--- a/tests/hosted/src/actions.rs
+++ b/tests/hosted/src/actions.rs
@@ -315,14 +315,11 @@ pub async fn redeem_term_deposits(
 
 pub async fn consume_events(ctx: &TestContext, market: &MarketInfo) {
     let consumer = EventConsumer::new(ctx.rpc().clone_with_payer(ctx.inner.crank.clone()).into());
-
     consumer.load_markets(&[market.address]).await.unwrap();
-    consumer.sync_users().await.unwrap();
-    consumer.sync_queues().await.unwrap();
-
-    while consumer.pending_events(&market.address).unwrap() > 0 {
-        consumer.consume().await.unwrap();
-    }
+    consumer
+        .sync_and_consume_all(&[market.address])
+        .await
+        .unwrap();
 }
 
 pub fn position_balance(account: &MarginAccountClient, token: &Token) -> u64 {

--- a/tests/hosted/src/load.rs
+++ b/tests/hosted/src/load.rs
@@ -130,7 +130,8 @@ pub async fn under_collateralized_fixed_term_borrow_orders(
             pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
             user.refresh_and_margin_borrow_order(underlying(1_000, 2_000)).await?,
         }
-        .send_and_confirm_condensed_in_order(&client).await
+        .send_and_confirm_condensed_in_order(&client)
+        .await
     }))
     .await?;
 

--- a/tests/hosted/tests/fixed_term.rs
+++ b/tests/hosted/tests/fixed_term.rs
@@ -20,7 +20,6 @@ use jet_fixed_term::{
     },
 };
 use jet_margin_sdk::{
-    cat,
     fixed_term::settler::SETTLES_PER_TX,
     ix_builder::MarginIxBuilder,
     margin_integrator::{NoProxy, Proxy},
@@ -32,7 +31,6 @@ use jet_margin_sdk::{
         },
     },
     tx_builder::MarginInvoke,
-    util::data::Concat,
 };
 use jet_margin_sdk::{margin_integrator::RefreshingProxy, refresh::canonical_position_refresher};
 use jet_program_common::{
@@ -482,20 +480,12 @@ async fn settle_many_margin_accounts() -> Result<()> {
                     vec![(collateral, 0, u64::MAX / 1_000)],
                 )
             );
-            cat![
+            transactions! {
                 lender.proxy.refresh().await.unwrap(),
                 borrower.proxy.refresh().await.unwrap(),
-                vec![
-                    lender
-                        .margin_lend_order(underlying(1_001, 2_000))
-                        .await
-                        .unwrap(),
-                    borrower
-                        .margin_borrow_order(underlying(1_000, 2_000))
-                        .await
-                        .unwrap()
-                ],
-            ]
+                lender.margin_lend_order(underlying(1_001, 2_000)).await.unwrap(),
+                borrower.margin_borrow_order(underlying(1_000, 2_000)).await.unwrap()
+            }
             .send_and_confirm_condensed_in_order(&client)
             .await
             .unwrap();
@@ -532,20 +522,12 @@ async fn margin_borrow() -> Result<()> {
     )
     .await;
 
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        user.refresh_and_margin_borrow_order(underlying(1_000, 2_000))
-            .await?,
-    )
+    transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        user.refresh_and_margin_borrow_order(underlying(1_000, 2_000)).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 
@@ -571,20 +553,12 @@ async fn margin_borrow_fails_without_collateral() -> Result<()> {
 
     let user = create_and_fund_fixed_term_market_margin_user(&ctx, manager.clone(), vec![]).await;
 
-    let result = vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        user.refresh_and_margin_borrow_order(underlying(1_000, 2_000))
-            .await?,
-    )
+    let result = transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        user.refresh_and_margin_borrow_order(underlying(1_000, 2_000)).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await;
 
@@ -615,24 +589,14 @@ async fn margin_lend() -> Result<()> {
 
     let user = create_and_fund_fixed_term_market_margin_user(&ctx, manager.clone(), vec![]).await;
 
-    let result = vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        user.refresh_and_margin_lend_order(underlying(1_000, 2_000))
-            .await?,
-    )
+    transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        user.refresh_and_margin_lend_order(underlying(1_000, 2_000)).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
-    .await;
-
-    assert!(result.is_ok());
+    .await?;
 
     assert_eq!(STARTING_TOKENS - 1_000, user.tokens().await?);
     assert_eq!(0, user.tickets().await?);
@@ -660,21 +624,12 @@ async fn margin_borrow_then_margin_lend() -> Result<()> {
 
     let lender = create_and_fund_fixed_term_market_margin_user(&ctx, manager.clone(), vec![]).await;
 
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        borrower
-            .refresh_and_margin_borrow_order(underlying(1_000, 2_000))
-            .await?,
-    )
+    transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        borrower.refresh_and_margin_borrow_order(underlying(1_000, 2_000)).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 
@@ -697,7 +652,6 @@ async fn margin_borrow_then_margin_lend() -> Result<()> {
     assert_eq!(0, lender.claims().await?);
 
     manager.consume_events().await?;
-    let _ = manager.expect_and_execute_settlement(&[&borrower]).await;
     borrower
         .proxy
         .proxy
@@ -740,17 +694,12 @@ async fn margin_lend_then_margin_borrow() -> Result<()> {
     let lender = create_and_fund_fixed_term_market_margin_user(&ctx, manager.clone(), vec![]).await;
 
     let lend_params = underlying(1_001, 2_000);
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(lender.refresh_and_margin_lend_order(lend_params).await?)
+    transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        lender.refresh_and_margin_lend_order(lend_params).await?
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 
@@ -763,21 +712,12 @@ async fn margin_lend_then_margin_borrow() -> Result<()> {
     let simulated_order = manager
         .simulate_new_order_with_fees(borrow_params, agnostic_orderbook::state::Side::Ask)
         .await?;
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        borrower
-            .refresh_and_margin_borrow_order(borrow_params)
-            .await?,
-    )
+    transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        borrower.refresh_and_margin_borrow_order(borrow_params).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 
@@ -836,19 +776,11 @@ async fn margin_sell_tickets() -> Result<()> {
     let user = create_and_fund_fixed_term_market_margin_user(&ctx, manager.clone(), vec![]).await;
     user.convert_tokens(10_000).await.unwrap();
 
-    vec![
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        user.margin_sell_tickets_order(tickets(1_200, 2_000))
-            .await?,
-    )
+    transactions! {
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        user.margin_sell_tickets_order(tickets(1_200, 2_000)).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 
@@ -943,16 +875,12 @@ async fn auto_roll_flags() -> Result<()> {
 
     let mut params = underlying(1_000, 2_000);
     params.auto_roll = true;
-    let borrow_order = vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await?,
-    ]
-    .cat(user.refresh_and_margin_borrow_order(params).await?);
+    let borrow_order = transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        user.refresh_and_margin_borrow_order(params).await?
+    };
 
     // TODO: assert proper failure
     // This fails due to an unconfigured auto_roll setting in the margin_user account
@@ -976,16 +904,12 @@ async fn auto_roll_flags() -> Result<()> {
     assert!(posted_info.flags().contains(CallbackFlags::AUTO_ROLL));
 
     params.auto_roll = false;
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await?,
-    ]
-    .cat(user.refresh_and_margin_borrow_order(params).await?)
+    transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        user.refresh_and_margin_borrow_order(params).await?
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 
@@ -1018,35 +942,13 @@ async fn auto_roll_lend_order_is_correct() -> Result<()> {
     let mut lend_params = underlying(1_001, 2_000);
     lend_params.auto_roll = true;
 
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(lender.refresh_and_margin_lend_order(lend_params).await?)
-    .send_and_confirm_condensed_in_order(&client)
-    .await?;
-
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        borrower
-            .refresh_and_margin_borrow_order(underlying(1_000, 2_000))
-            .await?,
-    )
+    transactions! {
+        pricer.set_oracle_price_tx(&collateral, 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await?,
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        lender.refresh_and_margin_lend_order(lend_params).await?,
+        borrower.refresh_and_margin_borrow_order(underlying(1_000, 2_000)).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 
@@ -1169,35 +1071,13 @@ async fn auto_roll_borrow_order_is_correct() -> Result<()> {
         })
         .await?;
 
-    vec![
+    transactions! {
         pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(lender.refresh_and_margin_lend_order(lend_params).await?)
-    .send_and_confirm_condensed_in_order(&client)
-    .await?;
-
-    vec![
-        pricer.set_oracle_price_tx(&collateral, 1.0).await.unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0)
-            .await
-            .unwrap(),
-        pricer
-            .set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0)
-            .await?,
-    ]
-    .cat(
-        borrower
-            .refresh_and_margin_borrow_order(borrow_params)
-            .await?,
-    )
+        pricer.set_oracle_price_tx(&manager.ix_builder.ticket_mint(), 1.0).await.unwrap(),
+        pricer.set_oracle_price_tx(&manager.ix_builder.token_mint(), 1.0).await?,
+        lender.refresh_and_margin_lend_order(lend_params).await?,
+        borrower.refresh_and_margin_borrow_order(borrow_params).await?,
+    }
     .send_and_confirm_condensed_in_order(&client)
     .await?;
 

--- a/tests/hosted/tests/load.rs
+++ b/tests/hosted/tests/load.rs
@@ -1,10 +1,27 @@
-use hosted_tests::load::{unhealthy_accounts_load_test, UnhealthyAccountsLoadTestScenario};
+use hosted_tests::load::{
+    under_collateralized_fixed_term_borrow_orders, unhealthy_accounts_load_test,
+    UnhealthyAccountsLoadTestScenario,
+};
 use solana_sdk::{signature::Keypair, signer::Signer};
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(not(feature = "localnet"), serial_test::serial)]
-async fn trivial_load_test_execution() -> Result<(), anyhow::Error> {
+async fn pools_load_test_can_run() -> Result<(), anyhow::Error> {
     unhealthy_accounts_load_test(UnhealthyAccountsLoadTestScenario {
+        keep_looping: false,
+        user_count: 1,
+        mint_count: 1,
+        repricing_delay: 0,
+        repricing_scale: 0.9,
+        liquidator: Keypair::new().pubkey(),
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(not(feature = "localnet"), serial_test::serial)]
+async fn fixed_term_load_test_can_run() -> Result<(), anyhow::Error> {
+    under_collateralized_fixed_term_borrow_orders(UnhealthyAccountsLoadTestScenario {
         keep_looping: false,
         user_count: 1,
         mint_count: 1,

--- a/tests/scripts/on_localnet.sh
+++ b/tests/scripts/on_localnet.sh
@@ -136,8 +136,8 @@ with-validator() {
     if [[ ${SOLANA_LOGS:-false} == true ]]; then
         solana -ul logs &
     fi
-    # enable use with the liquidator, using its test key at liquidator/testkey.json
-    solana airdrop 100 6xfNgz63mk5y8K5CSiNfiBN5DCNMj9s9BwNwJznnfHB7
+    # uncomment to enable use with the liquidator, using its test key at liquidator/testkey.json
+    # solana airdrop 100 6xfNgz63mk5y8K5CSiNfiBN5DCNMj9s9BwNwJznnfHB7
     $@
 }
 

--- a/tests/scripts/on_localnet.sh
+++ b/tests/scripts/on_localnet.sh
@@ -136,6 +136,8 @@ with-validator() {
     if [[ ${SOLANA_LOGS:-false} == true ]]; then
         solana -ul logs &
     fi
+    # enable use with the liquidator, using its test key at liquidator/testkey.json
+    solana airdrop 100 6xfNgz63mk5y8K5CSiNfiBN5DCNMj9s9BwNwJznnfHB7
     $@
 }
 


### PR DESCRIPTION
fixed term crank improvements
- implement Crank struct to easily get a complete fixed term crank for any markets
- implement Settler struct for a more flexible approach to settling margin accounts
- generify Settler logic into QueueProcessor type to live alongside the Queue implementation
- use async mutex for inner mutex in EventConsumer to make it Send, since it needs to hold a lock across an await
- fix bug in test that was missed because the settle function was not validating properly

fix issues with liquidator load test:
- actually set the prices correctly
- include a full crank to consume events and settle accounts

misc:
- use transactions macro in fixed term tests to clean up clutter
- clone_to_async macro to simplify creating async closures
