### PR TITLE
get_program_accounts - support all search filters

### DIFF
--- a/libraries/rust/margin/src/fixed_term/event_consumer.rs
+++ b/libraries/rust/margin/src/fixed_term/event_consumer.rs
@@ -10,6 +10,7 @@ use agnostic_orderbook::state::{
 };
 use anchor_lang::AccountDeserialize;
 use futures::{future::join_all, lock::Mutex as AsyncMutex};
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction, packet::PACKET_DATA_SIZE, pubkey::Pubkey,
     signer::Signer, transaction::Transaction,
@@ -142,7 +143,9 @@ impl EventConsumer {
             .rpc
             .get_program_accounts(
                 &jet_fixed_term::ID,
-                Some(8 + std::mem::size_of::<MarginUser>()),
+                vec![RpcFilterType::DataSize(
+                    8 + std::mem::size_of::<MarginUser>() as u64,
+                )],
             )
             .await?;
 

--- a/libraries/rust/margin/src/fixed_term/mod.rs
+++ b/libraries/rust/margin/src/fixed_term/mod.rs
@@ -10,6 +10,7 @@ pub use ix_builder::*;
 
 use anchor_lang::AccountDeserialize;
 use jet_simulation::SolanaRpcClient;
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::{pubkey::Pubkey, signer::Signer};
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -27,7 +28,12 @@ pub async fn find_markets(
     rpc: &Arc<dyn SolanaRpcClient>,
 ) -> anyhow::Result<HashMap<Pubkey, Market>> {
     Ok(rpc
-        .get_program_accounts(&jet_fixed_term::ID, Some(std::mem::size_of::<Market>() + 8))
+        .get_program_accounts(
+            &jet_fixed_term::ID,
+            vec![RpcFilterType::DataSize(
+                std::mem::size_of::<Market>() as u64 + 8,
+            )],
+        )
         .await?
         .into_iter()
         .flat_map(|(k, account)| {

--- a/libraries/rust/margin/src/swap/openbook_swap.rs
+++ b/libraries/rust/margin/src/swap/openbook_swap.rs
@@ -26,6 +26,7 @@ use anchor_lang::ToAccountMetas;
 use anchor_spl::dex::serum_dex::state::{gen_vault_signer_key, MarketState};
 use jet_margin_swap::{accounts as ix_accounts, seeds::OPENBOOK_OPEN_ORDERS, SwapRouteIdentifier};
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, rent::Rent, sysvar::SysvarId};
 
 use crate::ix_builder::SwapAccounts;
@@ -74,7 +75,7 @@ impl OpenBookMarket {
         let program = anchor_spl::dex::id();
         let size = std::mem::size_of::<MarketState>();
         let accounts = rpc
-            .get_program_accounts(&program, Some(size + 12)) // Some(size)
+            .get_program_accounts(&program, vec![RpcFilterType::DataSize(size as u64 + 12)]) // Some(size)
             .await
             .unwrap();
 

--- a/libraries/rust/margin/src/swap/saber_swap.rs
+++ b/libraries/rust/margin/src/swap/saber_swap.rs
@@ -26,6 +26,7 @@ use anchor_lang::ToAccountMetas;
 use jet_margin_swap::{accounts as ix_accounts, SwapRouteIdentifier};
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
 use saber_client::state::SwapInfo;
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::{instruction::AccountMeta, program_pack::Pack, pubkey::Pubkey};
 
 use crate::ix_builder::SwapAccounts;
@@ -66,7 +67,7 @@ impl SaberSwapPool {
         let swap_program = saber_client::id();
         let size = SwapInfo::LEN;
         let accounts = rpc
-            .get_program_accounts(&swap_program, Some(size)) // Some(size)
+            .get_program_accounts(&swap_program, vec![RpcFilterType::DataSize(size as u64)])
             .await
             .unwrap();
 

--- a/libraries/rust/margin/src/swap/spl_swap.rs
+++ b/libraries/rust/margin/src/swap/spl_swap.rs
@@ -26,6 +26,7 @@ use anchor_lang::ToAccountMetas;
 use jet_margin_swap::{accounts as ix_accounts, SwapRouteIdentifier};
 use jet_simulation::solana_rpc_api::SolanaRpcClient;
 use jet_static_program_registry::orca_swap_v2::state::SwapV1;
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::{instruction::AccountMeta, program_pack::Pack, pubkey::Pubkey};
 
 use crate::ix_builder::SwapAccounts;
@@ -70,7 +71,7 @@ impl SplSwapPool {
     ) -> anyhow::Result<HashMap<(Pubkey, Pubkey), Self>> {
         let size = SwapV1::LEN + 1;
         let accounts = rpc
-            .get_program_accounts(&swap_program, Some(size))
+            .get_program_accounts(&swap_program, vec![RpcFilterType::DataSize(size as u64)])
             .await
             .unwrap();
 

--- a/libraries/rust/simulation/src/solana_rpc_api.rs
+++ b/libraries/rust/simulation/src/solana_rpc_api.rs
@@ -57,7 +57,7 @@ pub trait SolanaRpcClient: Send + Sync {
     async fn get_program_accounts(
         &self,
         program_id: &Pubkey,
-        size: Option<usize>,
+        filters: Vec<RpcFilterType>,
     ) -> Result<Vec<(Pubkey, Account)>>;
 
     async fn airdrop(&self, account: &Pubkey, amount: u64) -> Result<()>;
@@ -223,16 +223,14 @@ impl SolanaRpcClient for RpcConnection {
     async fn get_program_accounts(
         &self,
         program_id: &Pubkey,
-        size: Option<usize>,
+        filters: Vec<RpcFilterType>,
     ) -> Result<Vec<(Pubkey, Account)>> {
-        let filters = size.map(|s| vec![RpcFilterType::DataSize(s as u64)]);
-
         Ok(self
             .rpc
             .get_program_accounts_with_config(
                 program_id,
                 RpcProgramAccountsConfig {
-                    filters,
+                    filters: Some(filters),
                     account_config: RpcAccountInfoConfig {
                         encoding: Some(UiAccountEncoding::Base64Zstd),
                         ..Default::default()

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -45,6 +45,7 @@ use jet_margin_sdk::{
 };
 use jet_program_common::Fp32;
 use jet_simulation::{send_and_confirm, solana_rpc_api::SolanaRpcClient};
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::{
     hash::Hash,
     instruction::Instruction,
@@ -751,7 +752,9 @@ impl TestManager {
             .client
             .get_program_accounts(
                 &jet_fixed_term::ID,
-                Some(std::mem::size_of::<TermDeposit>() + 8),
+                vec![RpcFilterType::DataSize(
+                    std::mem::size_of::<TermDeposit>() as u64 + 8,
+                )],
             )
             .await?
             .into_iter()
@@ -776,7 +779,9 @@ impl TestManager {
             .client
             .get_program_accounts(
                 &jet_fixed_term::ID,
-                Some(std::mem::size_of::<TermLoan>() + 8),
+                vec![RpcFilterType::DataSize(
+                    std::mem::size_of::<TermLoan>() as u64 + 8,
+                )],
             )
             .await?
             .into_iter()

--- a/tests/hosted/src/margin.rs
+++ b/tests/hosted/src/margin.rs
@@ -45,6 +45,7 @@ use jet_margin_sdk::solana::transaction::{
 use jet_margin_sdk::swap::spl_swap::SplSwapPool;
 use jet_margin_sdk::tokens::TokenOracle;
 use jet_solana_client::signature::Authorization;
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::signature::{Keypair, Signature, Signer};
 use solana_sdk::system_program;
@@ -142,7 +143,9 @@ impl MarginClient {
         self.rpc
             .get_program_accounts(
                 &jet_margin_pool::ID,
-                Some(std::mem::size_of::<MarginPool>()),
+                vec![RpcFilterType::DataSize(
+                    std::mem::size_of::<MarginPool>() as u64
+                )],
             )
             .await?
             .into_iter()

--- a/tools/jet-alt-registry-client/src/addresses.rs
+++ b/tools/jet-alt-registry-client/src/addresses.rs
@@ -7,6 +7,7 @@ use jet_margin_sdk::{
     jet_margin::{TokenAdmin, TokenConfig},
 };
 use jet_simulation::SolanaRpcClient;
+use solana_client::rpc_filter::RpcFilterType;
 use solana_sdk::account::ReadableAccount;
 
 use crate::Result;
@@ -81,7 +82,10 @@ async fn find_anchor_accounts<T: AccountDeserialize>(
     program: &Pubkey,
 ) -> Result<Vec<(Pubkey, T)>> {
     let result = rpc
-        .get_program_accounts(program, Some(std::mem::size_of::<T>() + 8))
+        .get_program_accounts(
+            program,
+            vec![RpcFilterType::DataSize(std::mem::size_of::<T>() as u64 + 8)],
+        )
         .await?;
     Ok(result
         .into_iter()


### PR DESCRIPTION
In SolanaRpcClient::get_program_accounts, currently we only support searching by account size. This is a frustrating restriction. The underlying rpc client supports other filters that are more valuable than size. I don't see a reason why it needs to be this way.

This change is motivated by the liquidator, which is currently not filtering accounts by anything other than size, which is causing issues on devnet. To filter accounts properly, it will be better if the liquidator can submit requests with the Memcmp filter, instead of filtering by size and the applying another filter manually on top of the response