### PR TITLE
Refactor `AutoRollConfig` and add price bounds to `FixedTermMarket` orders

### DIFF
--- a/libraries/rust/client/src/fixed_term.rs
+++ b/libraries/rust/client/src/fixed_term.rs
@@ -345,6 +345,7 @@ impl<I: NetworkUserInterface> MarginAccountMarketClient<I> {
             self.account
                 .builder
                 .adapter_invoke(self.builder.margin_redeem_deposit(
+                    self.account.state().owner,
                     self.account.address(),
                     deposit_key,
                     Some(token_account),
@@ -517,9 +518,10 @@ impl<I: NetworkUserInterface> MarginAccountMarketClient<I> {
 
         if !self.client.account_exists(&user_market_account).await? {
             ixns.push(
-                self.account
-                    .builder
-                    .adapter_invoke(self.builder.initialize_margin_user(self.account.address)),
+                self.account.builder.adapter_invoke(
+                    self.builder
+                        .initialize_margin_user(self.account.state().owner, self.account.address),
+                ),
             );
 
             ixns.push(

--- a/libraries/rust/client/src/fixed_term.rs
+++ b/libraries/rust/client/src/fixed_term.rs
@@ -463,12 +463,11 @@ impl<I: NetworkUserInterface> MarginAccountMarketClient<I> {
 
         self.with_user_registration(&mut ixns).await?;
 
-        ixns.push(
-            self.account.builder.adapter_invoke(
-                self.builder
-                    .configure_auto_roll(self.account.address, config),
-            ),
-        );
+        ixns.push(self.builder.configure_auto_roll(
+            self.account.address,
+            self.account.state().owner,
+            config,
+        ));
 
         self.account.send_with_refresh(&ixns).await
     }

--- a/libraries/rust/instructions/src/fixed_term/builder.rs
+++ b/libraries/rust/instructions/src/fixed_term/builder.rs
@@ -325,6 +325,7 @@ impl FixedTermIxBuilder {
             ix::sell_tickets_order_accounts(
                 self.orderbook_mut(),
                 user,
+                self.airspace,
                 &self.underlying_mint,
                 ticket_source,
                 token_destination,
@@ -346,6 +347,7 @@ impl FixedTermIxBuilder {
             ix::sell_tickets_order_accounts(
                 self.orderbook_mut(),
                 margin_account,
+                self.airspace,
                 &self.underlying_mint,
                 ticket_source,
                 token_destination,
@@ -380,6 +382,7 @@ impl FixedTermIxBuilder {
         ix::lend_order(
             params,
             seed,
+            self.airspace,
             &self.market,
             user,
             lender_tickets,

--- a/libraries/rust/instructions/src/fixed_term/builder.rs
+++ b/libraries/rust/instructions/src/fixed_term/builder.rs
@@ -496,9 +496,10 @@ impl FixedTermIxBuilder {
     pub fn configure_auto_roll(
         &self,
         margin_account: Pubkey,
+        owner: Pubkey,
         config: AutoRollConfig,
     ) -> Instruction {
-        ix::configure_auto_roll(self.market, margin_account, config)
+        ix::configure_auto_roll(self.market, margin_account, owner, config)
     }
 
     pub fn toggle_auto_roll_deposit(&self, margin_account: Pubkey, deposit: Pubkey) -> Instruction {

--- a/libraries/rust/instructions/src/fixed_term/ix/margin_user.rs
+++ b/libraries/rust/instructions/src/fixed_term/ix/margin_user.rs
@@ -76,8 +76,14 @@ pub fn margin_sell_tickets_order(
     let accounts = jet_fixed_term::accounts::MarginSellTicketsOrder {
         ticket_collateral: user_ticket_collateral(&margin_user),
         ticket_collateral_mint: ticket_collateral_mint(&inner.orderbook_mut.market),
-        inner,
         margin_user,
+        margin_account: inner.authority,
+        user_ticket_vault: inner.user_ticket_vault,
+        user_token_vault: inner.user_token_vault,
+        orderbook_mut: inner.orderbook_mut,
+        ticket_mint: inner.ticket_mint,
+        underlying_token_vault: inner.underlying_token_vault,
+        token_program: inner.token_program,
     }
     .to_account_metas(None);
     Instruction::new_with_bytes(jet_fixed_term::ID, &data, accounts)
@@ -129,6 +135,7 @@ pub fn margin_lend_order(
     let inner = lend_order_accounts(
         params,
         &deposit_seqno.to_le_bytes(),
+        Pubkey::default(), // Airspace only needed to derive permit for non-margin users
         &market,
         margin_account,
         Some(ata(&margin_account, &ticket_mint(&market))),
@@ -140,8 +147,16 @@ pub fn margin_lend_order(
     let accounts = jet_fixed_term::accounts::MarginLendOrder {
         ticket_collateral: user_ticket_collateral(&margin_user),
         ticket_collateral_mint: ticket_collateral_mint(&inner.orderbook_mut.market),
-        inner,
         margin_user,
+        margin_account,
+        orderbook_mut: inner.orderbook_mut,
+        ticket_settlement: inner.ticket_settlement,
+        lender_tokens: inner.lender_tokens,
+        underlying_token_vault: inner.underlying_token_vault,
+        ticket_mint: inner.ticket_mint,
+        payer,
+        system_program: inner.system_program,
+        token_program: inner.token_program,
     }
     .to_account_metas(None);
     Instruction::new_with_bytes(jet_fixed_term::ID, &data, accounts)

--- a/libraries/rust/instructions/src/fixed_term/ix/margin_user.rs
+++ b/libraries/rust/instructions/src/fixed_term/ix/margin_user.rs
@@ -178,12 +178,14 @@ pub fn margin_repay(
 pub fn configure_auto_roll(
     market: Pubkey,
     margin_account: Pubkey,
+    owner: Pubkey,
     config: AutoRollConfig,
 ) -> Instruction {
     let margin_user = margin_user(&market, &margin_account);
     let accounts = jet_fixed_term::accounts::ConfigureAutoRoll {
         margin_user,
         margin_account,
+        owner,
         market,
     }
     .to_account_metas(None);

--- a/libraries/rust/instructions/src/fixed_term/ix/margin_user.rs
+++ b/libraries/rust/instructions/src/fixed_term/ix/margin_user.rs
@@ -8,12 +8,14 @@ use jet_fixed_term::{
     accounts::OrderbookMut, margin::state::AutoRollConfig, orderbook::state::OrderParams,
 };
 
+use crate::airspace::derive_permit;
 use crate::fixed_term::derive::*;
 use crate::margin::derive_token_config;
 
 use super::lend_order_accounts;
 
 pub fn initialize_margin_user(
+    owner: Pubkey,
     margin_account: Pubkey,
     market: Pubkey,
     airspace: Pubkey,
@@ -24,6 +26,7 @@ pub fn initialize_margin_user(
     let claims_mint = claims_mint(&market);
     let margin_user = margin_user(&market, &margin_account);
     let accounts = jet_fixed_term::accounts::InitializeMarginUser {
+        permit: derive_permit(&airspace, &owner),
         market,
         payer,
         margin_user,
@@ -60,7 +63,13 @@ pub fn margin_redeem_deposit(
         ticket_collateral: user_ticket_collateral(&margin_user),
         ticket_collateral_mint: ticket_collateral_mint(market),
         margin_user,
-        inner: accounts,
+        margin_account: accounts.owner,
+        deposit: accounts.deposit,
+        payer: accounts.payer,
+        token_account: accounts.token_account,
+        market: accounts.market,
+        underlying_token_vault: accounts.underlying_token_vault,
+        token_program: accounts.token_program,
     }
     .to_account_metas(None);
     Instruction::new_with_bytes(jet_fixed_term::ID, &data, accounts)

--- a/libraries/rust/instructions/src/fixed_term/ix/user.rs
+++ b/libraries/rust/instructions/src/fixed_term/ix/user.rs
@@ -8,7 +8,7 @@ use jet_fixed_term::{
 use solana_sdk::instruction::Instruction;
 use spl_associated_token_account::get_associated_token_address as ata;
 
-use crate::fixed_term::derive::*;
+use crate::{airspace::derive_permit, fixed_term::derive::*};
 
 /// can derive keys from `owner`, else needs vault addresses
 pub fn convert_tokens(
@@ -126,12 +126,14 @@ pub fn sell_tickets_order(
 pub fn sell_tickets_order_accounts(
     orderbook_mut: OrderbookMut,
     authority: Pubkey,
+    airspace: Pubkey,
     underlying_mint: &Pubkey,
     ticket_source: Option<Pubkey>,
     token_destination: Option<Pubkey>,
 ) -> jet_fixed_term::accounts::SellTicketsOrder {
     let ticket_mint = ticket_mint(&orderbook_mut.market);
     jet_fixed_term::accounts::SellTicketsOrder {
+        permit: derive_permit(&airspace, &authority),
         authority,
         user_ticket_vault: ticket_source.unwrap_or_else(|| ata(&authority, &ticket_mint)),
         user_token_vault: token_destination.unwrap_or_else(|| ata(&authority, underlying_mint)),
@@ -145,6 +147,7 @@ pub fn sell_tickets_order_accounts(
 pub fn lend_order(
     params: OrderParams,
     seed: &[u8],
+    airspace: Pubkey,
     market: &Pubkey,
     authority: Pubkey,
     lender_tickets: Option<Pubkey>,
@@ -161,6 +164,7 @@ pub fn lend_order(
     let accounts = lend_order_accounts(
         params,
         seed,
+        airspace,
         market,
         authority,
         lender_tickets,
@@ -175,6 +179,7 @@ pub fn lend_order(
 pub fn lend_order_accounts(
     params: OrderParams,
     seed: &[u8],
+    airspace: Pubkey,
     market: &Pubkey,
     authority: Pubkey,
     lender_tickets: Option<Pubkey>,
@@ -188,6 +193,7 @@ pub fn lend_order_accounts(
     let lender_tokens = lender_tokens.unwrap_or_else(|| ata(&authority, &underlying_mint));
     let deposit = term_deposit_bytes(market, &authority, seed);
     jet_fixed_term::accounts::LendOrder {
+        permit: derive_permit(&airspace, &authority),
         authority,
         ticket_settlement: if params.auto_stake {
             deposit

--- a/libraries/rust/instructions/src/fixed_term/ix/user.rs
+++ b/libraries/rust/instructions/src/fixed_term/ix/user.rs
@@ -13,6 +13,7 @@ use crate::{airspace::derive_permit, fixed_term::derive::*};
 /// can derive keys from `owner`, else needs vault addresses
 pub fn convert_tokens(
     amount: u64,
+    airspace: Pubkey,
     market: Pubkey,
     owner: Pubkey,
     underlying_token_source: Option<Pubkey>,
@@ -22,6 +23,7 @@ pub fn convert_tokens(
     let ticket_mint = ticket_mint(&market);
     let data = jet_fixed_term::instruction::ExchangeTokens { amount }.data();
     let accounts = jet_fixed_term::accounts::ExchangeTokens {
+        permit: derive_permit(&airspace, &owner),
         underlying_token_vault: underlying_token_vault(&market),
         market,
         ticket_mint,
@@ -38,6 +40,7 @@ pub fn convert_tokens(
 pub fn stake_tickets(
     amount: u64,
     seed: &[u8],
+    airspace: Pubkey,
     market: Pubkey,
     ticket_holder: Pubkey,
     ticket_source: Option<Pubkey>,
@@ -53,6 +56,7 @@ pub fn stake_tickets(
     }
     .data();
     let accounts = jet_fixed_term::accounts::StakeTickets {
+        permit: derive_permit(&airspace, &ticket_holder),
         deposit,
         market,
         ticket_holder,
@@ -73,6 +77,7 @@ pub fn redeem_deposit(accounts: jet_fixed_term::accounts::RedeemDeposit) -> Inst
 }
 
 pub fn redeem_deposit_accounts(
+    airspace: Pubkey,
     market: Pubkey,
     owner: Pubkey,
     underlying_mint: Pubkey,
@@ -82,6 +87,7 @@ pub fn redeem_deposit_accounts(
 ) -> jet_fixed_term::accounts::RedeemDeposit {
     let token_account = token_destination.unwrap_or_else(|| ata(&owner, &underlying_mint));
     jet_fixed_term::accounts::RedeemDeposit {
+        permit: derive_permit(&airspace, &owner),
         deposit,
         owner,
         token_account,

--- a/packages/margin/src/fixed-term/fixedTerm.ts
+++ b/packages/margin/src/fixed-term/fixedTerm.ts
@@ -319,19 +319,15 @@ export class FixedTermMarket {
       .accounts({
         ...this.addresses,
         marginUser: marketUser,
+        marginAccount: user.address,
         ticketCollateralMint: this.addresses.ticketCollateralMint,
         ticketCollateral,
-        inner: {
-          ...this.addresses,
-          orderbookMut: this.orderbookMut(),
-          authority: user.address,
-          payer,
-          ticketMint: this.addresses.ticketMint,
-          tokenProgram: TOKEN_PROGRAM_ID,
-          systemProgram: SystemProgram.programId,
-          lenderTokens: userTokenVault,
-          ticketSettlement
-        }
+        ticketSettlement,
+        lenderTokens: userTokenVault,
+        orderbookMut: this.orderbookMut(),
+        payer,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId
       })
       .instruction()
   }

--- a/packages/margin/src/fixed-term/fixedTerm.ts
+++ b/packages/margin/src/fixed-term/fixedTerm.ts
@@ -592,6 +592,7 @@ export class FixedTermMarket {
         ticketCollateral,
         ticketCollateralMint,
         inner: {
+          permit: marginAccount.findAirspacePermitAddress(),
           deposit: deposit.address,
           owner: marginUser,
           authority: marginAccount.address,

--- a/packages/margin/src/fixed-term/types/JetFixedTerm.ts
+++ b/packages/margin/src/fixed-term/types/JetFixedTerm.ts
@@ -1194,90 +1194,85 @@ export type JetFixedTerm = {
           docs: ["Token mint used by the margin program to track the debt that must be collateralized"]
         },
         {
-          name: "inner"
+          name: "marginAccount"
+          isMut: false
+          isSigner: true
+          docs: ["The margin account responsible for this order"]
+        },
+        {
+          name: "orderbookMut"
           accounts: [
             {
-              name: "authority"
-              isMut: false
-              isSigner: true
-              docs: ["Signing authority over the token vault transferring for a lend order"]
-            },
-            {
-              name: "orderbookMut"
-              accounts: [
-                {
-                  name: "market"
-                  isMut: true
-                  isSigner: false
-                  docs: ["The `Market` account tracks global information related to this particular fixed term market"]
-                },
-                {
-                  name: "orderbookMarketState"
-                  isMut: true
-                  isSigner: false
-                },
-                {
-                  name: "eventQueue"
-                  isMut: true
-                  isSigner: false
-                },
-                {
-                  name: "bids"
-                  isMut: true
-                  isSigner: false
-                },
-                {
-                  name: "asks"
-                  isMut: true
-                  isSigner: false
-                }
-              ]
-            },
-            {
-              name: "ticketSettlement"
+              name: "market"
               isMut: true
               isSigner: false
-              docs: [
-                "where to settle tickets on match:",
-                "- TermDeposit that will be created if the order is filled as a taker and `auto_stake` is enabled",
-                "- ticket token account to receive tickets",
-                "be careful to check this properly. one way is by using lender_tickets_token_account"
-              ]
+              docs: ["The `Market` account tracks global information related to this particular fixed term market"]
             },
             {
-              name: "lenderTokens"
+              name: "orderbookMarketState"
               isMut: true
               isSigner: false
-              docs: ["where to loan tokens from"]
             },
             {
-              name: "underlyingTokenVault"
+              name: "eventQueue"
               isMut: true
               isSigner: false
-              docs: ["The market token vault"]
             },
             {
-              name: "ticketMint"
+              name: "bids"
               isMut: true
               isSigner: false
-              docs: ["The market token vault"]
             },
             {
-              name: "payer"
+              name: "asks"
               isMut: true
-              isSigner: true
-            },
-            {
-              name: "systemProgram"
-              isMut: false
-              isSigner: false
-            },
-            {
-              name: "tokenProgram"
-              isMut: false
               isSigner: false
             }
           ]
+        },
+        {
+          name: "ticketSettlement"
+          isMut: true
+          isSigner: false
+          docs: [
+            "where to settle tickets on match:",
+            "- TermDeposit that will be created if the order is filled as a taker and `auto_stake` is enabled",
+            "- ticket token account to receive tickets",
+            "be careful to check this properly. one way is by using lender_tickets_token_account"
+          ]
+        },
+        {
+          name: "lenderTokens"
+          isMut: true
+          isSigner: false
+          docs: ["where to loan tokens from"]
+        },
+        {
+          name: "underlyingTokenVault"
+          isMut: true
+          isSigner: false
+          docs: ["The market token vault"]
+        },
+        {
+          name: "ticketMint"
+          isMut: true
+          isSigner: false
+          docs: ["The market token vault"]
+        },
+        {
+          name: "payer"
+          isMut: true
+          isSigner: true
+        },
+        {
+          name: "systemProgram"
+          isMut: false
+          isSigner: false
+        },
+        {
+          name: "tokenProgram"
+          isMut: false
+          isSigner: false
         }
       ]
       args: [
@@ -3071,8 +3066,8 @@ export type JetFixedTerm = {
           index: false
         },
         {
-          name: "autoRoll",
-          type: "bool",
+          name: "autoRoll"
+          type: "bool"
           index: false
         }
       ]
@@ -3156,8 +3151,8 @@ export type JetFixedTerm = {
           index: false
         },
         {
-          name: "isAutoRoll",
-          type: "bool",
+          name: "isAutoRoll"
+          type: "bool"
           index: false
         }
       ]
@@ -3191,8 +3186,8 @@ export type JetFixedTerm = {
           index: false
         },
         {
-          name: "isAutoRoll",
-          type: "bool",
+          name: "isAutoRoll"
+          type: "bool"
           index: false
         }
       ]
@@ -5036,90 +5031,85 @@ export const IDL: JetFixedTerm = {
           docs: ["Token mint used by the margin program to track the debt that must be collateralized"]
         },
         {
-          name: "inner",
+          name: "marginAccount",
+          isMut: false,
+          isSigner: true,
+          docs: ["The margin account responsible for this order"]
+        },
+        {
+          name: "orderbookMut",
           accounts: [
             {
-              name: "authority",
-              isMut: false,
-              isSigner: true,
-              docs: ["Signing authority over the token vault transferring for a lend order"]
-            },
-            {
-              name: "orderbookMut",
-              accounts: [
-                {
-                  name: "market",
-                  isMut: true,
-                  isSigner: false,
-                  docs: ["The `Market` account tracks global information related to this particular fixed term market"]
-                },
-                {
-                  name: "orderbookMarketState",
-                  isMut: true,
-                  isSigner: false
-                },
-                {
-                  name: "eventQueue",
-                  isMut: true,
-                  isSigner: false
-                },
-                {
-                  name: "bids",
-                  isMut: true,
-                  isSigner: false
-                },
-                {
-                  name: "asks",
-                  isMut: true,
-                  isSigner: false
-                }
-              ]
-            },
-            {
-              name: "ticketSettlement",
+              name: "market",
               isMut: true,
               isSigner: false,
-              docs: [
-                "where to settle tickets on match:",
-                "- TermDeposit that will be created if the order is filled as a taker and `auto_stake` is enabled",
-                "- ticket token account to receive tickets",
-                "be careful to check this properly. one way is by using lender_tickets_token_account"
-              ]
+              docs: ["The `Market` account tracks global information related to this particular fixed term market"]
             },
             {
-              name: "lenderTokens",
+              name: "orderbookMarketState",
               isMut: true,
-              isSigner: false,
-              docs: ["where to loan tokens from"]
-            },
-            {
-              name: "underlyingTokenVault",
-              isMut: true,
-              isSigner: false,
-              docs: ["The market token vault"]
-            },
-            {
-              name: "ticketMint",
-              isMut: true,
-              isSigner: false,
-              docs: ["The market token vault"]
-            },
-            {
-              name: "payer",
-              isMut: true,
-              isSigner: true
-            },
-            {
-              name: "systemProgram",
-              isMut: false,
               isSigner: false
             },
             {
-              name: "tokenProgram",
-              isMut: false,
+              name: "eventQueue",
+              isMut: true,
+              isSigner: false
+            },
+            {
+              name: "bids",
+              isMut: true,
+              isSigner: false
+            },
+            {
+              name: "asks",
+              isMut: true,
               isSigner: false
             }
           ]
+        },
+        {
+          name: "ticketSettlement",
+          isMut: true,
+          isSigner: false,
+          docs: [
+            "where to settle tickets on match:",
+            "- TermDeposit that will be created if the order is filled as a taker and `auto_stake` is enabled",
+            "- ticket token account to receive tickets",
+            "be careful to check this properly. one way is by using lender_tickets_token_account"
+          ]
+        },
+        {
+          name: "lenderTokens",
+          isMut: true,
+          isSigner: false,
+          docs: ["where to loan tokens from"]
+        },
+        {
+          name: "underlyingTokenVault",
+          isMut: true,
+          isSigner: false,
+          docs: ["The market token vault"]
+        },
+        {
+          name: "ticketMint",
+          isMut: true,
+          isSigner: false,
+          docs: ["The market token vault"]
+        },
+        {
+          name: "payer",
+          isMut: true,
+          isSigner: true
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false
+        },
+        {
+          name: "tokenProgram",
+          isMut: false,
+          isSigner: false
         }
       ],
       args: [

--- a/packages/margin/src/fixed-term/types/JetFixedTerm.ts
+++ b/packages/margin/src/fixed-term/types/JetFixedTerm.ts
@@ -1119,6 +1119,12 @@ export type JetFixedTerm = {
           name: "inner"
           accounts: [
             {
+              name: "permit"
+              isMut: false
+              isSigner: false
+              docs: ["The airspace metadata permit"]
+            },
+            {
               name: "deposit"
               isMut: true
               isSigner: false
@@ -4955,6 +4961,12 @@ export const IDL: JetFixedTerm = {
         {
           name: "inner",
           accounts: [
+            {
+              name: "permit",
+              isMut: false,
+              isSigner: false,
+              docs: ["The airspace metadata permit"]
+            },
             {
               name: "deposit",
               isMut: true,

--- a/packages/margin/src/wasm-src/bindings/fixed_term/instructions.rs
+++ b/packages/margin/src/wasm-src/bindings/fixed_term/instructions.rs
@@ -10,12 +10,14 @@ use crate::{bindings::serialization::JsSerializable, JsResult};
 
 #[wasm_bindgen(js_name = "initializeMarginUserIx", skip_typescript)]
 pub fn initialize_margin_user_js(
+    owner: String,
     margin_account: String,
     market: String,
     airspace: String,
     payer: String,
 ) -> JsResult {
     initialize_margin_user(
+        Pubkey::from_str(&owner)?,
         Pubkey::from_str(&margin_account)?,
         Pubkey::from_str(&market)?,
         Pubkey::from_str(&airspace)?,

--- a/packages/margin/src/wasm-src/bindings/fixed_term/instructions.rs
+++ b/packages/margin/src/wasm-src/bindings/fixed_term/instructions.rs
@@ -28,11 +28,13 @@ pub fn initialize_margin_user_js(
 pub fn configure_auto_roll_lend_js(
     market: String,
     margin_account: String,
+    owner: String,
     limit_price: u64,
 ) -> JsResult {
     configure_auto_roll(
         Pubkey::from_str(&market)?,
         Pubkey::from_str(&margin_account)?,
+        Pubkey::from_str(&owner)?,
         AutoRollConfig::Lend(LendAutoRollConfig { limit_price }),
     )
     .to_js_default_serializer()
@@ -42,12 +44,14 @@ pub fn configure_auto_roll_lend_js(
 pub fn configure_auto_roll_borrow_js(
     market: String,
     margin_account: String,
+    owner: String,
     roll_tenor: u64,
     limit_price: u64,
 ) -> JsResult {
     configure_auto_roll(
         Pubkey::from_str(&market)?,
         Pubkey::from_str(&margin_account)?,
+        Pubkey::from_str(&owner)?,
         AutoRollConfig::Borrow(BorrowAutoRollConfig {
             roll_tenor,
             limit_price,
@@ -68,12 +72,14 @@ export function initializeMarginUserIx(
 export function configureAutoRollLendIx(
     market: string,
     marginAccount: string,
+    owner: string,
     limitPrice: bigint
 ): WasmTransactionInstruction;
   
 export function configureAutoRollBorrowIx(
     market: string,
     marginAccount: string,
+    owner: string,
     rollTenor: bigint,
     limitPrice: bigint
 ): WasmTransactionInstruction;

--- a/programs/fixed-term/src/errors.rs
+++ b/programs/fixed-term/src/errors.rs
@@ -148,4 +148,6 @@ pub enum FixedTermErrorCode {
     TermDepositAlreadyInitialized,
     #[msg("a term deposit belonging to margin account collateral must use the MarginRedeemDeposit instruction")]
     MarginUserCannotUseInstruction,
+    #[msg("cannot place an order with negative interest rates")]
+    PriceOutOfBounds,
 }

--- a/programs/fixed-term/src/margin/instructions/configure_auto_roll.rs
+++ b/programs/fixed-term/src/margin/instructions/configure_auto_roll.rs
@@ -21,8 +21,11 @@ pub struct ConfigureAutoRoll<'info> {
     pub margin_user: Box<Account<'info, MarginUser>>,
 
     /// The signing authority for this user account
-    #[account(signer)]
+    #[account(has_one = owner)]
     pub margin_account: AccountLoader<'info, MarginAccount>,
+
+    /// The controlling signer for the `MarginAccount`
+    pub owner: Signer<'info>,
 
     /// The fixed-term market this user belongs to
     pub market: AccountLoader<'info, Market>,

--- a/programs/fixed-term/src/margin/instructions/margin_lend_order.rs
+++ b/programs/fixed-term/src/margin/instructions/margin_lend_order.rs
@@ -1,13 +1,10 @@
 use anchor_lang::prelude::*;
+use anchor_spl::token::{accessor::mint, Mint, Token, TokenAccount};
+use jet_margin::MarginAccount;
 use jet_program_proc_macros::MarketTokenManager;
 
 use crate::{
-    margin::state::MarginUser,
-    orderbook::{
-        instructions::lend_order::*,
-        state::{LendOrderAccounts, MarginLendAccounts, OrderParams},
-    },
-    serialization::RemainingAccounts,
+    margin::state::MarginUser, orderbook::state::*, serialization::RemainingAccounts,
     FixedTermErrorCode,
 };
 
@@ -16,7 +13,7 @@ pub struct MarginLendOrder<'info> {
     /// The account tracking borrower debts
     #[account(
         mut,
-        constraint = margin_user.margin_account.key() == inner.authority.key(),
+        constraint = margin_user.margin_account.key() == margin_account.key(),
         has_one = ticket_collateral @ FixedTermErrorCode::WrongTicketCollateralAccount,
     )]
     pub margin_user: Box<Account<'info, MarginUser>>,
@@ -29,9 +26,36 @@ pub struct MarginLendOrder<'info> {
     #[account(mut)]
     pub ticket_collateral_mint: AccountInfo<'info>,
 
-    #[market(orderbook_mut)]
-    #[token_program]
-    pub inner: LendOrder<'info>,
+    /// The margin account responsible for this order
+    #[account(signer)]
+    pub margin_account: AccountLoader<'info, MarginAccount>,
+
+    #[market]
+    pub orderbook_mut: OrderbookMut<'info>,
+
+    /// where to settle tickets on match:
+    /// - TermDeposit that will be created if the order is filled as a taker and `auto_stake` is enabled
+    /// - ticket token account to receive tickets
+    /// be careful to check this properly. one way is by using lender_tickets_token_account
+    #[account(mut)]
+    pub(crate) ticket_settlement: AccountInfo<'info>,
+
+    /// where to loan tokens from
+    #[account(mut, constraint = mint(&lender_tokens.to_account_info())? == orderbook_mut.underlying_mint() @ FixedTermErrorCode::WrongUnderlyingTokenMint)]
+    pub lender_tokens: Account<'info, TokenAccount>,
+
+    /// The market token vault
+    #[account(mut, address = orderbook_mut.vault() @ FixedTermErrorCode::WrongVault)]
+    pub underlying_token_vault: Account<'info, TokenAccount>,
+
+    /// The market token vault
+    #[account(mut, address = orderbook_mut.ticket_mint() @ FixedTermErrorCode::WrongTicketMint)]
+    pub ticket_mint: Account<'info, Mint>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
     // Optional event adapter account
     // pub event_adapter: AccountInfo<'info>,
 }
@@ -43,15 +67,15 @@ pub fn handler(ctx: Context<MarginLendOrder>, params: OrderParams) -> Result<()>
         ticket_collateral: &a.ticket_collateral,
         ticket_collateral_mint: &a.ticket_collateral_mint,
         inner: &mut LendOrderAccounts {
-            authority: &a.inner.authority,
-            orderbook_mut: &mut a.inner.orderbook_mut,
-            ticket_settlement: &a.inner.ticket_settlement,
-            lender_tokens: a.inner.lender_tokens.as_ref(),
-            underlying_token_vault: &a.inner.underlying_token_vault,
-            ticket_mint: &a.inner.ticket_mint,
-            payer: &a.inner.payer,
-            system_program: &a.inner.system_program,
-            token_program: &a.inner.token_program,
+            authority: &a.margin_account.to_account_info(),
+            orderbook_mut: &mut a.orderbook_mut,
+            ticket_settlement: &a.ticket_settlement,
+            lender_tokens: a.lender_tokens.as_ref(),
+            underlying_token_vault: &a.underlying_token_vault,
+            ticket_mint: &a.ticket_mint,
+            payer: &a.payer,
+            system_program: &a.system_program,
+            token_program: &a.token_program,
         },
     };
     accounts.margin_lend_order(

--- a/programs/fixed-term/src/margin/instructions/margin_redeem_deposit.rs
+++ b/programs/fixed-term/src/margin/instructions/margin_redeem_deposit.rs
@@ -1,34 +1,63 @@
 use anchor_lang::prelude::*;
+use anchor_spl::token::{Token, TokenAccount};
+use jet_margin::MarginAccount;
 use jet_program_proc_macros::MarketTokenManager;
 
 use crate::{
+    control::state::Market,
     margin::state::MarginUser,
-    tickets::{
-        instructions::redeem_deposit::*,
-        state::{MarginRedeemDepositAccounts, RedeemDepositAccounts},
-    },
+    tickets::state::{MarginRedeemDepositAccounts, RedeemDepositAccounts, TermDeposit},
     FixedTermErrorCode,
 };
 
 #[derive(Accounts, MarketTokenManager)]
 pub struct MarginRedeemDeposit<'info> {
     #[account(mut,
-		constraint = margin_user.margin_account == inner.owner.key() @ FixedTermErrorCode::WrongMarginUserAuthority,
+		has_one = margin_account @ FixedTermErrorCode::WrongMarginUserAuthority,
         has_one = ticket_collateral,
 	)]
     pub margin_user: Box<Account<'info, MarginUser>>,
+
+    #[account(signer)]
+    pub margin_account: AccountLoader<'info, MarginAccount>,
 
     /// Token account used by the margin program to track the collateral value of assets custodied by fixed-term market
     #[account(mut)]
     pub ticket_collateral: AccountInfo<'info>,
 
     /// Token mint used by the margin program to track the collateral value of assets custodied by fixed-term market
-    #[account(mut, address = inner.market.load()?.ticket_collateral_mint)]
+    #[account(mut, address = market.load()?.ticket_collateral_mint)]
     pub ticket_collateral_mint: AccountInfo<'info>,
 
-    #[market]
-    #[token_program]
-    pub inner: RedeemDeposit<'info>,
+    /// The tracking account for the deposit
+    #[account(mut,
+        close = payer,
+        constraint = deposit.owner == margin_account.key() @ FixedTermErrorCode::WrongDepositOwner,
+        has_one = payer
+)]
+    pub deposit: Account<'info, TermDeposit>,
+
+    /// Receiver for the rent used to track the deposit
+    #[account(mut)]
+    pub payer: AccountInfo<'info>,
+
+    /// The token account designated to receive the assets underlying the claim
+    #[account(mut)]
+    pub token_account: Account<'info, TokenAccount>,
+
+    /// The Market responsible for the asset
+    #[account(
+        has_one = underlying_token_vault @ FixedTermErrorCode::WrongVault,
+        constraint = !market.load()?.tickets_paused.as_bool() @ FixedTermErrorCode::TicketsPaused,
+    )]
+    pub market: AccountLoader<'info, Market>,
+
+    /// The vault stores the tokens of the underlying asset managed by the Market
+    #[account(mut)]
+    pub underlying_token_vault: Account<'info, TokenAccount>,
+
+    /// SPL token program
+    pub token_program: Program<'info, Token>,
 }
 
 pub fn handler(ctx: Context<MarginRedeemDeposit>) -> Result<()> {
@@ -38,13 +67,13 @@ pub fn handler(ctx: Context<MarginRedeemDeposit>) -> Result<()> {
         ticket_collateral: &accs.ticket_collateral,
         ticket_collateral_mint: &accs.ticket_collateral_mint,
         inner: &RedeemDepositAccounts {
-            deposit: &accs.inner.deposit,
-            owner: &accs.inner.owner,
-            payer: &accs.inner.payer,
-            token_account: accs.inner.token_account.as_ref(),
-            market: &accs.inner.market,
-            underlying_token_vault: &accs.inner.underlying_token_vault,
-            token_program: &accs.inner.token_program,
+            deposit: &accs.deposit,
+            owner: accs.margin_account.as_ref(),
+            payer: &accs.payer,
+            token_account: accs.token_account.as_ref(),
+            market: &accs.market,
+            underlying_token_vault: &accs.underlying_token_vault,
+            token_program: &accs.token_program,
         },
     };
     accounts.margin_redeem(true)

--- a/programs/fixed-term/src/margin/instructions/margin_sell_tickets_order.rs
+++ b/programs/fixed-term/src/margin/instructions/margin_sell_tickets_order.rs
@@ -1,15 +1,14 @@
 use agnostic_orderbook::state::Side;
 use anchor_lang::prelude::*;
+use anchor_spl::token::{accessor::mint, Mint, Token, TokenAccount};
+use jet_margin::MarginAccount;
 use jet_program_proc_macros::MarketTokenManager;
 
 use crate::{
     events::OrderType,
     margin::state::MarginUser,
     market_token_manager::MarketTokenManager,
-    orderbook::{
-        instructions::sell_tickets_order::*,
-        state::{CallbackFlags, OrderParams, RoundingAction},
-    },
+    orderbook::{instructions::sell_tickets_order::*, state::*},
     serialization::RemainingAccounts,
     FixedTermErrorCode,
 };
@@ -18,7 +17,7 @@ use crate::{
 pub struct MarginSellTicketsOrder<'info> {
     /// The account tracking borrower debts
     #[account(mut,
-        constraint = margin_user.margin_account == inner.authority.key() @ FixedTermErrorCode::UnauthorizedCaller,
+        constraint = margin_user.margin_account == margin_account.key() @ FixedTermErrorCode::UnauthorizedCaller,
         has_one = ticket_collateral @ FixedTermErrorCode::WrongTicketCollateralAccount,
     )]
     pub margin_user: Box<Account<'info, MarginUser>>,
@@ -32,16 +31,42 @@ pub struct MarginSellTicketsOrder<'info> {
     #[account(mut)]
     pub ticket_collateral_mint: AccountInfo<'info>,
 
-    #[market(orderbook_mut)]
-    #[token_program]
-    pub inner: SellTicketsOrder<'info>,
+    #[account(signer)]
+    pub margin_account: AccountLoader<'info, MarginAccount>,
+
+    /// Account containing the tickets being sold
+    #[account(mut, constraint =
+        mint(&user_ticket_vault.to_account_info()).unwrap()
+        == ticket_mint.key() @ FixedTermErrorCode::WrongTicketMint
+    )]
+    pub user_ticket_vault: Account<'info, TokenAccount>,
+
+    /// The account to receive the matched tokens
+    #[account(mut, constraint =
+        mint(&user_token_vault.to_account_info()).unwrap()
+        == orderbook_mut.market.load().unwrap().underlying_token_mint.key() @ FixedTermErrorCode::WrongUnderlyingTokenMint
+    )]
+    pub user_token_vault: Account<'info, TokenAccount>,
+
+    #[market]
+    pub orderbook_mut: OrderbookMut<'info>,
+
+    /// The ticket mint
+    #[account(mut, address = orderbook_mut.market.load().unwrap().ticket_mint.key() @ FixedTermErrorCode::WrongTicketMint)]
+    pub ticket_mint: Account<'info, Mint>,
+
+    /// The token vault holding the underlying token of the ticket
+    #[account(mut, address = orderbook_mut.market.load().unwrap().underlying_token_vault.key() @ FixedTermErrorCode::WrongTicketMint)]
+    pub underlying_token_vault: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
 }
 
 pub fn handler(ctx: Context<MarginSellTicketsOrder>, params: OrderParams) -> Result<()> {
-    let (info, order_summary) = ctx.accounts.inner.orderbook_mut.place_margin_order(
+    let (info, order_summary) = ctx.accounts.orderbook_mut.place_margin_order(
         Side::Ask,
         params,
-        ctx.accounts.inner.authority.key(),
+        ctx.accounts.margin_account.key(),
         ctx.accounts.margin_user.key(),
         ctx.remaining_accounts
             .iter()
@@ -62,11 +87,22 @@ pub fn handler(ctx: Context<MarginSellTicketsOrder>, params: OrderParams) -> Res
         posted_value,
     )?;
 
-    ctx.accounts.inner.sell_tickets(
+    let user = ctx.accounts.margin_user.key();
+    let a = ctx.accounts;
+    SellTicketsAccounts {
+        authority: a.margin_account.as_ref(),
+        user_ticket_vault: a.user_ticket_vault.as_ref(),
+        user_token_vault: a.user_token_vault.as_ref(),
+        orderbook_mut: &a.orderbook_mut,
+        ticket_mint: a.ticket_mint.as_ref(),
+        underlying_token_vault: a.underlying_token_vault.as_ref(),
+        token_program: &a.token_program,
+    }
+    .sell_tickets(
         info.order_tag.as_u128(),
         order_summary,
         &params,
-        Some(ctx.accounts.margin_user.key()),
+        Some(user),
         OrderType::MarginSellTickets,
     )
 }

--- a/programs/fixed-term/src/orderbook/instructions/lend_order.rs
+++ b/programs/fixed-term/src/orderbook/instructions/lend_order.rs
@@ -1,11 +1,19 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{accessor::mint, Mint, Token, TokenAccount};
+use jet_airspace::state::AirspacePermit;
 use jet_program_proc_macros::MarketTokenManager;
 
 use crate::{orderbook::state::*, serialization::RemainingAccounts, FixedTermErrorCode};
 
 #[derive(Accounts, MarketTokenManager)]
 pub struct LendOrder<'info> {
+    /// Metadata permit allowing this user to interact with this market
+    #[account(
+        constraint = permit.owner == authority.key() @ FixedTermErrorCode::WrongAirspaceAuthorization,
+        constraint = permit.airspace == orderbook_mut.airspace() @ FixedTermErrorCode::WrongAirspaceAuthorization,
+    )]
+    pub permit: Account<'info, AirspacePermit>,
+
     /// Authority accounted for as the owner of resulting orderbook bids and `TermDeposit` accounts
     pub authority: Signer<'info>,
 

--- a/programs/fixed-term/src/orderbook/state/mod.rs
+++ b/programs/fixed-term/src/orderbook/state/mod.rs
@@ -107,6 +107,10 @@ impl<'info> OrderbookMut<'info> {
         self.market.load().unwrap().claims_mint
     }
 
+    pub fn airspace(&self) -> Pubkey {
+        self.market.load().unwrap().airspace
+    }
+
     fn place_order(
         &self,
         side: Side,

--- a/programs/fixed-term/src/orderbook/state/mod.rs
+++ b/programs/fixed-term/src/orderbook/state/mod.rs
@@ -5,6 +5,7 @@ mod rounding;
 
 pub use borrow::*;
 pub use event_queue::*;
+use jet_program_common::FP32_ONE;
 pub use lend::*;
 pub use rounding::*;
 
@@ -114,6 +115,10 @@ impl<'info> OrderbookMut<'info> {
     ) -> Result<SensibleOrderSummary> {
         let order_params = params.as_new_order_params(side, info.into());
         let limit_price = order_params.limit_price;
+        require!(
+            limit_price <= FP32_ONE as u64,
+            FixedTermErrorCode::PriceOutOfBounds,
+        );
         let order_summary = new_order::process(
             &crate::id(),
             orderbook_accounts!(self, new_order),

--- a/programs/fixed-term/src/tickets/instructions/exchange_tokens.rs
+++ b/programs/fixed-term/src/tickets/instructions/exchange_tokens.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{transfer, Mint, Token, TokenAccount, Transfer};
+use jet_airspace::state::AirspacePermit;
 use jet_program_proc_macros::MarketTokenManager;
 
 use crate::{
@@ -9,6 +10,13 @@ use crate::{
 
 #[derive(Accounts, MarketTokenManager)]
 pub struct ExchangeTokens<'info> {
+    /// Metadata permit allowing this user to interact with this market
+    #[account(
+        constraint = permit.owner == user_authority.key() @ FixedTermErrorCode::WrongAirspaceAuthorization,
+        constraint = permit.airspace == market.load()?.airspace @ FixedTermErrorCode::WrongAirspaceAuthorization,
+    )]
+    pub permit: Account<'info, AirspacePermit>,
+
     /// The Market manages asset tokens for a particular tenor
     #[account(
             has_one = ticket_mint @ FixedTermErrorCode::WrongTicketMint,

--- a/programs/fixed-term/src/tickets/instructions/redeem_deposit.rs
+++ b/programs/fixed-term/src/tickets/instructions/redeem_deposit.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Token, TokenAccount};
+use jet_airspace::state::AirspacePermit;
 use jet_program_proc_macros::MarketTokenManager;
 
 use crate::{
@@ -10,6 +11,12 @@ use crate::{
 
 #[derive(Accounts, MarketTokenManager)]
 pub struct RedeemDeposit<'info> {
+    /// Metadata permit allowing this user to interact with this market
+    #[account(
+        constraint = permit.airspace == market.load()?.airspace @ FixedTermErrorCode::WrongAirspaceAuthorization,
+    )]
+    pub permit: Account<'info, AirspacePermit>,
+
     /// The tracking account for the deposit
     #[account(mut,
               close = payer,

--- a/programs/fixed-term/src/tickets/instructions/redeem_deposit.rs
+++ b/programs/fixed-term/src/tickets/instructions/redeem_deposit.rs
@@ -13,6 +13,7 @@ use crate::{
 pub struct RedeemDeposit<'info> {
     /// Metadata permit allowing this user to interact with this market
     #[account(
+        has_one = owner @ FixedTermErrorCode::WrongAirspaceAuthorization,
         constraint = permit.airspace == market.load()?.airspace @ FixedTermErrorCode::WrongAirspaceAuthorization,
     )]
     pub permit: Account<'info, AirspacePermit>,

--- a/programs/fixed-term/src/tickets/instructions/stake_tickets.rs
+++ b/programs/fixed-term/src/tickets/instructions/stake_tickets.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{burn, Burn, Mint, Token, TokenAccount};
+use jet_airspace::state::AirspacePermit;
 
 use crate::{
     control::state::Market,
@@ -28,6 +29,13 @@ pub struct StakeTicketsParams {
 #[derive(Accounts)]
 #[instruction(params: StakeTicketsParams)]
 pub struct StakeTickets<'info> {
+    /// Metadata permit allowing this user to interact with this market
+    #[account(
+        constraint = permit.owner == ticket_holder.key() @ FixedTermErrorCode::WrongAirspaceAuthorization,
+        constraint = permit.airspace == market.load()?.airspace @ FixedTermErrorCode::WrongAirspaceAuthorization,
+    )]
+    pub permit: Account<'info, AirspacePermit>,
+
     /// A struct used to track maturation and total claimable funds
     #[account(
         init,

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -1089,20 +1089,22 @@ impl<P: Proxy> FixedTermUser<P> {
     }
 
     pub async fn set_lend_roll_config(&self, config: LendAutoRollConfig) -> Result<Signature> {
-        let set_config = self
-            .manager
-            .ix_builder
-            .configure_auto_roll(self.proxy.pubkey(), AutoRollConfig::Lend(config));
+        let set_config = self.manager.ix_builder.configure_auto_roll(
+            self.proxy.pubkey(),
+            self.owner.pubkey(),
+            AutoRollConfig::Lend(config),
+        );
         self.client
             .send_and_confirm_1tx(&[self.proxy.invoke_signed(set_config)], &[&self.owner])
             .await
     }
 
     pub async fn set_borrow_roll_config(&self, config: BorrowAutoRollConfig) -> Result<Signature> {
-        let set_config = self
-            .manager
-            .ix_builder
-            .configure_auto_roll(self.proxy.pubkey(), AutoRollConfig::Borrow(config));
+        let set_config = self.manager.ix_builder.configure_auto_roll(
+            self.proxy.pubkey(),
+            self.owner.pubkey(),
+            AutoRollConfig::Borrow(config),
+        );
         self.client
             .send_and_confirm_1tx(&[self.proxy.invoke_signed(set_config)], &[&self.owner])
             .await

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -951,7 +951,7 @@ impl<P: Proxy> FixedTermUser<P> {
         let ix = self
             .manager
             .ix_builder
-            .initialize_margin_user(self.proxy.pubkey());
+            .initialize_margin_user(self.owner.pubkey(), self.proxy.pubkey());
         self.client
             .send_and_confirm_1tx(&[self.proxy.invoke_signed(ix)], &[&self.owner])
             .await

--- a/tests/hosted/src/fixed_term.rs
+++ b/tests/hosted/src/fixed_term.rs
@@ -813,11 +813,12 @@ pub trait GenerateProxy {
 #[async_trait]
 impl GenerateProxy for NoProxy {
     async fn generate(
-        _ctx: Arc<MarginTestContext>,
+        ctx: Arc<MarginTestContext>,
         _manager: Arc<TestManager>,
         owner: &Keypair,
         _seed: u16,
     ) -> Result<Self> {
+        ctx.issue_permit(owner.pubkey()).await?;
         Ok(NoProxy(owner.pubkey()))
     }
 }

--- a/tests/hosted/tests/fixed_term.rs
+++ b/tests/hosted/tests/fixed_term.rs
@@ -21,7 +21,6 @@ use jet_fixed_term::{
 };
 use jet_margin_sdk::{
     fixed_term::settler::SETTLES_PER_TX,
-    ix_builder::MarginIxBuilder,
     margin_integrator::{NoProxy, Proxy},
     solana::{
         keypair::KeypairExt,
@@ -45,14 +44,6 @@ async fn non_margin_orders() -> Result<(), anyhow::Error> {
     let ctx = margin_test_context!();
     let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
     non_margin_orders_for_proxy::<NoProxy>(ctx, manager).await
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "localnet"), serial_test::serial)]
-async fn non_margin_orders_through_margin_account() -> Result<()> {
-    let ctx = margin_test_context!();
-    let manager = Arc::new(FixedTermTestManager::full(&ctx).await.unwrap());
-    non_margin_orders_for_proxy::<MarginIxBuilder>(ctx, manager).await
 }
 
 async fn non_margin_orders_for_proxy<P: Proxy + GenerateProxy>(


### PR DESCRIPTION
Adjusting the auto roll config no longer needs to run through an adaptor

Fixed term market orders have configurable bounds on limit price to prevent exploit and potential user error