### PR TITLE
fixed-term: security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6024,9 +6024,9 @@ dependencies = [
 
 [[package]]
 name = "solana-security-txt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0461f3afb29d8591300b3dd09b5472b3772d65688a2826ad960b8c0d5fa605"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"

--- a/libraries/rust/instructions/src/fixed_term/derive.rs
+++ b/libraries/rust/instructions/src/fixed_term/derive.rs
@@ -87,6 +87,16 @@ pub fn term_deposit_bytes(market: &Pubkey, owner: &Pubkey, seed: &[u8]) -> Pubke
     ])
 }
 
+pub fn term_deposit_user_bytes(market: &Pubkey, owner: &Pubkey, seed: &[u8]) -> Pubkey {
+    fixed_term_address(&[
+        jet_fixed_term::seeds::TERM_DEPOSIT,
+        market.as_ref(),
+        owner.as_ref(),
+        jet_fixed_term::seeds::USER,
+        seed,
+    ])
+}
+
 pub fn crank_authorization(market: &Pubkey, crank: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(
         &[

--- a/libraries/rust/instructions/src/fixed_term/ix/user.rs
+++ b/libraries/rust/instructions/src/fixed_term/ix/user.rs
@@ -46,7 +46,7 @@ pub fn stake_tickets(
     ticket_source: Option<Pubkey>,
     payer: Pubkey,
 ) -> Instruction {
-    let deposit = term_deposit_bytes(&market, &ticket_holder, seed);
+    let deposit = term_deposit_user_bytes(&market, &ticket_holder, seed);
     let ticket_mint = ticket_mint(&market);
     let data = jet_fixed_term::instruction::StakeTickets {
         params: StakeTicketsParams {

--- a/programs/fixed-term/src/control/instructions/authorize_crank.rs
+++ b/programs/fixed-term/src/control/instructions/authorize_crank.rs
@@ -3,7 +3,6 @@ use anchor_lang::prelude::*;
 use jet_airspace::state::Airspace;
 
 use crate::control::state::{CrankAuthorization, Market};
-#[cfg(not(feature = "testing"))]
 use crate::FixedTermErrorCode;
 
 #[derive(Accounts)]
@@ -26,6 +25,7 @@ pub struct AuthorizeCrank<'info> {
     pub crank_authorization: Account<'info, CrankAuthorization>,
 
     /// The market this signer is authorized to send instructions to
+    #[account(has_one = airspace @ FixedTermErrorCode::WrongAirspace)]
     pub market: AccountLoader<'info, Market>,
 
     /// The authority that must sign to make this change

--- a/programs/fixed-term/src/lib.rs
+++ b/programs/fixed-term/src/lib.rs
@@ -410,6 +410,9 @@ pub mod seeds {
     pub const TERM_DEPOSIT: &[u8] = b"term_deposit";
 
     #[constant]
+    pub const USER: &[u8] = b"user";
+
+    #[constant]
     pub const ORDERBOOK_MARKET_STATE: &[u8] = b"orderbook_market_state";
 
     #[constant]

--- a/programs/fixed-term/src/tickets/instructions/redeem_deposit.rs
+++ b/programs/fixed-term/src/tickets/instructions/redeem_deposit.rs
@@ -21,6 +21,7 @@ pub struct RedeemDeposit<'info> {
     /// The tracking account for the deposit
     #[account(mut,
               close = payer,
+              has_one = market @ FixedTermErrorCode::WrongMarket,
               has_one = owner @ FixedTermErrorCode::WrongDepositOwner,
               has_one = payer
     )]

--- a/programs/fixed-term/src/tickets/instructions/stake_tickets.rs
+++ b/programs/fixed-term/src/tickets/instructions/stake_tickets.rs
@@ -43,6 +43,7 @@ pub struct StakeTickets<'info> {
             seeds::TERM_DEPOSIT,
             market.key().as_ref(),
             ticket_holder.key.as_ref(),
+            seeds::USER,
             params.seed.as_slice(),
         ],
         bump,

--- a/tests/hosted/tests/fixed_term.rs
+++ b/tests/hosted/tests/fixed_term.rs
@@ -68,7 +68,9 @@ async fn non_margin_orders_for_proxy<P: Proxy + GenerateProxy>(
     alice.stake_tokens(STAKE_AMOUNT, &ticket_seed).await?;
     assert_eq!(alice.tickets().await?, START_TICKETS - STAKE_AMOUNT);
 
-    let deposit = alice.load_term_deposit(&ticket_seed).await?;
+    let deposit = alice
+        .load_term_deposit(jet_fixed_term::seeds::USER.as_ref())
+        .await?;
     assert_eq!(deposit.amount, STAKE_AMOUNT);
     assert_eq!(deposit.market, manager.ix_builder.market());
     assert_eq!(deposit.owner, alice.proxy.pubkey());


### PR DESCRIPTION
- add more missing airspace/market checks
- prevent `stake_tickets` from front running cranks