### PR TITLE
move health check methods from MarginAccount to Valuation

### DIFF
--- a/programs/margin/src/instructions/adapter_invoke.rs
+++ b/programs/margin/src/instructions/adapter_invoke.rs
@@ -74,7 +74,8 @@ pub fn adapter_invoke_handler<'info>(
     ctx.accounts
         .margin_account
         .load()?
-        .verify_healthy_positions(sys().unix_timestamp())?;
+        .valuation(sys().unix_timestamp())?
+        .verify_healthy()?;
 
     Ok(())
 }

--- a/programs/margin/src/instructions/liquidate_begin.rs
+++ b/programs/margin/src/instructions/liquidate_begin.rs
@@ -70,7 +70,7 @@ pub fn liquidate_begin_handler(ctx: Context<LiquidateBegin>) -> Result<()> {
     let timestamp = sys().unix_timestamp();
 
     // verify the account is subject to liquidation
-    account.verify_unhealthy_positions(timestamp)?;
+    account.valuation(timestamp)?.verify_unhealthy()?;
 
     // verify not already being liquidated
     match account.liquidator {

--- a/programs/margin/src/instructions/verify_healthy.rs
+++ b/programs/margin/src/instructions/verify_healthy.rs
@@ -32,7 +32,9 @@ pub struct VerifyHealthy<'info> {
 pub fn verify_healthy_handler(ctx: Context<VerifyHealthy>) -> Result<()> {
     let account = ctx.accounts.margin_account.load()?;
 
-    account.verify_healthy_positions(sys().unix_timestamp())?;
+    account
+        .valuation(sys().unix_timestamp())?
+        .verify_healthy()?;
 
     emit!(events::VerifiedHealthy {
         margin_account: ctx.accounts.margin_account.key(),

--- a/programs/margin/src/instructions/verify_unhealthy.rs
+++ b/programs/margin/src/instructions/verify_unhealthy.rs
@@ -32,7 +32,9 @@ pub struct VerifyUnhealthy<'info> {
 pub fn verify_unhealthy_handler(ctx: Context<VerifyUnhealthy>) -> Result<()> {
     let account = ctx.accounts.margin_account.load()?;
 
-    account.verify_unhealthy_positions(sys().unix_timestamp())?;
+    account
+        .valuation(sys().unix_timestamp())?
+        .verify_unhealthy()?;
 
     emit!(events::VerifiedUnealthy {
         margin_account: ctx.accounts.margin_account.key(),


### PR DESCRIPTION
This refactor enables the liquidator to be more efficient. When evaluating the health of each margin account, the liquidator needs to calculate an account's valuation three times in a quick succession. By moving this logic to the valuation, the liquidator only needs to calculate the valuation once, and can do all its checks from there.

The idea of being in good or bad health is derived solely from the Valuation so this actually seems to me like a better place for the logic.
