### PR TITLE
events: remove margin position events

### DIFF
--- a/programs/margin/src/adapter.rs
+++ b/programs/margin/src/adapter.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::BTreeMap, convert::TryFrom};
+use std::convert::TryFrom;
 
 use anchor_lang::{
     prelude::*,
@@ -26,7 +26,6 @@ use jet_program_common::Number128;
 use solana_program::clock::UnixTimestamp;
 
 use crate::{
-    events::{PositionClosed, PositionEvent, PositionRegistered, PositionTouched},
     syscall::{sys, Sys},
     util::{log_on_error, Require},
     AccountPositionKey, AdapterPositionFlags, Approver, ErrorCode, MarginAccount,
@@ -156,7 +155,7 @@ impl TryFrom<pyth_sdk_solana::PriceFeed> for PriceChangeInfo {
 
 /// Invoke a margin adapter with the requested data
 /// * `signed` - sign with the margin account
-pub fn invoke(ctx: &InvokeAdapter, data: Vec<u8>) -> Result<Vec<PositionEvent>> {
+pub fn invoke(ctx: &InvokeAdapter, data: Vec<u8>) -> Result<()> {
     let signer = ctx.margin_account.load()?.signer_seeds_owned();
 
     let accounts = ctx
@@ -190,8 +189,8 @@ pub fn invoke(ctx: &InvokeAdapter, data: Vec<u8>) -> Result<Vec<PositionEvent>> 
     handle_adapter_result(ctx)
 }
 
-fn handle_adapter_result(ctx: &InvokeAdapter) -> Result<Vec<PositionEvent>> {
-    let mut events = update_balances(ctx)?;
+fn handle_adapter_result(ctx: &InvokeAdapter) -> Result<()> {
+    update_balances(ctx)?;
 
     match program::get_return_data() {
         None => (),
@@ -199,9 +198,7 @@ fn handle_adapter_result(ctx: &InvokeAdapter) -> Result<Vec<PositionEvent>> {
         Some((_, data)) => {
             let result = AdapterResult::deserialize(&mut &data[..])?;
             for (mint, changes) in result.position_changes {
-                if let Some(event) = apply_changes(ctx, mint, changes)? {
-                    events.insert(mint, event);
-                }
+                apply_changes(ctx, mint, changes)?;
             }
         }
     };
@@ -209,12 +206,10 @@ fn handle_adapter_result(ctx: &InvokeAdapter) -> Result<Vec<PositionEvent>> {
     // clear return data after reading it
     program::set_return_data(&[]);
 
-    Ok(events.into_values().collect())
+    Ok(())
 }
 
-fn update_balances(ctx: &InvokeAdapter) -> Result<BTreeMap<Pubkey, PositionEvent>> {
-    let mut touched_positions: BTreeMap<Pubkey, PositionEvent> = BTreeMap::new();
-
+fn update_balances(ctx: &InvokeAdapter) -> Result<()> {
     let mut margin_account = ctx.margin_account.load_mut()?;
     for account_info in ctx.accounts {
         if account_info.owner == &TokenAccount::owner() {
@@ -225,9 +220,7 @@ fn update_balances(ctx: &InvokeAdapter) -> Result<BTreeMap<Pubkey, PositionEvent
                     account_info.key,
                     account.amount,
                 ) {
-                    Ok(position) => {
-                        touched_positions.insert(account.mint, PositionTouched { position }.into());
-                    }
+                    Ok(_) => (),
                     Err(ErrorCode::PositionNotRegistered) => (),
                     Err(err) => return Err(err.into()),
                 }
@@ -235,18 +228,13 @@ fn update_balances(ctx: &InvokeAdapter) -> Result<BTreeMap<Pubkey, PositionEvent
         }
     }
 
-    Ok(touched_positions)
+    Ok(())
 }
 
-fn apply_changes(
-    ctx: &InvokeAdapter,
-    mint: Pubkey,
-    changes: Vec<PositionChange>,
-) -> Result<Option<PositionEvent>> {
+fn apply_changes(ctx: &InvokeAdapter, mint: Pubkey, changes: Vec<PositionChange>) -> Result<()> {
     let mut margin_account = ctx.margin_account.load_mut()?;
     let mut key = margin_account.get_position_key(&mint);
     let mut position = key.and_then(|k| margin_account.get_position_by_key_mut(&k));
-    let mut net_registration = 0isize;
     if let Some(ref p) = position {
         if p.adapter != ctx.adapter_program.key() {
             return err!(ErrorCode::InvalidPositionAdapter);
@@ -277,7 +265,6 @@ fn apply_changes(
                         mint,
                         token_account,
                     )?);
-                    net_registration += 1;
                 }
             },
             PositionChange::Close(token_account) => {
@@ -292,34 +279,11 @@ fn apply_changes(
                         ctx.adapter_result_approvals().as_slice(),
                     )?;
                     key = None;
-                    net_registration -= 1;
                 }
             }
         }
     }
-    Ok(match net_registration {
-        0 => key
-            .and_then(|k| margin_account.get_position_by_key(&k))
-            .map(|p| PositionTouched { position: *p }.into()),
-        n if n > 0 => Some(
-            PositionRegistered {
-                margin_account: ctx.margin_account.key(),
-                position: *key
-                    .and_then(|k| margin_account.get_position_by_key(&k))
-                    .require()?,
-                authority: ctx.adapter_program.key(),
-            }
-            .into(),
-        ),
-        _ => Some(
-            PositionClosed {
-                margin_account: ctx.margin_account.key(),
-                authority: ctx.adapter_program.key(),
-                token: mint,
-            }
-            .into(),
-        ),
-    })
+    Ok(())
 }
 
 fn register_position(
@@ -391,12 +355,6 @@ mod test {
     use anchor_lang::Discriminator;
 
     use super::*;
-
-    impl std::fmt::Debug for PositionEvent {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("PositionEvent").finish()
-        }
-    }
 
     fn all_change_types() -> Vec<PositionChange> {
         vec![

--- a/programs/margin/src/events.rs
+++ b/programs/margin/src/events.rs
@@ -1,15 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::{AccountPosition, Liquidation, Permissions, TokenConfigUpdate, Valuation};
-
-event_groups! {
-    PositionEvent {
-        PositionRegistered,
-        PositionClosed,
-        PositionBalanceUpdated,
-        PositionTouched
-    }
-}
+use crate::{Liquidation, Permissions, TokenConfigUpdate, Valuation};
 
 #[event]
 pub struct AccountCreated {
@@ -32,31 +23,6 @@ pub struct VerifiedHealthy {
 #[event]
 pub struct VerifiedUnealthy {
     pub margin_account: Pubkey,
-}
-
-pub struct PositionRegistered {
-    pub margin_account: Pubkey,
-    pub authority: Pubkey,
-    pub position: AccountPosition,
-}
-
-pub struct PositionClosed {
-    pub margin_account: Pubkey,
-    pub authority: Pubkey,
-    pub token: Pubkey,
-}
-
-pub struct PositionMetadataRefreshed {
-    pub margin_account: Pubkey,
-    pub position: AccountPosition,
-}
-
-pub struct PositionBalanceUpdated {
-    pub position: AccountPosition,
-}
-
-pub struct PositionTouched {
-    pub position: AccountPosition,
 }
 
 #[event]
@@ -160,31 +126,3 @@ impl From<Valuation> for ValuationSummary {
         }
     }
 }
-
-/// Allows you to return a single type that could actually be any of variety of events.
-/// This cannot be done with traits because Box<Dyn $Name> is not possible because
-/// AnchorSerialize prevents trait objects.
-macro_rules! event_groups {
-    ($($Name:ident{$($Variant:ident),+$(,)?})*) => {
-        $(
-        #[allow(clippy::enum_variant_names)]
-        pub enum $Name {
-            $($Variant($Variant),)+
-        }
-
-        // impl $Name {
-        //     pub fn emit(self) {
-        //         match self {
-        //             $(Self::$Variant(item) => emit!(item),)+
-        //         }
-        //     }
-        // }
-
-        $(impl From<$Variant> for $Name {
-            fn from(item: $Variant) -> Self {
-                Self::$Variant(item)
-            }
-        })+)+
-    };
-}
-pub(crate) use event_groups;

--- a/programs/margin/src/events.rs
+++ b/programs/margin/src/events.rs
@@ -34,32 +34,32 @@ pub struct VerifiedUnealthy {
     pub margin_account: Pubkey,
 }
 
-#[event]
+// #[event]
 pub struct PositionRegistered {
     pub margin_account: Pubkey,
     pub authority: Pubkey,
     pub position: AccountPosition,
 }
 
-#[event]
+// #[event]
 pub struct PositionClosed {
     pub margin_account: Pubkey,
     pub authority: Pubkey,
     pub token: Pubkey,
 }
 
-#[event]
+// #[event]
 pub struct PositionMetadataRefreshed {
     pub margin_account: Pubkey,
     pub position: AccountPosition,
 }
 
-#[event]
+// #[event]
 pub struct PositionBalanceUpdated {
     pub position: AccountPosition,
 }
 
-#[event]
+// #[event]
 pub struct PositionTouched {
     pub position: AccountPosition,
 }
@@ -177,13 +177,13 @@ macro_rules! event_groups {
             $($Variant($Variant),)+
         }
 
-        impl $Name {
-            pub fn emit(self) {
-                match self {
-                    $(Self::$Variant(item) => emit!(item),)+
-                }
-            }
-        }
+        // impl $Name {
+        //     pub fn emit(self) {
+        //         match self {
+        //             $(Self::$Variant(item) => emit!(item),)+
+        //         }
+        //     }
+        // }
 
         $(impl From<$Variant> for $Name {
             fn from(item: $Variant) -> Self {

--- a/programs/margin/src/events.rs
+++ b/programs/margin/src/events.rs
@@ -34,32 +34,27 @@ pub struct VerifiedUnealthy {
     pub margin_account: Pubkey,
 }
 
-// #[event]
 pub struct PositionRegistered {
     pub margin_account: Pubkey,
     pub authority: Pubkey,
     pub position: AccountPosition,
 }
 
-// #[event]
 pub struct PositionClosed {
     pub margin_account: Pubkey,
     pub authority: Pubkey,
     pub token: Pubkey,
 }
 
-// #[event]
 pub struct PositionMetadataRefreshed {
     pub margin_account: Pubkey,
     pub position: AccountPosition,
 }
 
-// #[event]
 pub struct PositionBalanceUpdated {
     pub position: AccountPosition,
 }
 
-// #[event]
 pub struct PositionTouched {
     pub position: AccountPosition,
 }

--- a/programs/margin/src/instructions/accounting_invoke.rs
+++ b/programs/margin/src/instructions/accounting_invoke.rs
@@ -46,7 +46,7 @@ pub fn accounting_invoke_handler<'info>(
         adapter_program: ctx.accounts.adapter_program.key(),
     });
 
-    let _events = adapter::invoke(
+    adapter::invoke(
         &InvokeAdapter {
             margin_account: &ctx.accounts.margin_account,
             adapter_program: &ctx.accounts.adapter_program,
@@ -55,10 +55,6 @@ pub fn accounting_invoke_handler<'info>(
         },
         data,
     )?;
-
-    // for event in events {
-    //     event.emit();
-    // }
 
     emit!(events::AccountingInvokeEnd {});
 

--- a/programs/margin/src/instructions/accounting_invoke.rs
+++ b/programs/margin/src/instructions/accounting_invoke.rs
@@ -46,7 +46,7 @@ pub fn accounting_invoke_handler<'info>(
         adapter_program: ctx.accounts.adapter_program.key(),
     });
 
-    let events = adapter::invoke(
+    let _events = adapter::invoke(
         &InvokeAdapter {
             margin_account: &ctx.accounts.margin_account,
             adapter_program: &ctx.accounts.adapter_program,
@@ -56,9 +56,9 @@ pub fn accounting_invoke_handler<'info>(
         data,
     )?;
 
-    for event in events {
-        event.emit();
-    }
+    // for event in events {
+    //     event.emit();
+    // }
 
     emit!(events::AccountingInvokeEnd {});
 

--- a/programs/margin/src/instructions/adapter_invoke.rs
+++ b/programs/margin/src/instructions/adapter_invoke.rs
@@ -55,7 +55,7 @@ pub fn adapter_invoke_handler<'info>(
         adapter_program: ctx.accounts.adapter_program.key(),
     });
 
-    let _events = adapter::invoke(
+    adapter::invoke(
         &InvokeAdapter {
             margin_account: &ctx.accounts.margin_account,
             adapter_program: &ctx.accounts.adapter_program,
@@ -64,10 +64,6 @@ pub fn adapter_invoke_handler<'info>(
         },
         data,
     )?;
-
-    // for event in events {
-    //     event.emit();
-    // }
 
     emit!(events::AdapterInvokeEnd {});
 

--- a/programs/margin/src/instructions/adapter_invoke.rs
+++ b/programs/margin/src/instructions/adapter_invoke.rs
@@ -55,7 +55,7 @@ pub fn adapter_invoke_handler<'info>(
         adapter_program: ctx.accounts.adapter_program.key(),
     });
 
-    let events = adapter::invoke(
+    let _events = adapter::invoke(
         &InvokeAdapter {
             margin_account: &ctx.accounts.margin_account,
             adapter_program: &ctx.accounts.adapter_program,
@@ -65,9 +65,9 @@ pub fn adapter_invoke_handler<'info>(
         data,
     )?;
 
-    for event in events {
-        event.emit();
-    }
+    // for event in events {
+    //     event.emit();
+    // }
 
     emit!(events::AdapterInvokeEnd {});
 

--- a/programs/margin/src/instructions/close_position.rs
+++ b/programs/margin/src/instructions/close_position.rs
@@ -78,11 +78,5 @@ pub fn close_position_handler(ctx: Context<ClosePosition>) -> Result<()> {
         )?;
     }
 
-    // emit!(events::PositionClosed {
-    //     margin_account: ctx.accounts.margin_account.key(),
-    //     authority: ctx.accounts.authority.key(),
-    //     token: ctx.accounts.position_token_mint.key(),
-    // });
-
     Ok(())
 }

--- a/programs/margin/src/instructions/close_position.rs
+++ b/programs/margin/src/instructions/close_position.rs
@@ -18,7 +18,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, CloseAccount, Mint, Token, TokenAccount};
 
-use crate::{events, Approver, MarginAccount, SignerSeeds};
+use crate::{Approver, MarginAccount, SignerSeeds};
 
 #[derive(Accounts)]
 pub struct ClosePosition<'info> {
@@ -78,11 +78,11 @@ pub fn close_position_handler(ctx: Context<ClosePosition>) -> Result<()> {
         )?;
     }
 
-    emit!(events::PositionClosed {
-        margin_account: ctx.accounts.margin_account.key(),
-        authority: ctx.accounts.authority.key(),
-        token: ctx.accounts.position_token_mint.key(),
-    });
+    // emit!(events::PositionClosed {
+    //     margin_account: ctx.accounts.margin_account.key(),
+    //     authority: ctx.accounts.authority.key(),
+    //     token: ctx.accounts.position_token_mint.key(),
+    // });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/liquidator_invoke.rs
+++ b/programs/margin/src/instructions/liquidator_invoke.rs
@@ -63,7 +63,7 @@ pub fn liquidator_invoke_handler<'info>(
         liquidator: ctx.accounts.liquidator.key(),
     });
 
-    let events = adapter::invoke(
+    let _events = adapter::invoke(
         &InvokeAdapter {
             margin_account: &ctx.accounts.margin_account,
             adapter_program: &ctx.accounts.adapter_program,
@@ -73,9 +73,9 @@ pub fn liquidator_invoke_handler<'info>(
         data,
     )?;
 
-    for event in events {
-        event.emit();
-    }
+    // for event in events {
+    //     event.emit();
+    // }
 
     let liquidation = &mut ctx.accounts.liquidation.load_mut()?.state;
     let end_value = update_and_verify_liquidation(

--- a/programs/margin/src/instructions/liquidator_invoke.rs
+++ b/programs/margin/src/instructions/liquidator_invoke.rs
@@ -63,7 +63,7 @@ pub fn liquidator_invoke_handler<'info>(
         liquidator: ctx.accounts.liquidator.key(),
     });
 
-    let _events = adapter::invoke(
+    adapter::invoke(
         &InvokeAdapter {
             margin_account: &ctx.accounts.margin_account,
             adapter_program: &ctx.accounts.adapter_program,
@@ -72,10 +72,6 @@ pub fn liquidator_invoke_handler<'info>(
         },
         data,
     )?;
-
-    // for event in events {
-    //     event.emit();
-    // }
 
     let liquidation = &mut ctx.accounts.liquidation.load_mut()?.state;
     let end_value = update_and_verify_liquidation(

--- a/programs/margin/src/instructions/positions/create_deposit_position.rs
+++ b/programs/margin/src/instructions/positions/create_deposit_position.rs
@@ -21,9 +21,7 @@ use anchor_spl::{
     token::{Mint, Token, TokenAccount},
 };
 
-use crate::{
-    events, util::Require, Approver, ErrorCode, MarginAccount, PositionConfigUpdate, TokenConfig,
-};
+use crate::{Approver, ErrorCode, MarginAccount, PositionConfigUpdate, TokenConfig};
 
 #[derive(Accounts)]
 pub struct CreateDepositPosition<'info> {
@@ -67,7 +65,7 @@ pub fn create_deposit_position_handler(ctx: Context<CreateDepositPosition>) -> R
     let address = ctx.accounts.token_account.key();
     account.verify_authority(ctx.accounts.authority.key())?;
 
-    let key = account.register_position(
+    let _key = account.register_position(
         PositionConfigUpdate::new_from_config(
             config,
             position_token.decimals,
@@ -77,13 +75,13 @@ pub fn create_deposit_position_handler(ctx: Context<CreateDepositPosition>) -> R
         &[Approver::MarginAccountAuthority],
     )?;
 
-    let position = account.get_position_by_key(&key).require()?;
+    // let position = account.get_position_by_key(&key).require()?;
 
-    emit!(events::PositionRegistered {
-        margin_account: ctx.accounts.margin_account.key(),
-        authority: ctx.accounts.authority.key(),
-        position: *position,
-    });
+    // emit!(events::PositionRegistered {
+    //     margin_account: ctx.accounts.margin_account.key(),
+    //     authority: ctx.accounts.authority.key(),
+    //     position: *position,
+    // });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/positions/create_deposit_position.rs
+++ b/programs/margin/src/instructions/positions/create_deposit_position.rs
@@ -65,7 +65,7 @@ pub fn create_deposit_position_handler(ctx: Context<CreateDepositPosition>) -> R
     let address = ctx.accounts.token_account.key();
     account.verify_authority(ctx.accounts.authority.key())?;
 
-    let _key = account.register_position(
+    account.register_position(
         PositionConfigUpdate::new_from_config(
             config,
             position_token.decimals,
@@ -74,14 +74,6 @@ pub fn create_deposit_position_handler(ctx: Context<CreateDepositPosition>) -> R
         ),
         &[Approver::MarginAccountAuthority],
     )?;
-
-    // let position = account.get_position_by_key(&key).require()?;
-
-    // emit!(events::PositionRegistered {
-    //     margin_account: ctx.accounts.margin_account.key(),
-    //     authority: ctx.accounts.authority.key(),
-    //     position: *position,
-    // });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/positions/refresh_position_config.rs
+++ b/programs/margin/src/instructions/positions/refresh_position_config.rs
@@ -47,17 +47,12 @@ pub fn refresh_position_config_handler(ctx: Context<RefreshPositionConfig>) -> R
     let config = &ctx.accounts.config;
     let mut account = ctx.accounts.margin_account.load_mut()?;
 
-    let _position = account.refresh_position_metadata(
+    account.refresh_position_metadata(
         &config.mint,
         config.token_kind,
         config.value_modifier,
         config.max_staleness,
     )?;
-
-    // emit!(events::PositionMetadataRefreshed {
-    //     margin_account: ctx.accounts.margin_account.key(),
-    //     position,
-    // });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/positions/refresh_position_config.rs
+++ b/programs/margin/src/instructions/positions/refresh_position_config.rs
@@ -17,7 +17,7 @@
 
 use anchor_lang::prelude::*;
 
-use crate::{events, ErrorCode, MarginAccount, Permissions, Permit, TokenConfig};
+use crate::{ErrorCode, MarginAccount, Permissions, Permit, TokenConfig};
 
 #[derive(Accounts)]
 pub struct RefreshPositionConfig<'info> {
@@ -47,17 +47,17 @@ pub fn refresh_position_config_handler(ctx: Context<RefreshPositionConfig>) -> R
     let config = &ctx.accounts.config;
     let mut account = ctx.accounts.margin_account.load_mut()?;
 
-    let position = account.refresh_position_metadata(
+    let _position = account.refresh_position_metadata(
         &config.mint,
         config.token_kind,
         config.value_modifier,
         config.max_staleness,
     )?;
 
-    emit!(events::PositionMetadataRefreshed {
-        margin_account: ctx.accounts.margin_account.key(),
-        position,
-    });
+    // emit!(events::PositionMetadataRefreshed {
+    //     margin_account: ctx.accounts.margin_account.key(),
+    //     position,
+    // });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/positions/transfer_deposit.rs
+++ b/programs/margin/src/instructions/positions/transfer_deposit.rs
@@ -111,7 +111,5 @@ pub fn transfer_deposit_handler(ctx: Context<TransferDeposit>, amount: u64) -> R
         )?;
     };
 
-    // emit!(events::PositionBalanceUpdated { position });
-
     Ok(())
 }

--- a/programs/margin/src/instructions/positions/transfer_deposit.rs
+++ b/programs/margin/src/instructions/positions/transfer_deposit.rs
@@ -19,9 +19,11 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Token, TokenAccount, Transfer};
 
 use crate::{
-    events,
+    // events,
     syscall::{sys, Sys},
-    ErrorCode, MarginAccount, SignerSeeds,
+    ErrorCode,
+    MarginAccount,
+    SignerSeeds,
 };
 
 // FIXME: no transfer support for liquidators
@@ -58,7 +60,7 @@ pub fn transfer_deposit_handler(ctx: Context<TransferDeposit>, amount: u64) -> R
         Some(pos) => pos,
     };
 
-    let position = if position.address == ctx.accounts.source.key() {
+    if position.address == ctx.accounts.source.key() {
         let seeds = margin_account.signer_seeds_owned();
         drop(margin_account);
 
@@ -84,7 +86,7 @@ pub fn transfer_deposit_handler(ctx: Context<TransferDeposit>, amount: u64) -> R
             &source.key(),
             source.amount,
             sys().unix_timestamp(),
-        )?
+        )?;
     } else {
         token::transfer(
             CpiContext::new(
@@ -106,10 +108,10 @@ pub fn transfer_deposit_handler(ctx: Context<TransferDeposit>, amount: u64) -> R
             &destination.key(),
             destination.amount,
             sys().unix_timestamp(),
-        )?
+        )?;
     };
 
-    emit!(events::PositionBalanceUpdated { position });
+    // emit!(events::PositionBalanceUpdated { position });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/register_position.rs
+++ b/programs/margin/src/instructions/register_position.rs
@@ -18,9 +18,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
-use crate::{
-    events, util::Require, Approver, ErrorCode, MarginAccount, PositionConfigUpdate, TokenConfig,
-};
+use crate::{Approver, ErrorCode, MarginAccount, PositionConfigUpdate, TokenConfig};
 
 #[derive(Accounts)]
 pub struct RegisterPosition<'info> {
@@ -69,7 +67,7 @@ pub fn register_position_handler(ctx: Context<RegisterPosition>) -> Result<()> {
     let address = ctx.accounts.token_account.key();
     account.verify_authority(ctx.accounts.authority.key())?;
 
-    let key = account.register_position(
+    let _key = account.register_position(
         PositionConfigUpdate::new_from_config(
             config,
             position_token.decimals,
@@ -81,13 +79,13 @@ pub fn register_position_handler(ctx: Context<RegisterPosition>) -> Result<()> {
         &[Approver::MarginAccountAuthority],
     )?;
 
-    let position = account.get_position_by_key(&key).require()?;
+    // let position = account.get_position_by_key(&key).require()?;
 
-    emit!(events::PositionRegistered {
-        margin_account: ctx.accounts.margin_account.key(),
-        authority: ctx.accounts.authority.key(),
-        position: *position,
-    });
+    // emit!(events::PositionRegistered {
+    //     margin_account: ctx.accounts.margin_account.key(),
+    //     authority: ctx.accounts.authority.key(),
+    //     position: *position,
+    // });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/register_position.rs
+++ b/programs/margin/src/instructions/register_position.rs
@@ -67,7 +67,7 @@ pub fn register_position_handler(ctx: Context<RegisterPosition>) -> Result<()> {
     let address = ctx.accounts.token_account.key();
     account.verify_authority(ctx.accounts.authority.key())?;
 
-    let _key = account.register_position(
+    account.register_position(
         PositionConfigUpdate::new_from_config(
             config,
             position_token.decimals,
@@ -78,14 +78,6 @@ pub fn register_position_handler(ctx: Context<RegisterPosition>) -> Result<()> {
         ),
         &[Approver::MarginAccountAuthority],
     )?;
-
-    // let position = account.get_position_by_key(&key).require()?;
-
-    // emit!(events::PositionRegistered {
-    //     margin_account: ctx.accounts.margin_account.key(),
-    //     authority: ctx.accounts.authority.key(),
-    //     position: *position,
-    // });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/update_position_balance.rs
+++ b/programs/margin/src/instructions/update_position_balance.rs
@@ -38,14 +38,12 @@ pub fn update_position_balance_handler(ctx: Context<UpdatePositionBalance>) -> R
     let mut margin_account = ctx.accounts.margin_account.load_mut()?;
     let token_account = &ctx.accounts.token_account;
 
-    let _position = margin_account.set_position_balance(
+    margin_account.set_position_balance(
         &token_account.mint,
         &token_account.key(),
         token_account.amount,
         sys().unix_timestamp(),
     )?;
-
-    // emit!(events::PositionBalanceUpdated { position });
 
     Ok(())
 }

--- a/programs/margin/src/instructions/update_position_balance.rs
+++ b/programs/margin/src/instructions/update_position_balance.rs
@@ -19,7 +19,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::TokenAccount;
 
 use crate::{
-    events,
+    // events,
     syscall::{sys, Sys},
     MarginAccount,
 };
@@ -38,14 +38,14 @@ pub fn update_position_balance_handler(ctx: Context<UpdatePositionBalance>) -> R
     let mut margin_account = ctx.accounts.margin_account.load_mut()?;
     let token_account = &ctx.accounts.token_account;
 
-    let position = margin_account.set_position_balance(
+    let _position = margin_account.set_position_balance(
         &token_account.mint,
         &token_account.key(),
         token_account.amount,
         sys().unix_timestamp(),
     )?;
 
-    emit!(events::PositionBalanceUpdated { position });
+    // emit!(events::PositionBalanceUpdated { position });
 
     Ok(())
 }


### PR DESCRIPTION
This removes logging of margin position events as we now have an alternative way of getting this information.
We stream margin account changes, and diff the positions + balances on each new account that we get. The downside of this approach is that we could miss some updates, however we can compensate for that with building in some redundancy on the data layer.

The benefit of no longer logging these position events is that we're able to fit in more instructions in a versioned transaction without truncating logs. I haven't been able to quantify how the risk of truncation is reduced, however when running e2e with transactions that have a lot of instructions, I wasn't losing the events that I'm interested in.