### PR TITLE
pyth dependency management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,8 @@ dependencies = [
  "lookup-table-registry",
  "mock-adapter",
  "parking_lot 0.12.1",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk 0.7.0",
+ "pyth-sdk-solana 0.7.2",
  "rand 0.7.3",
  "rand_distr",
  "serde_json",
@@ -2651,7 +2652,7 @@ dependencies = [
  "jet-solana-client",
  "jet-test-service",
  "log",
- "pyth-sdk-solana 0.4.2",
+ "pyth-sdk-solana 0.7.2",
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
@@ -2728,7 +2729,7 @@ dependencies = [
  "jet-program-common",
  "jet-solana-client",
  "lazy_static",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk-solana 0.7.2",
  "serde",
  "serde_json",
  "serde_with 1.14.0",
@@ -2789,7 +2790,8 @@ dependencies = [
  "jet-program-proc-macros",
  "num-derive",
  "num-traits",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk 0.7.0",
+ "pyth-sdk-solana 0.7.2",
  "serde",
  "serde_json",
  "static_assertions",
@@ -2860,7 +2862,8 @@ dependencies = [
  "jet-program-common",
  "jet-program-proc-macros",
  "lookup-table-registry",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk 0.7.0",
+ "pyth-sdk-solana 0.7.2",
  "serde",
  "serde_test",
  "solana-program",
@@ -2878,7 +2881,8 @@ dependencies = [
  "jet-margin",
  "jet-metadata",
  "jet-program-common",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk 0.7.0",
+ "pyth-sdk-solana 0.7.2",
  "serde",
  "serde_test",
  "solana-program",
@@ -2914,7 +2918,7 @@ dependencies = [
  "jet-static-program-registry",
  "jet-test-service",
  "num-traits",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk 0.7.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2967,7 +2971,7 @@ dependencies = [
  "jet-program-common",
  "jet-simulation",
  "jet-solana-client",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk-solana 0.7.2",
  "serde_json",
  "solana-clap-utils",
  "solana-cli-config",
@@ -3103,7 +3107,7 @@ dependencies = [
  "bytemuck",
  "jet-program-common",
  "jet-static-program-registry",
- "pyth-sdk-solana 0.7.0",
+ "pyth-sdk-solana 0.7.2",
  "serum_dex 0.5.10",
  "stable-swap-anchor",
  "stable-swap-client",
@@ -4179,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-solana"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c637b4d8e9558e596a13cd5a11e406431c80eed4fbed01e4b1ff474257b04db9"
+checksum = "e1fcd2dcd063ea85004667cf5cb07f30de7387f17249df988a295e764a47b9f5"
 dependencies = [
  "borsh 0.9.3",
  "borsh-derive 0.9.3",

--- a/libraries/rust/client/Cargo.toml
+++ b/libraries/rust/client/Cargo.toml
@@ -30,7 +30,7 @@ solana-sdk = "1.10"
 spl-token = "3"
 spl-associated-token-account = "1"
 spl-token-swap = { version = "3", features = ["no-entrypoint"] }
-pyth-sdk-solana = "0.4"
+pyth-sdk-solana = "0.7.2"
 
 anchor-lang = "0.27"
 

--- a/libraries/rust/client/src/state/oracles.rs
+++ b/libraries/rust/client/src/state/oracles.rs
@@ -1,7 +1,13 @@
 use std::collections::HashSet;
 
+use anchor_lang::prelude::Pubkey;
 use jet_program_common::Number128;
 use jet_solana_client::rpc::SolanaRpcExtra;
+use pyth_sdk_solana::{
+    state::{load_price_account, PriceAccount, PriceStatus},
+    PythError,
+};
+use solana_sdk::account_info::{Account, IntoAccountInfo};
 
 use super::AccountStates;
 use crate::client::ClientResult;
@@ -34,25 +40,36 @@ pub async fn sync(states: &AccountStates) -> ClientResult<()> {
             }
         };
 
-        let price_feed = match pyth_sdk_solana::load_price_feed_from_account(&address, &mut account)
-        {
+        let price_account = match load_price_account_from_account(&address, &mut account) {
             Ok(feed) => feed,
             Err(e) => {
                 log::error!("could not parse oracle '{address}': {e}");
                 continue;
             }
         };
-
-        let current_price = price_feed.get_current_price_unchecked();
+        let current_price = price_account.to_price_feed(&address).get_price_unchecked();
 
         let price = Number128::from_decimal(current_price.price, current_price.expo);
         let state = PriceOracleState {
             price,
-            is_valid: price_feed.get_current_price().is_some(),
+            is_valid: matches!(price_account.agg.status, PriceStatus::Trading),
         };
 
         states.cache.set(&address, state);
     }
 
     Ok(())
+}
+
+/// copy of `pyth_sdk_solana::load_price_feed_from_account` that returns one
+/// step early, so we can access the PriceAccount.
+fn load_price_account_from_account(
+    price_key: &Pubkey,
+    price_account: &mut impl Account,
+) -> Result<PriceAccount, PythError> {
+    let price_account_info = (price_key, price_account).into_account_info();
+    let data = price_account_info
+        .try_borrow_data()
+        .map_err(|_| PythError::InvalidAccountData)?;
+    load_price_account(*data).cloned()
 }

--- a/libraries/rust/margin/Cargo.toml
+++ b/libraries/rust/margin/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1"
 
 agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "fill-event", features = ["lib", "utils"] }
 
-pyth-sdk-solana = "0.7"
+pyth-sdk = "0.7"
 solana-sdk = "1.14"
 # Only used to manually construct RPC calls for versioned transactions, remove when upgrading to 1.14
 solana-client = "1.14"

--- a/programs/fixed-term/Cargo.toml
+++ b/programs/fixed-term/Cargo.toml
@@ -30,7 +30,8 @@ bs58 = "0.4"
 bytemuck = {version = "1.7.2", features = ["derive"]}
 num-derive = "0.3.3"
 num-traits = "0.2"
-pyth-sdk-solana = "0.7"
+pyth-sdk = "0.7"
+pyth-sdk-solana = "0.7.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 agnostic-orderbook = { git = "https://github.com/jet-lab/agnostic-orderbook.git", branch = "fill-event", features = ["lib", "utils"] }

--- a/programs/fixed-term/src/margin/instructions/refresh_position.rs
+++ b/programs/fixed-term/src/margin/instructions/refresh_position.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use anchor_lang::{prelude::*, solana_program::clock::UnixTimestamp};
 use anchor_spl::token::Token;
 use jet_margin::{AdapterPositionFlags, AdapterResult, PositionChange};
-use pyth_sdk_solana::PriceFeed;
+use pyth_sdk::PriceFeed;
 
 use crate::{
     control::{events::PositionRefreshed, state::Market},

--- a/programs/margin-pool/Cargo.toml
+++ b/programs/margin-pool/Cargo.toml
@@ -29,7 +29,8 @@ anchor-lang = "0.27"
 anchor-spl = "0.27"
 solana-program = "1.14"
 
-pyth-sdk-solana = "0.7"
+pyth-sdk = "0.7"
+pyth-sdk-solana = "0.7.2"
 
 jet-program-common = { path = "../../libraries/rust/program-common" }
 jet-margin = { path = "../margin", features = ["cpi"] }

--- a/programs/margin-pool/src/state.rs
+++ b/programs/margin-pool/src/state.rs
@@ -20,7 +20,7 @@ use std::convert::TryFrom;
 
 use anchor_lang::{prelude::*, solana_program::clock::UnixTimestamp};
 use jet_program_common::{Number, BPS_EXPONENT};
-use pyth_sdk_solana::PriceFeed;
+use pyth_sdk::PriceFeed;
 
 #[cfg(any(test, feature = "no-entrypoint"))]
 use serde::{

--- a/programs/margin/Cargo.toml
+++ b/programs/margin/Cargo.toml
@@ -32,7 +32,8 @@ anchor-lang = { version = "0.27", features = [
 anchor-spl = "0.27"
 solana-program = "1.14"
 
-pyth-sdk-solana = "0.7"
+pyth-sdk = "0.7"
+pyth-sdk-solana = "0.7.2"
 
 jet-program-proc-macros = { path = "../../libraries/rust/program-proc-macros" }
 jet-program-common = { path = "../../libraries/rust/program-common" }

--- a/programs/margin/src/adapter.rs
+++ b/programs/margin/src/adapter.rs
@@ -138,10 +138,10 @@ impl PriceChangeInfo {
     }
 }
 
-impl TryFrom<pyth_sdk_solana::PriceFeed> for PriceChangeInfo {
+impl TryFrom<pyth_sdk::PriceFeed> for PriceChangeInfo {
     type Error = ErrorCode;
 
-    fn try_from(oracle: pyth_sdk_solana::PriceFeed) -> std::result::Result<Self, Self::Error> {
+    fn try_from(oracle: pyth_sdk::PriceFeed) -> std::result::Result<Self, Self::Error> {
         let price = oracle.get_price_unchecked();
         let ema_price = oracle.get_ema_price_unchecked();
         Ok(PriceChangeInfo {

--- a/programs/test-service/Cargo.toml
+++ b/programs/test-service/Cargo.toml
@@ -22,7 +22,7 @@ anchor-lang = "0.27"
 anchor-spl = { version = "0.27", features = ["dex"] }
 openbook = { package = "serum_dex", git = "https://github.com/openbook-dex/program", branch = "master", features = ["no-entrypoint"] }
 
-pyth-sdk-solana = "0.7"
+pyth-sdk-solana = "0.7.2"
 bytemuck = "1.7"
 
 saber-stable-swap = { package = "stable-swap-anchor", git = "https://github.com/jet-lab/stable-swap", branch = "master" }

--- a/tests/hosted/Cargo.toml
+++ b/tests/hosted/Cargo.toml
@@ -46,7 +46,8 @@ spl-token = "3.1.0"
 spl-associated-token-account = "1.0"
 saber-client = { package = "stable-swap-client", git = "https://github.com/jet-lab/stable-swap", branch = "master" }
 saber-program = { package = "stable-swap", git = "https://github.com/jet-lab/stable-swap", branch = "master" }
-pyth-sdk-solana = "0.7"
+pyth-sdk = "0.7"
+pyth-sdk-solana = "0.7.2"
 
 jet-fixed-term = { path = "../../programs/fixed-term", features = ["no-entrypoint", "testing"] }
 jet-control = { path = "../../programs/control", features = ["no-entrypoint", "testing"] }

--- a/tests/hosted/src/tokens.rs
+++ b/tests/hosted/src/tokens.rs
@@ -207,7 +207,7 @@ impl TokenManager {
         let mut product_account = pyth_sdk_solana::state::ProductAccount {
             ver: pyth_sdk_solana::state::VERSION,
             magic: pyth_sdk_solana::state::MAGIC,
-            size: std::mem::size_of::<pyth_sdk_solana::Price>() as u32,
+            size: std::mem::size_of::<pyth_sdk::Price>() as u32,
             atype: pyth_sdk_solana::state::AccountType::Product as u32,
             px_acc: price_address,
             attr: [0u8; pyth_sdk_solana::state::PROD_ATTR_SIZE],

--- a/tools/ctl/Cargo.toml
+++ b/tools/ctl/Cargo.toml
@@ -36,7 +36,7 @@ comfy-table = "6"
 anchor-syn = { version = "0.27", features = ["idl"] }
 anchor-lang = "0.27"
 spl-governance = { git = "https://github.com/jet-lab/solana-program-library", branch = "temp-fix-spl-deps", features = ["no-entrypoint"] }
-pyth-sdk-solana = "0.7"
+pyth-sdk-solana = "0.7.2"
 
 solana-account-decoder = "1.14"
 solana-clap-utils = "1.14"

--- a/tools/oracle-mirror/Cargo.toml
+++ b/tools/oracle-mirror/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = "1"
 clap = { version = "3.2", features = ["derive", "env"] }
 tokio = { version = "1.0", features = ["time", "rt"] }
 
-pyth-sdk-solana = "0.7"
+pyth-sdk-solana = "0.7.2"
 solana-clap-utils = "1.14"
 solana-cli-config = "1.14"
 solana-client = "1.14"


### PR DESCRIPTION
I have upgraded some pyth dependencies and replace pyth-sdk-solana with pyth-sdk where possible.

# Motivation
This change:
- generally improves dependency management to avoid unnecessary restrictions.
- facilitates the eventual upgrade of solana to 1.15. we were going to need to make a change like this for our pyth dependencies eventually regardless.
- is a step in the direction of improving the liquidator.

I've been experiencing dependency hell in the liquidator because some solana dependencies are restricting what versions I can use of other crates. For example, solana-logger 1.14 blocks me from using any version of tokio later than 1.14, which is preventing me from using specific features that would improve the quality of the liquidator.

This change on its own is not enough to fix my problems in the liquidator. I need solana to be upgraded from 1.14 to 1.15, but there are two additional issues preventing that at this time:
- solana-client-wasm and solana-extra-wasm do not have 1.15 releases. The reason for this is unclear to me. But it means that I cannot get solana 1.15 working in this repository at all.
- Mainnet is still on 1.14. This may not matter, but I see a hypothetical risk of building a program that uses some features that are not supported by the runtime.

# Changes

### Upgrade pyth-sdk-solana to 0.7.2
pyth-sdk-solana 0.7.1 is only compatible with up to solana 1.14. I've upgraded pyth-sdk-solana to 0.7.2 to enable compatibility with solana 1.15. I made it explicit in Cargo.toml so it is clear that we intentionally need to use at least that version.

### Depend on pyth-sdk instead of pyth-sdk-solana whenever possible
pyth-sdk-solana depends on pyth-sdk and it re-exports the types from pyth-sdk. So you could in theory just depend solely on pyth-sdk-solana and everything would work

The problem is that pyth-sdk-solana also comes with a bunch of restrictions, like what solana versions it is compatible with. So it would be a best practice to use pyth-sdk directly whenever possible, and only depend on pyth-sdk-solana when you actually need code specifically from that crate.

### Oracle sync code change
For some reason, the oracle sync was using pyth-sdk-solana 0.4.2, and there have been breaking changes to the crate since then. In order to upgrade, a code change was required.

I implemented it such that the logic is exactly the same as it was before. I needed to adapt some of the code from version 0.4.2 to make this possible. I just wanted to keep the logic identical for this PR so it is easy to reason about its implications. If we actually want a change in behavior here, we can revisit this with another PR.