### PR TITLE
Fix fixed term valuation

### DIFF
--- a/packages/margin/src/margin/accountPosition.ts
+++ b/packages/margin/src/margin/accountPosition.ts
@@ -35,8 +35,8 @@ export class AccountPosition {
     if (this.price) {
       return this.balance.toNumber() * 10 ** this.exponent * this.price.price
     } else {
-      return NaN
-    } 
+      return 0.0
+    }
   }
 
   /** The amount of tokens in the account */

--- a/packages/margin/src/margin/marginAccount.ts
+++ b/packages/margin/src/margin/marginAccount.ts
@@ -551,7 +551,7 @@ export class MarginAccount {
 
     let borrow = TokenAmount.tokens(
       this.valuation.availableSetupCollateral /
-        (1 - depositNoteValueModifier + 1 / (loanNoteValueModifier * MarginAccount.SETUP_LEVERAGE_FRACTION)),
+      (1 - depositNoteValueModifier + 1 / (loanNoteValueModifier * MarginAccount.SETUP_LEVERAGE_FRACTION)),
       decimals
     )
     borrow = TokenAmount.min(borrow, effectiveVaultForBorrow)
@@ -587,7 +587,7 @@ export class MarginAccount {
     if (equity >= 0) {
       leverage = assets / equity
     } else {
-      leverage = Infinity
+      leverage = 999.9 // This is better than infinity
     }
 
     const availableCollateral = this.valuation.availableCollateral

--- a/packages/store/src/api.ts
+++ b/packages/store/src/api.ts
@@ -58,9 +58,7 @@ export const useFixedTermAccountingShim = (apiEndpoint: string, account?: string
       if (account) {
         return fetch(`${apiEndpoint}/${path}`).then(r => r.json());
       } else {
-        return {
-          asset_value: 0
-        } as FixedTermAccountingShim;
+        return {} as FixedTermAccountingShim;
       }
     },
     { refreshInterval: 30_000 }

--- a/ts-types/blackbox/fixed-term.d.ts
+++ b/ts-types/blackbox/fixed-term.d.ts
@@ -83,6 +83,4 @@ interface SwapLiquidity {
   price_range: [min: number, max: number];
 }
 
-interface FixedTermAccountingShim {
-  asset_value: number;
-}
+type FixedTermAccountingShim = Record<string, number>;


### PR DESCRIPTION
The account summary is incorrect because the fixed term values don't consider USD values. This would have caused the UI to display incorrect balances for say SOL markets.

The fix is in the data service to return a map of underlying mint and its asset values. Then the UI converts this to a USD value using latest prices.