### PR TITLE
ui: use websockets for margin account update + disable swap page

### DIFF
--- a/apps/react-app/src/App.tsx
+++ b/apps/react-app/src/App.tsx
@@ -17,7 +17,7 @@ import '@styles/App.less';
 
 const AccountsView = lazy(() => import('@views/AccountsView'));
 const PoolsView = lazy(() => import('@views/PoolsView'));
-const SwapsView = lazy(() => import('@views/SwapsView'));
+// const SwapsView = lazy(() => import('@views/SwapsView'));
 
 const StateSyncer = lazy(() => import('@state/StateSyncer'));
 const FixedLendView = lazy(() => import('@views/FixedLendView'));
@@ -51,14 +51,14 @@ export const App = (): JSX.Element => {
                 </Suspense>
               }
             />
-            <Route
+            {/* <Route
               path="/swaps"
               element={
                 <Suspense>
                   <SwapsView />
                 </Suspense>
               }
-            />
+            /> */}
             <Route
               path="/accounts"
               element={

--- a/apps/react-app/src/components/misc/AccountSnapshot/SnapshotHead.tsx
+++ b/apps/react-app/src/components/misc/AccountSnapshot/SnapshotHead.tsx
@@ -8,9 +8,11 @@ import { Typography, Button, Dropdown, Tabs } from 'antd';
 import { StarFilled, StarOutlined } from '@ant-design/icons';
 import AngleDown from '@assets/icons/arrow-angle-down.svg';
 import { CopyableField } from '../CopyableField';
+import { useJetStore } from '@jet-lab/store';
 
 // Head of the Account Snapshot, where user can select/edit/create their margin accounts
 export function SnapshotHead(): JSX.Element {
+  const selectMarginAccount = useJetStore().selectMarginAccount;
   const dictionary = useRecoilValue(Dictionary);
   const { publicKey } = useWallet();
   const walletTokens = useRecoilValue(WalletTokens);
@@ -51,6 +53,7 @@ export function SnapshotHead(): JSX.Element {
         } else if (!newFavorites.includes(accountKey)) {
           newFavorites.push(accountKey);
           setCurrentAccountAddress(accountKey);
+          selectMarginAccount(accountKey);
         }
         favoriteAccountsClone[publicKey.toString()] = newFavorites;
         setFavoriteAccounts(favoriteAccountsClone);
@@ -67,7 +70,10 @@ export function SnapshotHead(): JSX.Element {
       render = (
         <Tabs
           activeKey={currentAccountAddress}
-          onChange={(key: string) => setCurrentAccountAddress(key)}
+          onChange={(key: string) => {
+            setCurrentAccountAddress(key)
+            selectMarginAccount(key);
+          }}
           className={
             !currentAccountAddress || !walletFavoriteAccounts.includes(currentAccountAddress) ? 'no-active-tabs' : ''
           }
@@ -107,7 +113,10 @@ export function SnapshotHead(): JSX.Element {
                 key,
                 label: (
                   <div
-                    onClick={() => setCurrentAccountAddress(key)}
+                    onClick={() => {
+                      setCurrentAccountAddress(key)
+                      selectMarginAccount(key);
+                    }}
                     className="all-accounts-menu-name flex align-center justify-start">
                     {walletFavoriteAccounts.includes(key) ? (
                       <StarFilled style={{ opacity: 1 }} onClick={() => updateFavoriteAccounts(key, true)} />

--- a/apps/react-app/src/components/misc/Navbar/NavLinks.tsx
+++ b/apps/react-app/src/components/misc/Navbar/NavLinks.tsx
@@ -20,7 +20,7 @@ export function NavLinks(): JSX.Element {
   const cluster = useJetStore(state => state.settings.cluster);
   const navLinks: Link[] = [
     { title: dictionary.poolsView.title, route: '/', disabled: false, hidden: false },
-    { title: dictionary.swapsView.title, route: '/swaps', disabled: false, hidden: false },
+    { title: dictionary.swapsView.title, route: '/swaps', disabled: false, hidden: cluster !== 'localnet' },
     { title: dictionary.accountsView.title, route: '/accounts', disabled: false, hidden: false },
     { title: 'Fixed Lend', route: '/fixed-lend', disabled: false, hidden: cluster === 'mainnet-beta' },
     { title: 'Fixed Borrow', route: '/fixed-borrow', disabled: false, hidden: cluster === 'mainnet-beta' }

--- a/apps/react-app/src/state/config/marginConfig.ts
+++ b/apps/react-app/src/state/config/marginConfig.ts
@@ -13,9 +13,9 @@ export const MainConfig = atom<MarginConfig | undefined>({
 
 // A syncer to be called so that we can have dependent atom state
 export function useMainConfigSyncer() {
-  const { cluster, updateLookupTables } = useJetStore(state => ({
+  const { cluster, updateAirspaceLookupTables } = useJetStore(state => ({
     cluster: state.settings.cluster,
-    updateLookupTables: state.updateLookupTables
+    updateAirspaceLookupTables: state.updateAirspaceLookupTables
   }));
   const setMainConfig = useSetRecoilState(MainConfig);
 
@@ -32,7 +32,7 @@ export function useMainConfigSyncer() {
         let airspaces = (await axios.get('/localnet.config.json')).data.airspaces;
         return getAuthorityLookupTables(airspaces[0].lookupRegistryAuthority)
       }).then(addresses => {
-        updateLookupTables(addresses);
+        updateAirspaceLookupTables(addresses);
       });
     } else {
       MarginClient.getConfig(cluster).then(config => setMainConfig(config));

--- a/apps/react-app/src/state/user/accounts.tsx
+++ b/apps/react-app/src/state/user/accounts.tsx
@@ -127,7 +127,9 @@ export function useAccountsSyncer() {
       }
 
       // Load accounts, only use ones that exist
-      setAccountsLoading(true);;
+      setAccountsLoading(true);
+      const accountData = Object.values(marginAccounts)
+      console.log('accounts and prices', JSON.stringify(accountData, null, 2), !!prices)
       const accounts = await MarginAccount.loadAllByOwnerFromCache({
         programs,
         provider,
@@ -135,7 +137,7 @@ export function useAccountsSyncer() {
         walletTokens,
         owner,
         prices,
-        accountData: Object.values(marginAccounts),
+        accountData
       });
 
       // Set up accountNames and set up histories

--- a/apps/react-app/src/state/user/accounts.tsx
+++ b/apps/react-app/src/state/user/accounts.tsx
@@ -128,16 +128,15 @@ export function useAccountsSyncer() {
 
       // Load accounts, only use ones that exist
       setAccountsLoading(true);
-      const accountData = Object.values(marginAccounts)
-      console.log('accounts and prices', JSON.stringify(accountData, null, 2), !!prices)
-      const accounts = await MarginAccount.loadAllByOwnerFromCache({
+      const accounts = await MarginAccount.loadAllByOwner({
         programs,
         provider,
         pools: pools.tokenPools,
         walletTokens,
         owner,
         prices,
-        accountData
+        doRefresh: true,
+        doFilterAirspace: true
       });
 
       // Set up accountNames and set up histories

--- a/apps/react-app/src/utils/jet/marginActions.ts
+++ b/apps/react-app/src/utils/jet/marginActions.ts
@@ -22,6 +22,7 @@ export enum ActionResponse {
   Cancelled = 'CANCELLED'
 }
 export function useMarginActions() {
+  const selectMarginAccount = useJetStore().selectMarginAccount;
   const config = useRecoilValue(MainConfig);
   const [cluster, prices] = useJetStore(state => [state.settings.cluster, state.prices]);
   const dictionary = useRecoilValue(Dictionary);
@@ -46,8 +47,8 @@ export function useMarginActions() {
     (cluster === 'mainnet-beta'
       ? ''
       : cluster === 'devnet'
-      ? process.env.REACT_APP_DEV_SWAP_API
-      : process.env.REACT_APP_LOCAL_SWAP_API) || '';
+        ? process.env.REACT_APP_DEV_SWAP_API
+        : process.env.REACT_APP_LOCAL_SWAP_API) || '';
 
   // Refresh to trigger new data fetching after a timeout
   async function actionRefresh() {
@@ -199,7 +200,9 @@ export function useMarginActions() {
       newWalletFavorites.add(newMarginAccount.address.toString());
       favoriteAccountsClone[wallet.publicKey.toString()] = Array.from(newWalletFavorites);
       setFavoriteAccounts(favoriteAccountsClone);
-      setCurrentAccountAddress(newMarginAccount.address.toString());
+      const selected = newMarginAccount.address.toString();
+      setCurrentAccountAddress(selected);
+      selectMarginAccount(selected);
 
       await actionRefresh();
       return [undefined, ActionResponse.Success];

--- a/packages/margin/src/fixed-term/api.ts
+++ b/packages/margin/src/fixed-term/api.ts
@@ -116,7 +116,7 @@ export const offerLoan = async ({
     instructions: orderInstructions,
     adapterInstruction: loanOffer
   })
-  return sendAndConfirmV0(provider, [instructions, orderInstructions], airspaceLookupTables, [])
+  return sendAndConfirmV0(provider, [instructions.concat(orderInstructions)], airspaceLookupTables, [])
 }
 
 interface ICreateBorrowOrder {
@@ -196,7 +196,7 @@ export const requestLoan = async ({
     instructions: orderInstructions,
     adapterInstruction: borrowOffer
   })
-  return sendAndConfirmV0(provider, [setupInstructions, orderInstructions], airspaceLookupTables, [])
+  return sendAndConfirmV0(provider, [setupInstructions.concat(orderInstructions)], airspaceLookupTables, [])
 }
 
 interface ICancelOrder {
@@ -336,7 +336,7 @@ export const borrowNow = async ({
     instructions: orderInstructions,
     adapterInstruction: depositIx
   })
-  return sendAndConfirmV0(provider, [setupInstructions, orderInstructions], airspaceLookupTables, [])
+  return sendAndConfirmV0(provider, [setupInstructions.concat(orderInstructions)], airspaceLookupTables, [])
 }
 
 interface ILendNow {
@@ -408,7 +408,7 @@ export const lendNow = async ({
 
   await marginAccount.withUpdateAllPositionBalances({ instructions: orderInstructions })
 
-  return sendAndConfirmV0(provider, [setupInstructions, orderInstructions], airspaceLookupTables, [])
+  return sendAndConfirmV0(provider, [setupInstructions.concat(orderInstructions)], airspaceLookupTables, [])
 }
 
 interface ISettle {
@@ -465,7 +465,7 @@ export const settle = async ({
     adapterInstruction: depositIx
   })
   await marginAccount.withUpdatePositionBalance({ instructions: settleInstructions, position })
-  return sendAndConfirmV0(provider, [refreshInstructions, settleInstructions], airspaceLookupTables, [])
+  return sendAndConfirmV0(provider, [refreshInstructions.concat(settleInstructions)], airspaceLookupTables, [])
 }
 
 interface IRepay {
@@ -564,7 +564,7 @@ export const repay = async ({
     marketAddress: market.market.address
   })
   instructions = instructions.concat(refreshIxs)
-  return sendAndConfirmV0(provider, [refreshInstructions, instructions], airspaceLookupTables, [])
+  return sendAndConfirmV0(provider, [refreshInstructions.concat(instructions)], airspaceLookupTables, [])
 }
 
 interface IRedeem {

--- a/packages/margin/src/margin/accountPosition.ts
+++ b/packages/margin/src/margin/accountPosition.ts
@@ -19,8 +19,6 @@ export interface StorePriceInfo {
 }
 
 export class AccountPosition {
-  /** The raw account position deserialized by anchor */
-  info: AccountPositionInfo
 
   /** The address of the token/mint of the asset */
   token: PublicKey
@@ -64,7 +62,6 @@ export class AccountPosition {
   flags: AdapterPositionFlags
 
   constructor({ info, price }: { info: AccountPositionInfo; price?: StorePriceInfo }) {
-    this.info = info
     this.token = info.token
     this.address = info.address
     this.adapter = info.adapter
@@ -76,6 +73,34 @@ export class AccountPosition {
     this.valueModifier = info.valueModifier / 100
     this.maxStaleness = info.maxStaleness
     this.flags = info.flags.flags
+  }
+
+  static fromCache({ data, price }: { data: AccountPositionData; price?: StorePriceInfo }): AccountPosition {
+    const info: AccountPositionInfo = {
+      token: new PublicKey(data.token),
+      address: new PublicKey(data.address),
+      adapter: new PublicKey(data.adapter),
+      balance: new BN(data.balance),
+      balanceTimestamp: new BN(data.balanceTimestamp),
+      exponent: data.exponent,
+      valueModifier: data.valueModifier, // the modifier is already a fraction
+      maxStaleness: new BN(data.maxStaleness),
+      value: [],
+      price: {
+        value: new BN(data.price.value),
+        timestamp: new BN(data.price.timestamp),
+        exponent: data.price.exponent,
+        isValid: data.price.isValid,
+        reserved: [],
+      },
+      kind: data.kind === 'Collateral' ? 1 : data.kind === 'Claim' ? 2 : 3,
+      flags: {
+        flags: 0
+      },
+      reserved: []
+
+    }
+    return new AccountPosition({ info, price })
   }
 
   collateralValue(): number {

--- a/packages/margin/src/margin/state.ts
+++ b/packages/margin/src/margin/state.ts
@@ -18,7 +18,7 @@ type AllTypesMap<IDL extends Idl> = AccountMap<AllTypes<IDL>>
  ****************************/
 
 export type LiquidationData = TypeDef<AllTypesMap<JetMarginIDL>["Liquidation"], IdlTypes<JetMarginIDL>>
-export type MarginAccountData = TypeDef<AllAccountsMap<JetMarginIDL>["marginAccount"], IdlTypes<JetMarginIDL>>
+export type OnChainMarginAccountData = TypeDef<AllAccountsMap<JetMarginIDL>["marginAccount"], IdlTypes<JetMarginIDL>>
 
 /****************************
  * Program Types

--- a/packages/store/src/slices/accounts.ts
+++ b/packages/store/src/slices/accounts.ts
@@ -7,6 +7,9 @@ export const createAccountsSlice: StateCreator<JetStore, [['zustand/devtools', n
 ) => ({
   wallets: {},
   selectedWallet: null,
+  marginAccounts: {},
+  selectedMarginAccount: null,
+  marginAccountLookupTables: {},
   airspaceLookupTables: [],
   connectWallet: async wallet => {
     set(
@@ -27,44 +30,21 @@ export const createAccountsSlice: StateCreator<JetStore, [['zustand/devtools', n
       false,
       'DISCONNECT_WALLET'
     ),
-  updateLookupTables: tables => set(() => ({ airspaceLookupTables: tables }), false, 'UPDATE_LOOKUP_TABLE_ADDRESSES'),
+  updateAirspaceLookupTables: tables => set(() => ({ airspaceLookupTables: tables }), false, 'UPDATE_LOOKUP_TABLE_ADDRESSES'),
   updateMarginAccount: (update: MarginAccountData) => {
     return set(
       state => {
-        if (!state.selectedWallet) {
-          return state;
-        }
-        let wallet = state.wallets[state.selectedWallet];
-        if (!wallet) {
-          // Create a wallet container
-          state.wallets[state.selectedWallet] = {
-            pubkey: state.selectedWallet,
-            accounts: {
-              [update.address]: update
-            },
-            selectedMarginAccount: null,
-            lookupTables: {}
-          };
-          wallet = state.wallets[state.selectedWallet];
-        }
-        const account = wallet.accounts[update.address];
         return {
           ...state,
-          wallets: {
-            ...state.wallets,
-            [state.selectedWallet]: {
-              ...wallet,
-              accounts: {
-                ...wallet.accounts,
-                [update.address]: {
-                  ...account
-                }
-              }
+          marginAccounts: {
+            ...state.marginAccounts,
+            [update.address]: {
+              ...update
             }
           }
         };
       },
-      false,
+      true,
       'UPDATE_MARGIN_ACCOUNT'
     );
   },
@@ -73,22 +53,12 @@ export const createAccountsSlice: StateCreator<JetStore, [['zustand/devtools', n
     const keys = Object.keys(update);
     return set(
       state => {
-        if (!state.selectedWallet) {
-          return state;
-        }
-        const wallet = state.wallets[state.selectedWallet];
         return {
           ...state,
-          wallets: {
-            ...state.wallets,
-            [state.selectedWallet]: {
-              ...wallet,
-              accounts: update,
-              selectedMarginAccount: keys.includes(String(wallet.selectedMarginAccount))
-                ? wallet.selectedMarginAccount
-                : keys[0]
-            }
-          }
+          marginAccounts: update,
+          selectedMarginAccount: keys.includes(String(state.selectedMarginAccount))
+            ? state.selectedMarginAccount
+            : keys[0]
         };
       },
       true,
@@ -101,21 +71,17 @@ export const createAccountsSlice: StateCreator<JetStore, [['zustand/devtools', n
         if (!state.selectedWallet) {
           return state;
         }
-        const wallet = state.wallets[state.selectedWallet];
-        const keys = Object.keys(wallet.accounts);
+        const keys = Object.keys(state.marginAccounts);
         return {
           ...state,
-          wallets: {
-            ...state.wallets,
-            [state.selectedWallet]: {
-              ...wallet,
-              selectedMarginAccount: keys.includes(String(address)) ? address : keys[0]
-            }
-          }
+          selectedMarginAccount: keys.includes(String(address)) ? address : keys[0]
         };
       },
       false,
       'SELECT_MARGIN_ACCOUNT'
     );
+  },
+  updateMarginAccountLookupTables: (_address: string, _tables: LookupTable[]) => {
+    return set(state => state, false, 'UPDATE_MARGIN_ACCOUNT_LOOKUP_TABLES')
   }
 });

--- a/packages/store/src/slices/accounts.ts
+++ b/packages/store/src/slices/accounts.ts
@@ -34,7 +34,19 @@ export const createAccountsSlice: StateCreator<JetStore, [['zustand/devtools', n
         if (!state.selectedWallet) {
           return state;
         }
-        const wallet = state.wallets[state.selectedWallet];
+        let wallet = state.wallets[state.selectedWallet];
+        if (!wallet) {
+          // Create a wallet container
+          state.wallets[state.selectedWallet] = {
+            pubkey: state.selectedWallet,
+            accounts: {
+              [update.address]: update
+            },
+            selectedMarginAccount: null,
+            lookupTables: {}
+          };
+          wallet = state.wallets[state.selectedWallet];
+        }
         const account = wallet.accounts[update.address];
         return {
           ...state,

--- a/packages/store/src/websocket/index.ts
+++ b/packages/store/src/websocket/index.ts
@@ -63,6 +63,8 @@ export const initWebsocket = (cluster?: Cluster, wallet?: string | null) => {
         useJetStore.getState().updatePool(update);
       } else if (data.type === 'PRICE-UPDATE') {
         useJetStore.getState().updatePrices(data);
+      } else if (data.type === 'MARGIN-ACCOUNT-UPDATE') {
+        useJetStore.getState().updateMarginAccount(data.payload);
       }
     };
 

--- a/packages/store/src/websocket/index.ts
+++ b/packages/store/src/websocket/index.ts
@@ -67,7 +67,7 @@ export const initWebsocket = (cluster?: Cluster, wallet?: string | null) => {
         useJetStore.getState().updateMarginAccount(data.payload);
       } else if (data.type === 'MARGIN-ACCOUNT-LIST') {
         const map = {};
-        for (const el of data.payload) {
+        for (const el of data.payload.accounts) {
           map[el.address] = el;
         }
         useJetStore.getState().initAllMarginAccounts(map);

--- a/packages/store/src/websocket/index.ts
+++ b/packages/store/src/websocket/index.ts
@@ -65,6 +65,12 @@ export const initWebsocket = (cluster?: Cluster, wallet?: string | null) => {
         useJetStore.getState().updatePrices(data);
       } else if (data.type === 'MARGIN-ACCOUNT-UPDATE') {
         useJetStore.getState().updateMarginAccount(data.payload);
+      } else if (data.type === 'MARGIN-ACCOUNT-LIST') {
+        const map = {};
+        for (const el of data.payload) {
+          map[el.address] = el;
+        }
+        useJetStore.getState().initAllMarginAccounts(map);
       }
     };
 

--- a/tools/oracle-mirror/src/lib.rs
+++ b/tools/oracle-mirror/src/lib.rs
@@ -249,7 +249,7 @@ async fn replace_openbook_orders(
     program: &Pubkey,
 ) -> Result<()> {
     for ((token_a, token_b), market) in markets {
-        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(1_200_000)];
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(800_000)];
 
         let scratch_a = get_scratch_address(&signer.pubkey(), token_a);
         let scratch_b = get_scratch_address(&signer.pubkey(), token_b);
@@ -296,7 +296,10 @@ async fn replace_openbook_orders(
         );
 
         let balance_tx = Transaction::new_signed_with_payer(
-            &[balance_ix],
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(800_000),
+                balance_ix,
+            ],
             Some(&signer.pubkey()),
             &[signer],
             target.get_latest_blockhash().await?,

--- a/ts-types/blackbox/websocket.d.ts
+++ b/ts-types/blackbox/websocket.d.ts
@@ -46,15 +46,21 @@ interface MARGIN_ACCOUNT_UPDATE {
   payload: MarginAccountData
 }
 
+interface MARGIN_ACCOUNT_LIST {
+  type: 'MARGIN-ACCOUNT-LIST';
+  payload: MarginAccountData[]
+}
+
 interface MarginAccountData {
   owner: string;
+  seed: number;
   address: string;
   airspace: string;
   liquidator: string;
-  positions: AccountPosition[]
+  positions: AccountPositionData[]
 }
 
-interface AccountPosition {
+interface AccountPositionData {
   address: string;
   token: string;
   adapter: string;
@@ -87,4 +93,4 @@ interface SUBSCRIBE {
 
 type APPLICATION_WS_EVENTS = SUBSCRIBE;
 
-type JET_WS_EVENTS = PRICE_UPDATE | MARGIN_POOL_UPDATE | MARGIN_ACCOUNT_UPDATE;
+type JET_WS_EVENTS = PRICE_UPDATE | MARGIN_POOL_UPDATE | MARGIN_ACCOUNT_UPDATE | MARGIN_ACCOUNT_LIST;

--- a/ts-types/blackbox/websocket.d.ts
+++ b/ts-types/blackbox/websocket.d.ts
@@ -48,7 +48,10 @@ interface MARGIN_ACCOUNT_UPDATE {
 
 interface MARGIN_ACCOUNT_LIST {
   type: 'MARGIN-ACCOUNT-LIST';
-  payload: MarginAccountData[]
+  payload: {
+    owner: string;
+    accounts: MarginAccountData[];
+  }
 }
 
 interface MarginAccountData {

--- a/ts-types/blackbox/websocket.d.ts
+++ b/ts-types/blackbox/websocket.d.ts
@@ -39,6 +39,42 @@ interface MARGIN_POOL_UPDATE {
 
 // *** END MARGIN POOL UPDATE EVENT ***
 
+// *** MARGIN ACCOUNT UPDATE EVENT ***
+
+interface MARGIN_ACCOUNT_UPDATE {
+  type: 'MARGIN-ACCOUNT-UPDATE';
+  payload: MarginAccountData
+}
+
+interface MarginAccountData {
+  owner: string;
+  address: string;
+  airspace: string;
+  liquidator: string;
+  positions: AccountPosition[]
+}
+
+interface AccountPosition {
+  address: string;
+  token: string;
+  adapter: string;
+  value: string;
+  balance: number;
+  balanceTimestamp: number;
+  price: {
+    value: number;
+    timestamp: number;
+    exponent: number;
+    isValid: number;
+  }
+  kind: 'Collateral' | 'AdapterCollateral' | 'Claim';
+  exponent: number;
+  valueModifier: number;
+  maxStaleness: number;
+}
+
+// *** END MARGIN ACCOUNT UPDATE EVENT ***
+
 // *** SUBSCRIBE EVENT ***
 interface SUBSCRIBE {
   type: 'SUBSCRIBE';
@@ -51,4 +87,4 @@ interface SUBSCRIBE {
 
 type APPLICATION_WS_EVENTS = SUBSCRIBE;
 
-type JET_WS_EVENTS = PRICE_UPDATE | MARGIN_POOL_UPDATE;
+type JET_WS_EVENTS = PRICE_UPDATE | MARGIN_POOL_UPDATE | MARGIN_ACCOUNT_UPDATE;

--- a/ts-types/store/accounts-slice.d.ts
+++ b/ts-types/store/accounts-slice.d.ts
@@ -4,32 +4,6 @@
 //   amount: number;
 // }
 
-interface MarginAccountData {
-  address: string;
-  owner: string;
-  liquidator: string;
-  positions: MarginPosition[];
-}
-
-interface MarginPosition {
-  adapter: string;
-  address: string;
-  balance: number;
-  balanceTimestamp: number;
-  exponent: number;
-  kind: 'Collateral' | 'AdapterCollateral' | 'Claim';
-  maxStaleness: number;
-  price: {
-    exponent: number;
-    isValid: number;
-    timestamp: number;
-    value: number;
-  };
-  token: string;
-  value: string; // Number192 formatted as decimal string
-  valueModifier: number;
-}
-
 interface Wallet {
   pubkey: string;
   accounts: Record<string, MarginAccountData>;

--- a/ts-types/store/accounts-slice.d.ts
+++ b/ts-types/store/accounts-slice.d.ts
@@ -6,9 +6,6 @@
 
 interface Wallet {
   pubkey: string;
-  accounts: Record<string, MarginAccountData>;
-  selectedMarginAccount: string | null;
-  lookupTables: Record<string, string[]>;
   // tokens: Record<string, WalletToken>;
 }
 
@@ -23,10 +20,16 @@ interface AccountsSlice {
   selectedWallet: string | null;
   connectWallet: (wallet: string) => void;
   disconnectWallet: () => void;
-  // The lookup addresses of the airspace. Only storing here as we don't yet have an airspace slice
-  airspaceLookupTables: LookupTable[];
-  updateLookupTables: (tables: LookupTable[]) => void;
+  // Margin accounts
+  marginAccounts: Record<string, MarginAccountData>;
+  selectedMarginAccount: string | null;
   updateMarginAccount: (update: MarginAccountData) => void;
   initAllMarginAccounts: (update: Record<string, MarginAccountData>) => void;
   selectMarginAccount: (address: string) => void;
+  // The lookup addresses of margin accounts.
+  marginAccountLookupTables: Record<string, LookupTable[]>;
+  updateMarginAccountLookupTables: (address: string, tables: LookupTable[]) => void;
+  // The lookup addresses of the airspace. Only storing here as we don't yet have an airspace slice
+  airspaceLookupTables: LookupTable[];
+  updateAirspaceLookupTables: (tables: LookupTable[]) => void;
 }


### PR DESCRIPTION
This continues to implement using margin accounts from websockets in the UI.

Changes include:
* Getting all margin accounts of the connected wallet from websockets (initial sync)
* Consuming all the margin account changes that we listen to on the backend
* Injecting `MarginAccountData` in the valuation code, allowing us to load margin account data without loading all accounts
* Simplifying the account store for margin accounts. We don't need to track margin accounts of disconnected wallets, so we could simplify the storage and related logic

I've been manually testing while working on this and fixing up issues.