### PR TITLE
ui: merge configs on devnet and mainnet

### DIFF
--- a/packages/margin/src/margin/config.ts
+++ b/packages/margin/src/margin/config.ts
@@ -3,8 +3,10 @@ import axios from "axios"
 import { SPLSwapPool } from "./pool"
 
 export const MARGIN_CONFIG_URL_BASE = "https://storage.googleapis.com/jet-app-config/"
-export const MARGIN_CONFIG_MAINNET_URL = MARGIN_CONFIG_URL_BASE + "mainnet.legacy.json"
-export const MARGIN_CONFIG_DEVNET_URL = MARGIN_CONFIG_URL_BASE + "devnet.legacy.json"
+export const MARGIN_CONFIG_MAINNET_URL = MARGIN_CONFIG_URL_BASE + "mainnet.json"
+export const MARGIN_CONFIG_DEVNET_URL = MARGIN_CONFIG_URL_BASE + "devnet.json"
+export const MARGIN_CONFIG_LEGACY_MAINNET_URL = MARGIN_CONFIG_URL_BASE + "mainnet.legacy.json"
+export const MARGIN_CONFIG_LEGACY_DEVNET_URL = MARGIN_CONFIG_URL_BASE + "devnet.legacy.json"
 
 export type MarginCluster = "localnet" | "devnet" | "mainnet-beta" | MarginConfig
 
@@ -32,6 +34,7 @@ export interface AirspaceConfig {
   name: string
   tokens: string[]
   fixedTermMarkets: Record<string, FixedTermMarketConfig>
+  lookupRegistryAuthority: string
 }
 
 export interface FixedTermMarketConfig {
@@ -88,12 +91,18 @@ export interface MarginMarketConfig {
   feeRateBps: number
 }
 
-export async function getLatestConfig(cluster: string): Promise<MarginConfig> {
+export async function getLatestLegacyConfig(cluster: string): Promise<MarginConfig> {
   let response =
-    cluster == "devnet" ? await axios.get(MARGIN_CONFIG_DEVNET_URL) : await axios.get(MARGIN_CONFIG_MAINNET_URL)
+    cluster == "devnet" ? await axios.get(MARGIN_CONFIG_LEGACY_DEVNET_URL) : await axios.get(MARGIN_CONFIG_LEGACY_MAINNET_URL)
   if (response.data[cluster]) {
     return response.data[cluster]
   } else {
     return response.data
   }
+}
+
+export async function getLatestConfig(cluster: string): Promise<MarginConfig> {
+  let response =
+    cluster == "devnet" ? await axios.get(MARGIN_CONFIG_DEVNET_URL) : await axios.get(MARGIN_CONFIG_MAINNET_URL)
+  return response.data
 }

--- a/packages/margin/src/margin/marginClient.ts
+++ b/packages/margin/src/margin/marginClient.ts
@@ -8,7 +8,7 @@ import {
   JetMarginSwapIdl,
   JetMetadataIdl
 } from "../idls"
-import { MarginCluster, MarginConfig, getLatestConfig } from "./config"
+import { MarginCluster, MarginConfig, getLatestConfig, getLatestLegacyConfig } from "./config"
 import { Connection, ParsedTransactionWithMeta, PublicKey } from "@solana/web3.js"
 import axios from "axios"
 import { Pool } from "./pool"
@@ -71,6 +71,14 @@ export class MarginClient {
     return programs
   }
 
+  static async getLegacyConfig(cluster: MarginCluster): Promise<MarginConfig> {
+    if (typeof cluster === "string") {
+      return await getLatestLegacyConfig(cluster)
+    } else {
+      return cluster
+    }
+  }
+
   static async getConfig(cluster: MarginCluster): Promise<MarginConfig> {
     if (typeof cluster === "string") {
       return await getLatestConfig(cluster)
@@ -116,10 +124,10 @@ export class MarginClient {
       cluster === "mainnet-beta"
         ? process.env.REACT_APP_DATA_API
         : cluster === "devnet"
-        ? process.env.REACT_APP_DEV_DATA_API
-        : cluster === "localnet"
-        ? process.env.REACT_APP_LOCAL_DATA_API
-        : ""
+          ? process.env.REACT_APP_DEV_DATA_API
+          : cluster === "localnet"
+            ? process.env.REACT_APP_LOCAL_DATA_API
+            : ""
     const flightLogURL = `${url}/margin/accounts/activity/${pubKey}`
 
     const response = await axios.get(flightLogURL)


### PR DESCRIPTION
We temporarily have 2 config formats. Airspaces and newer information is in
the new format while the old format still have program IDs.
This loads both concurrently and merges them.