### PR TITLE
ui: find SOL fixed term markets

### DIFF
--- a/apps/react-app/src/state/fixed-term/fixed-term-market-sync.ts
+++ b/apps/react-app/src/state/fixed-term/fixed-term-market-sync.ts
@@ -90,7 +90,7 @@ export const useFixedTermSync = (): void => {
       Object.entries(airspace.fixedTermMarkets).map(async ([name, marketConfig]) => {
         try {
           const market = await FixedTermMarket.load(program, marketConfig.market, marginProgramId);
-          const token = config?.tokens[marketConfig.symbol];
+          const token = Object.values(config?.tokens || {}).find(token => token.symbol === marketConfig.symbol);
           if (token) {
             markets.push({ market, config: marketConfig, name, token });
           }


### PR DESCRIPTION
Fixes a small issue where the SOL markets weren't showing up becuase the symbol's SOL and the keys on the config are in token names (Solana)