### PR TITLE
liquidator and ata position support

### DIFF
--- a/libraries/rust/instructions/src/margin.rs
+++ b/libraries/rust/instructions/src/margin.rs
@@ -34,6 +34,7 @@ use jet_program_common::ADDRESS_LOOKUP_REGISTRY_ID;
 
 pub use jet_margin::ID as MARGIN_PROGRAM;
 pub use jet_margin::{TokenAdmin, TokenConfigUpdate, TokenKind, TokenOracle};
+use spl_associated_token_account::instruction::create_associated_token_account_idempotent;
 
 use crate::airspace::derive_permit;
 
@@ -244,16 +245,7 @@ impl MarginIxBuilder {
     ///
     /// `account` - The account address that has had a balance change
     pub fn update_position_balance(&self, account: Pubkey) -> Instruction {
-        let accounts = ix_account::UpdatePositionBalance {
-            margin_account: self.address,
-            token_account: account,
-        };
-
-        Instruction {
-            program_id: JetMargin::id(),
-            data: ix_data::UpdatePositionBalance.data(),
-            accounts: accounts.to_account_metas(None),
-        }
+        update_position_balance(self.address, account)
     }
 
     /// Get instruction to register new position
@@ -425,26 +417,13 @@ impl MarginIxBuilder {
     ///
     /// `token_mint` - The mint for the token to be deposited
     pub fn create_deposit_position(&self, token_mint: Pubkey) -> Instruction {
-        let config_ix = MarginConfigIxBuilder::new(self.airspace, self.payer(), None);
-        let token_account = get_associated_token_address(&self.address, &token_mint);
-        let accounts = ix_account::CreateDepositPosition {
-            margin_account: self.address,
-            authority: self.authority(),
-            payer: self.payer(),
-            mint: token_mint,
-            config: config_ix.derive_token_config(&token_mint),
-            token_account,
-            associated_token_program: spl_associated_token_account::ID,
-            token_program: spl_token::ID,
-            system_program: system_program::ID,
-            rent: Rent::id(),
-        };
-
-        Instruction {
-            program_id: jet_margin::ID,
-            accounts: accounts.to_account_metas(None),
-            data: ix_data::CreateDepositPosition.data(),
-        }
+        create_deposit_position(
+            self.address,
+            self.airspace,
+            self.authority(),
+            self.payer(),
+            token_mint,
+        )
     }
 
     /// Transfer tokens into or out of a deposit account associated with the margin account
@@ -545,6 +524,66 @@ impl MarginIxBuilder {
 
     fn registry_address(&self) -> Pubkey {
         Pubkey::find_program_address(&[self.address.as_ref()], &ADDRESS_LOOKUP_REGISTRY_ID).0
+    }
+}
+
+/// Get instruction to update the accounting for assets in
+/// the custody of the margin account.
+///
+/// # Params
+///
+/// `account` - The account address that has had a balance change
+pub fn update_position_balance(margin_account: Pubkey, token_account: Pubkey) -> Instruction {
+    let accounts = ix_account::UpdatePositionBalance {
+        margin_account,
+        token_account,
+    };
+    Instruction {
+        program_id: JetMargin::id(),
+        data: ix_data::UpdatePositionBalance.data(),
+        accounts: accounts.to_account_metas(None),
+    }
+}
+
+pub fn create_deposit_account_and_position(
+    margin_account: Pubkey,
+    airspace: Pubkey,
+    authority: Pubkey,
+    payer: Pubkey,
+    mint: Pubkey,
+) -> Vec<Instruction> {
+    vec![
+        create_associated_token_account_idempotent(&payer, &margin_account, &mint, &spl_token::ID),
+        create_deposit_position(margin_account, airspace, authority, payer, mint),
+    ]
+}
+
+/// Construct a CreateDepositPosition instruction
+pub fn create_deposit_position(
+    margin_account: Pubkey,
+    airspace: Pubkey,
+    authority: Pubkey,
+    payer: Pubkey,
+    mint: Pubkey,
+) -> Instruction {
+    let config_ix = MarginConfigIxBuilder::new(airspace, payer, None);
+    let token_account = get_associated_token_address(&margin_account, &mint);
+    let accounts = ix_account::CreateDepositPosition {
+        margin_account,
+        authority,
+        payer,
+        mint,
+        config: config_ix.derive_token_config(&mint),
+        token_account,
+        associated_token_program: spl_associated_token_account::ID,
+        token_program: spl_token::ID,
+        system_program: system_program::ID,
+        rent: Rent::id(),
+    };
+    Instruction {
+        program_id: jet_margin::ID,
+        accounts: accounts.to_account_metas(None),
+        data: ix_data::CreateDepositPosition.data(),
     }
 }
 

--- a/libraries/rust/margin/src/lib.rs
+++ b/libraries/rust/margin/src/lib.rs
@@ -55,6 +55,8 @@
 pub mod get_state;
 /// Instruction builders for programs and adapters supported by the SDK
 pub mod ix_builder;
+/// ease of use for reading a MarginAccount
+pub mod margin_account_ext;
 /// generic code to integrate adapters with margin
 pub mod margin_integrator;
 /// generically refreshing positions in a margin account

--- a/libraries/rust/margin/src/margin_account_ext.rs
+++ b/libraries/rust/margin/src/margin_account_ext.rs
@@ -1,0 +1,42 @@
+use anchor_lang::prelude::Pubkey;
+use anyhow::Context;
+use jet_instructions::margin::derive_margin_account_from_state;
+use jet_margin::MarginAccount;
+
+/// Simplifies MarginAccount reads with helper methods for common patterns.
+pub trait MarginAccountExt {
+    /// Returns the address of the margin account
+    fn address(&self) -> Pubkey;
+
+    /// Returns the balance in the margin account of this position.
+    /// Returns zero if the position does not exist.
+    fn balance(&self, position_token_mint: &Pubkey) -> u64;
+
+    /// Returns the position token account address for a particular position
+    /// token mint, or an error if it does not exist.
+    fn position_address(&self, position_token_mint: &Pubkey) -> anyhow::Result<Pubkey>;
+}
+
+impl MarginAccountExt for MarginAccount {
+    fn address(&self) -> Pubkey {
+        derive_margin_account_from_state(self)
+    }
+
+    fn balance(&self, position_token_mint: &Pubkey) -> u64 {
+        self.get_position(position_token_mint)
+            .map(|p| p.balance)
+            .unwrap_or(0)
+    }
+
+    fn position_address(&self, position_token_mint: &Pubkey) -> anyhow::Result<Pubkey> {
+        Ok(self
+            .get_position(position_token_mint)
+            .with_context(|| {
+                format!(
+                    "Cannot find position of token {position_token_mint} for margin account {}",
+                    self.address()
+                )
+            })?
+            .address)
+    }
+}

--- a/libraries/rust/margin/src/tx_builder/invoke_context.rs
+++ b/libraries/rust/margin/src/tx_builder/invoke_context.rs
@@ -1,3 +1,6 @@
+//! This module only defines the generic code for executing margin invocations.
+//! Other modules define ways to use this context to invoke specific adapters.
+
 use jet_instructions::margin::{accounting_invoke, adapter_invoke, liquidator_invoke};
 use jet_solana_client::{
     signature::NeedsSignature,
@@ -9,6 +12,13 @@ use solana_sdk::{instruction::Instruction, pubkey::Pubkey, signature::Keypair};
 /// Minimum information necessary to wrap an instruction in a margin invoke and
 /// sign the transaction. Simpler alternative to MarginTxBuilder, to minimize
 /// dependencies.
+///
+/// Data that is needed for a MarginTxBuilder, but not this:
+/// - an RPC client
+/// - signer keypair
+/// - margin account seed
+/// - margin account owner
+/// - payer
 ///
 /// If K cannot sign, then it won't actually sign transactions, but it can still
 /// wrap instructions.
@@ -51,21 +61,9 @@ impl<K: Key> MarginInvokeContext<K> {
 }
 
 impl MarginInvokeContext<Keypair> {
-    /// Invoke a margin adapter through a margin account using whatever wrapper
-    /// is needed: adapter_invoke, accounting_invoke, or liquidator_invoke.  
-    /// Provides a signer if needed.
-    pub fn invoke(&self, inner: Instruction) -> TransactionBuilder {
-        let (wrapped, needs_signature) = self.invoke_ix(inner);
-        if needs_signature {
-            wrapped.with_signer(self.authority.clone())
-        } else {
-            wrapped.into()
-        }
-    }
-
     /// Invoke margin adapters through a margin account using whatever wrapper
     /// is needed: adapter_invoke, accounting_invoke, or liquidator_invoke.  
-    /// Provides a signer if any instructions need it.
+    /// Provides a signer if any instructions need it
     pub fn invoke_many(&self, inners: Vec<Instruction>) -> TransactionBuilder {
         let mut needs_signature = false;
         let mut all_wrapped = vec![];
@@ -80,16 +78,129 @@ impl MarginInvokeContext<Keypair> {
             all_wrapped.into()
         }
     }
+}
+
+/// Methods for MarginInvokeContext to invoke instructions through a margin
+/// account.
+///
+/// These methods exist in a separate trait from CanInvokeTo to make it cleaner
+/// to call them. Without this trait, there would be some situations where you
+/// would need to cast the context to CanInvokeTo which is pointlessly verbose
+/// and hard to read.
+pub trait Invoke {
+    /// Invoke a margin adapter through a margin account using whatever wrapper
+    /// is needed: adapter_invoke, accounting_invoke, or liquidator_invoke.  
+    /// Provides a signer if needed and if the return type supports it.
+    fn invoke<T>(&self, inner: Instruction) -> T
+    where
+        Self: CanInvokeTo<T>,
+    {
+        self.__private_invoke(inner)
+    }
 
     /// Invoke margin adapters through a margin account using whatever wrapper
     /// is needed: adapter_invoke, accounting_invoke, or liquidator_invoke.  
-    /// Provides a signer for any transactions that need it.
-    pub fn invoke_each(&self, ixs: Vec<Instruction>) -> Vec<TransactionBuilder> {
+    /// Provides a signer for any transactions that need it and if the return
+    /// type supports it.
+    fn invoke_each<T>(&self, ixs: Vec<Instruction>) -> Vec<T>
+    where
+        Self: CanInvokeTo<T>,
+    {
         ixs.into_iter().map(|ix| self.invoke(ix)).collect()
+    }
+
+    /// executes the same type conversion as invoke but without actually
+    /// wrapping it in a margin invocation.
+    fn dont_wrap<T>(&self, inner: Instruction) -> T
+    where
+        Self: CanInvokeTo<T>,
+    {
+        self.__private_dont_wrap(inner)
+    }
+
+    /// executes the same type conversion as invoke_each but without actually
+    /// wrapping it in a margin invocation.
+    fn dont_wrap_any<T>(&self, ixs: Vec<Instruction>) -> Vec<T>
+    where
+        Self: CanInvokeTo<T>,
+    {
+        ixs.into_iter().map(|ix| self.dont_wrap(ix)).collect()
+    }
+}
+impl<T> Invoke for T {}
+
+/// This trait represents the ability to convert an instruction into one that is
+/// invoked through a margin account, and to output the result as an arbitrary
+/// type.
+///
+/// This is a behavior that we want in MarginInvokeContext. Instead of being a
+/// direct method, we implement it through a trait, to enable calling functions
+/// to be generic.
+///
+/// Some function might accept a MarginInvokeContext as a parameter, and return
+/// a transaction or instruction as a return type. To maximize the flexibility
+/// of that function, you may want both of these to be generic:
+/// - the type of authority key (pubkey or keypair) in the MarginInvokeContext
+/// - the return type of the function (either Instruction or TransactionBuilder)
+///
+/// If this trait's method were just an ordinary method of MarginInvokeContext,
+/// it would not be possible to make this hypothetical function so generic, for
+/// two reasons:
+/// - This method would actually need to be multiple methods with different
+///   names because you cannot have different implementations that are treated
+///   as the same method, unless it is a trait method.
+/// - There is no way to express the requirement in a function signature that
+///   you need a particular combination of types that have a particular method
+///   implemented for them, except with trait bounds.
+///
+/// The function would be forced to specify a concrete input or output type.
+///
+/// By dedicating a trait to this method, we allow the function to be generic
+/// over both its input and output types. The function only needs to express a
+/// constraint that `TheInput: CanInvokeTo<TheOutput>`
+///
+/// For some examples of these generic functions, see the methods in
+/// invoke_pools.rs and invoke_swap.rs.
+pub trait CanInvokeTo<Output> {
+    /// The implementation for MarginInvokeContext::invoke.
+    ///
+    /// Do not call this function directly. It is exposed publicly through
+    /// Invoke::invoke
+    fn __private_invoke(&self, inner: Instruction) -> Output;
+
+    /// This function should return the same Output type as __private_invoke,
+    /// but it should not wrap the instruction in a margin invocation
+    /// instruction.
+    fn __private_dont_wrap(&self, ix: Instruction) -> Output;
+}
+
+impl<K: Key> CanInvokeTo<Instruction> for MarginInvokeContext<K> {
+    fn __private_invoke(&self, inner: Instruction) -> Instruction {
+        self.invoke_ix(inner).0
+    }
+    fn __private_dont_wrap(&self, ix: Instruction) -> Instruction {
+        ix
     }
 }
 
-/// This trait is purely for readability, and does not introduce new behavior.
+impl CanInvokeTo<TransactionBuilder> for MarginInvokeContext<Keypair> {
+    fn __private_invoke(&self, inner: Instruction) -> TransactionBuilder {
+        let (wrapped, needs_signature) = self.invoke_ix(inner);
+        if needs_signature {
+            wrapped.with_signer(self.authority.clone())
+        } else {
+            wrapped.into()
+        }
+    }
+    fn __private_dont_wrap(&self, ix: Instruction) -> TransactionBuilder {
+        ix.into()
+    }
+}
+
+/// Extension methods for Instruction and TransactionBuilder.
+///
+/// These traits are for improving the readability of operations with
+/// collections of instructions and chained method calls.
 ///
 /// Inverts the receiver for methods of MarginTestContext, so Instruction or
 /// Vec<Instruction> can be the receiver. This means you can chain method calls
@@ -100,45 +211,74 @@ impl MarginInvokeContext<Keypair> {
 ///     .invoke(ctx)
 ///     .send_and_confirm(rpc)
 /// ```
-pub trait MarginInvoke: Sized {
-    /// Only wraps the included instruction(s), without signing anything.  
-    /// bool indicates if a signature is needed
-    fn invoke_ix<K: Key>(self, ctx: &MarginInvokeContext<K>) -> (Self, bool);
+pub mod invoke_into {
+    use super::*;
 
-    /// Invoke a margin adapter through a margin account using whichever wrapper
-    /// is needed: adapter_invoke, accounting_invoke, or liquidator_invoke. If
-    /// there are multiple instructions, they are combined into a single
-    /// TransactionBuilder
-    fn invoke(self, ctx: &MarginInvokeContext<Keypair>) -> TransactionBuilder;
+    /// Defines the way to unpack some type, invoke any containing instructions
+    /// through margin, and pack it back into the same type.
+    pub trait InvokeEachInto<K: Key>: Sized {
+        /// Only wraps the included instruction(s), without signing anything.  
+        /// bool indicates if a signature is needed
+        fn invoke_ix(self, ctx: &MarginInvokeContext<K>) -> (Self, bool);
 
-    /// Separately invokes each instruction into a separate TransactionBuilder
-    fn invoke_each(self, ctx: &MarginInvokeContext<Keypair>) -> Vec<TransactionBuilder>;
-}
+        /// Separately invokes each instruction into a desired type.
+        fn invoke_each_into<IxTx>(self, ctx: &MarginInvokeContext<K>) -> Vec<IxTx>
+        where
+            MarginInvokeContext<K>: CanInvokeTo<IxTx>,
+            IxTx: From<Instruction>;
+    }
 
-impl MarginInvoke for Instruction {
-    fn invoke_ix<K: Key>(self, ctx: &MarginInvokeContext<K>) -> (Self, bool) {
-        ctx.invoke_ix(self)
-    }
-    fn invoke(self, ctx: &MarginInvokeContext<Keypair>) -> TransactionBuilder {
-        ctx.invoke(self)
-    }
-    fn invoke_each(self, ctx: &MarginInvokeContext<Keypair>) -> Vec<TransactionBuilder> {
-        vec![self.invoke(ctx)]
-    }
-}
+    impl<K: Key> InvokeEachInto<K> for Instruction {
+        fn invoke_ix(self, ctx: &MarginInvokeContext<K>) -> (Self, bool) {
+            ctx.invoke_ix(self)
+        }
 
-impl MarginInvoke for Vec<Instruction> {
-    fn invoke_ix<K: Key>(self, ctx: &MarginInvokeContext<K>) -> (Self, bool) {
-        self.into_iter()
-            .map(|ix| ctx.invoke_ix(ix))
-            .fold((vec![], false), |(ixs, any_need), (ix, this_needs)| {
-                (ixs.with(ix), any_need | this_needs)
-            })
+        fn invoke_each_into<IxTx>(self, ctx: &MarginInvokeContext<K>) -> Vec<IxTx>
+        where
+            MarginInvokeContext<K>: CanInvokeTo<IxTx>,
+            IxTx: From<Instruction>,
+        {
+            vec![ctx.invoke(self)]
+        }
     }
-    fn invoke(self, ctx: &MarginInvokeContext<Keypair>) -> TransactionBuilder {
-        ctx.invoke_many(self)
+
+    impl<K: Key> InvokeEachInto<K> for Vec<Instruction> {
+        fn invoke_ix(self, ctx: &MarginInvokeContext<K>) -> (Self, bool) {
+            self.into_iter()
+                .map(|ix| ctx.invoke_ix(ix))
+                .fold((vec![], false), |(ixs, any_need), (ix, this_needs)| {
+                    (ixs.with(ix), any_need | this_needs)
+                })
+        }
+
+        fn invoke_each_into<IxTx>(self, ctx: &MarginInvokeContext<K>) -> Vec<IxTx>
+        where
+            MarginInvokeContext<K>: CanInvokeTo<IxTx>,
+            IxTx: From<Instruction>,
+        {
+            ctx.invoke_each(self)
+        }
     }
-    fn invoke_each(self, ctx: &MarginInvokeContext<Keypair>) -> Vec<TransactionBuilder> {
-        ctx.invoke_each(self)
+
+    /// Defines the way to unpack some type, invoke any containing instructions
+    /// through margin, and pack it all into a single TransactionBuilder.
+    pub trait InvokeInto: Sized {
+        /// Invoke a margin adapter through a margin account using whichever wrapper
+        /// is needed: adapter_invoke, accounting_invoke, or liquidator_invoke. If
+        /// there are multiple instructions, they are combined into a single
+        /// TransactionBuilder
+        fn invoke_into(self, ctx: &MarginInvokeContext<Keypair>) -> TransactionBuilder;
+    }
+
+    impl InvokeInto for Instruction {
+        fn invoke_into(self, ctx: &MarginInvokeContext<Keypair>) -> TransactionBuilder {
+            ctx.invoke(self)
+        }
+    }
+
+    impl InvokeInto for Vec<Instruction> {
+        fn invoke_into(self, ctx: &MarginInvokeContext<Keypair>) -> TransactionBuilder {
+            ctx.invoke_many(self)
+        }
     }
 }

--- a/libraries/rust/margin/src/tx_builder/invoke_pool.rs
+++ b/libraries/rust/margin/src/tx_builder/invoke_pool.rs
@@ -1,0 +1,122 @@
+use anchor_spl::associated_token::get_associated_token_address;
+use anyhow::Result;
+use futures::Future;
+use jet_margin::MarginAccount;
+use jet_margin_pool::TokenChange;
+use jet_solana_client::util::Key;
+use solana_sdk::pubkey::Pubkey;
+
+use crate::ix_builder::*;
+use crate::solana::pubkey::OrAta;
+
+use super::{CanInvokeTo, Invoke, MarginInvokeContext};
+
+/// Use MarginInvokeContext to invoke instructions to the margin-pool program
+impl<K: Key> MarginInvokeContext<K> {
+    /// Deposit into a margin pool from the specified source account, creating
+    /// the target position in the margin account if necessary.
+    pub fn pool_deposit<IxTx>(
+        &self,
+        underlying_mint: Pubkey,
+        source: Option<Pubkey>,
+        target: PoolTargetPosition,
+        change: TokenChange,
+    ) -> Vec<IxTx>
+    where
+        Self: CanInvokeTo<IxTx>,
+    {
+        let pool = MarginPoolIxBuilder::new(underlying_mint);
+        let auth = self.authority.address();
+        let (target, mut instructions) = self.get_or_create_pool_deposit(underlying_mint, target);
+        instructions.push(self.invoke(pool.deposit(
+            self.margin_account,
+            source.or_ata(&auth, &underlying_mint),
+            target,
+            change,
+        )));
+        instructions
+    }
+
+    /// Return the address to a pool deposit for this user, including
+    /// instructions to create and refresh the position if necessary.
+    pub fn get_or_create_pool_deposit<IxTx>(
+        &self,
+        underlying_mint: Pubkey,
+        position: PoolTargetPosition,
+    ) -> (Pubkey, Vec<IxTx>)
+    where
+        Self: CanInvokeTo<IxTx>,
+    {
+        let pool = MarginPoolIxBuilder::new(underlying_mint);
+        let mut instructions = vec![];
+        let target = match position {
+            PoolTargetPosition::Existing(pos) => pos,
+            PoolTargetPosition::NeedNew { pool_oracle, payer } => {
+                instructions.extend(self.create_pool_deposit(payer, underlying_mint, pool_oracle));
+                get_associated_token_address(&self.margin_account, &pool.deposit_note_mint)
+            }
+        };
+        (target, instructions)
+    }
+
+    /// Create and refresh a pool deposit position
+    pub fn create_pool_deposit<IxTx>(
+        &self,
+        payer: Pubkey,
+        underlying_mint: Pubkey,
+        pool_oracle: Pubkey,
+    ) -> Vec<IxTx>
+    where
+        Self: CanInvokeTo<IxTx>,
+    {
+        let pool = MarginPoolIxBuilder::new(underlying_mint);
+        let auth = self.authority.address();
+        let mut instructions = vec![];
+        instructions.extend(self.dont_wrap_any(create_deposit_account_and_position(
+            self.margin_account,
+            self.airspace,
+            auth,
+            payer,
+            pool.deposit_note_mint,
+        )));
+        instructions
+            .push(self.invoke(pool.margin_refresh_position(self.margin_account, pool_oracle)));
+        instructions
+    }
+}
+
+/// An instruction needs to allocate a non-zero balance into a pool position.
+/// This type represents whether or not the position exists:
+/// - if so, it provides the address of the token account for that position.
+/// - if not, it provides the data that will be necessary to create and refresh
+///   the position, so it can successfully acquire a balance.
+pub enum PoolTargetPosition {
+    /// The position already exists at the provided token account
+    Existing(Pubkey),
+    /// The position does not exist. Use this data to create and refresh it.
+    NeedNew {
+        /// needed to refresh the position
+        pool_oracle: Pubkey,
+        /// funds the creation of the token account
+        payer: Pubkey,
+    },
+}
+
+impl PoolTargetPosition {
+    /// common pattern to figure out what information is needed to target a pool
+    /// position.
+    pub async fn new<Fut: Future<Output = Result<Pubkey, E>>, E>(
+        margin_account: &MarginAccount,
+        position_token_mint: &Pubkey,
+        payer: &Pubkey,
+        pool_oracle: Fut,
+    ) -> Result<PoolTargetPosition, E> {
+        Ok(match margin_account.get_position(position_token_mint) {
+            Some(pos) => PoolTargetPosition::Existing(pos.address),
+            None => PoolTargetPosition::NeedNew {
+                pool_oracle: pool_oracle.await?,
+                payer: *payer,
+            },
+        })
+    }
+}

--- a/libraries/rust/margin/src/tx_builder/invoke_swap.rs
+++ b/libraries/rust/margin/src/tx_builder/invoke_swap.rs
@@ -1,0 +1,43 @@
+use jet_margin_pool::TokenChange;
+use jet_solana_client::util::{pubkey::OrAta, Key};
+use solana_sdk::pubkey::Pubkey;
+
+use crate::ix_builder::*;
+
+use super::{CanInvokeTo, Invoke, MarginInvokeContext, PoolTargetPosition};
+
+/// Use MarginInvokeContext to invoke instructions to the margin-pool program
+impl<K: Key> MarginInvokeContext<K> {
+    /// Transaction to swap one token for another.
+    pub fn swap<IxTx>(
+        &self,
+        addr: SplSwap,
+        source: Option<Pubkey>,
+        target: PoolTargetPosition,
+        change: TokenChange,
+        minimum_amount_out: u64,
+    ) -> Vec<IxTx>
+    where
+        Self: CanInvokeTo<IxTx>,
+    {
+        let source_pool = MarginPoolIxBuilder::new(addr.token_a);
+        let source_position = source.or_ata(&self.margin_account, &source_pool.deposit_note_mint);
+        let (target_position, mut instructions) =
+            self.get_or_create_pool_deposit(addr.token_b, target);
+
+        instructions.push(self.invoke(pool_spl_swap(
+            &addr,
+            &self.airspace,
+            &self.margin_account,
+            &addr.token_a,
+            &addr.token_b,
+            Some(source_position),
+            Some(target_position),
+            change.kind,
+            change.tokens,
+            minimum_amount_out,
+        )));
+
+        instructions
+    }
+}

--- a/libraries/rust/margin/src/tx_builder/mod.rs
+++ b/libraries/rust/margin/src/tx_builder/mod.rs
@@ -16,9 +16,17 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 mod airspace;
+/// invoke adapters through margin with minimal dependencies.
+/// lighter-weight and more versatile alternative to MarginTxBuilder.
 mod invoke_context;
+/// invoke margin-pool through a margin account.
+mod invoke_pool;
+/// invoke margin-swap through a margin account.
+mod invoke_swap;
 mod user;
 
 pub use airspace::*;
 pub use invoke_context::*;
+pub use invoke_pool::*;
+pub use invoke_swap::*;
 pub use user::*;

--- a/tests/hosted/src/margin.rs
+++ b/tests/hosted/src/margin.rs
@@ -509,8 +509,10 @@ impl MarginUser {
         source: &Pubkey,
         change: TokenChange,
     ) -> Result<(), Error> {
+        // todo use the new way, this requires some changes to the tests to get
+        // them to use ATA positions instead of the old style positions.
         self.tx
-            .pool_deposit(
+            .pool_deposit_deprecated(
                 mint,
                 Some(*source),
                 change,
@@ -588,7 +590,7 @@ impl MarginUser {
             (&swap_pool.token_b, &swap_pool.token_a)
         };
         self.rpc
-            .send_and_confirm(
+            .send_and_confirm_condensed_in_order(
                 self.tx
                     .swap(
                         source_mint,

--- a/tests/hosted/tests/fixed_term.rs
+++ b/tests/hosted/tests/fixed_term.rs
@@ -31,7 +31,7 @@ use jet_margin_sdk::{
             WithSigner,
         },
     },
-    tx_builder::MarginInvoke,
+    tx_builder::invoke_into::{InvokeEachInto, InvokeInto},
 };
 use jet_margin_sdk::{margin_integrator::RefreshingProxy, refresh::canonical_position_refresher};
 use jet_program_common::{
@@ -1173,15 +1173,15 @@ async fn fixed_term_borrow_becomes_unhealthy_without_collateral() -> Result<(), 
         vec![
             mkt.initialize_margin_user(*lender.address()),
             mkt.margin_lend_order(*lender.address(), None, params, 0),
-        ].invoke_each(&lender.ctx()),
+        ].invoke_each_into::<TransactionBuilder>(&lender.ctx()),
 
         // borrow with fill
         ctx.refresh_deposit(tsol.mint, *borrower.address()),
-        mkt.initialize_margin_user(*borrower.address()).invoke(&borrower.ctx()),
+        mkt.initialize_margin_user(*borrower.address()).invoke_into(&borrower.ctx()),
         vec![
             mkt.refresh_position(*borrower.address(), true),
             mkt.margin_borrow_order(*borrower.address(), params, 0)
-        ].invoke(&borrower.ctx()),
+        ].invoke_into(&borrower.ctx()),
 
         // make user unhealthy
         ctx.set_price(tsol.mint, 0.01),


### PR DESCRIPTION
- add ata compatibility to margin swap instruction builder
- separate some ix fns from MarginIxBuilder to allow the instructions to be constructed without needing a full builder struct
- helper methods to read a margin account
- deprecate pool registration method that is still in use which relies on the old position registration, and add a new method that uses the new approach
- add MarginInvokeContext methods to invoke swap and pool_deposit
- delegate MarginTxBuilder pool_deposit and swap to MarginInvokeContext
- use traits to make it possible use MarginInvokeContext generically. improve the naming and add docs explaining how the traits are helpful