### PR TITLE
ui: actually settle fixed term market

### DIFF
--- a/packages/margin/src/fixed-term/api.ts
+++ b/packages/margin/src/fixed-term/api.ts
@@ -465,7 +465,13 @@ export const settle = async ({
     instructions: settleInstructions,
     adapterInstruction: depositIx
   })
-  await marginAccount.withUpdatePositionBalance({ instructions: settleInstructions, position })
+
+  const fixedTermSettleIx = await market.settle(marginAccount)
+  await marginAccount.withAdapterInvoke({
+    instructions: settleInstructions,
+    adapterInstruction: fixedTermSettleIx
+  })
+  // await marginAccount.withUpdatePositionBalance({ instructions: settleInstructions, position })
   return sendAndConfirmV0(provider, [refreshInstructions, settleInstructions], lookupTables, [])
 }
 

--- a/packages/margin/src/fixed-term/fixedTerm.ts
+++ b/packages/margin/src/fixed-term/fixedTerm.ts
@@ -230,7 +230,7 @@ export class FixedTermMarket {
     const marginUser = await this.deriveMarginUserAddress(user)
     const termLoan = await this.deriveTermLoanAddress(marginUser, seed)
     const claims = await this.deriveMarginUserClaims(marginUser)
-    const tokenCollateral = await this.deriveTokenCollateral(marginUser)
+    const tokenCollateral = await this.deriveUnderlyingCollateral(marginUser)
     const underlyingSettlement = await getAssociatedTokenAddress(this.addresses.underlyingTokenMint, user.address, true)
 
     return this.program.methods
@@ -335,19 +335,25 @@ export class FixedTermMarket {
     const ticketSettlement = await getAssociatedTokenAddress(this.addresses.ticketMint, user.address, true)
     const marketUser = await this.deriveMarginUserAddress(user)
     const ticketCollateral = await this.deriveTicketCollateral(marketUser)
-    const tokenCollateral = await this.deriveTokenCollateral(marketUser)
+    const underlyingCollateral = await this.deriveUnderlyingCollateral(marketUser)
     const claims = await this.deriveMarginUserClaims(marketUser)
     const underlyingSettlement = await getAssociatedTokenAddress(this.addresses.underlyingTokenMint, user.address, true)
     return this.program.methods
       .settle()
       .accounts({
-        ...this.addresses,
+        // ...this.addresses,
         marginUser: marketUser,
         marginAccount: user.address,
-        ticketCollateral,
-        tokenCollateral,
+        market: this.addresses.market,
         tokenProgram: TOKEN_PROGRAM_ID,
         claims,
+        claimsMint: this.addresses.claimsMint,
+        ticketCollateral,
+        ticketCollateralMint: this.addresses.ticketCollateralMint,
+        underlyingCollateral: underlyingCollateral,
+        underlyingCollateralMint: this.addresses.underlyingCollateralMint,
+        underlyingTokenVault: this.addresses.underlyingTokenVault,
+        ticketMint: this.addresses.ticketMint,
         underlyingSettlement,
         ticketSettlement
       })
@@ -491,7 +497,7 @@ export class FixedTermMarket {
     return await findFixedTermDerivedAccount(["ticket_collateral_notes", marginUser], this.program.programId)
   }
 
-  async deriveTokenCollateral(marginUser: Address): Promise<PublicKey> {
+  async deriveUnderlyingCollateral(marginUser: Address): Promise<PublicKey> {
     return await findFixedTermDerivedAccount(["underlying_collateral_notes", marginUser], this.program.programId)
   }
 

--- a/packages/margin/src/idls/jetFixedTerm.ts
+++ b/packages/margin/src/idls/jetFixedTerm.ts
@@ -1439,12 +1439,12 @@ export const IDL: JetFixedTermIDL = {
           isSigner: false
         },
         {
-          name: "tokenCollateral",
+          name: "underlyingCollateral",
           isMut: true,
           isSigner: false
         },
         {
-          name: "tokenCollateralMint",
+          name: "underlyingCollateralMint",
           isMut: true,
           isSigner: false
         },

--- a/ts-types/idls/jetFixedTerm.d.ts
+++ b/ts-types/idls/jetFixedTerm.d.ts
@@ -1389,84 +1389,100 @@ type JetFixedTermIDL = {
     {
       name: "settle"
       docs: ["Settle payments to a margin account"]
-      accounts: [
+      "accounts": [
         {
-          name: "marginUser"
-          isMut: true
-          isSigner: false
-          docs: ["The account tracking information related to this particular user"]
+          "name": "marginUser",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The account tracking information related to this particular user"
+          ]
         },
         {
-          name: "marginAccount"
-          isMut: false
-          isSigner: false
-          docs: ["use accounting_invoke"]
+          "name": "marginAccount",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "use accounting_invoke"
+          ]
         },
         {
-          name: "market"
-          isMut: false
-          isSigner: false
-          docs: ["The `Market` account tracks global information related to this particular fixed term market"]
+          "name": "market",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The `Market` account tracks global information related to this particular fixed term market"
+          ]
         },
         {
-          name: "tokenProgram"
-          isMut: false
-          isSigner: false
-          docs: ["SPL token program"]
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "SPL token program"
+          ]
         },
         {
-          name: "claims"
-          isMut: true
-          isSigner: false
-          docs: ["Token account used by the margin program to track the debt that must be collateralized"]
+          "name": "claims",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Token account used by the margin program to track the debt that must be collateralized"
+          ]
         },
         {
-          name: "claimsMint"
-          isMut: true
-          isSigner: false
-          docs: ["Token mint used by the margin program to track the debt that must be collateralized"]
+          "name": "claimsMint",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Token mint used by the margin program to track the debt that must be collateralized"
+          ]
         },
         {
-          name: "ticketCollateral"
-          isMut: true
-          isSigner: false
+          "name": "ticketCollateral",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "ticketCollateralMint"
-          isMut: true
-          isSigner: false
+          "name": "ticketCollateralMint",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "tokenCollateral"
-          isMut: true
-          isSigner: false
+          "name": "underlyingCollateral",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "tokenCollateralMint"
-          isMut: true
-          isSigner: false
+          "name": "underlyingCollateralMint",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "underlyingTokenVault"
-          isMut: true
-          isSigner: false
+          "name": "underlyingTokenVault",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "ticketMint"
-          isMut: true
-          isSigner: false
+          "name": "ticketMint",
+          "isMut": true,
+          "isSigner": false
         },
         {
-          name: "underlyingSettlement"
-          isMut: true
-          isSigner: false
-          docs: ["Where to receive owed tokens"]
+          "name": "underlyingSettlement",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Where to receive owed tokens"
+          ]
         },
         {
-          name: "ticketSettlement"
-          isMut: true
-          isSigner: false
-          docs: ["Where to receive owed tickets"]
+          "name": "ticketSettlement",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Where to receive owed tickets"
+          ]
         }
       ]
       args: []


### PR DESCRIPTION
The Settle button on the UI was only transferring tokens into pools, but not settling markets. We've added an instruction to now do this.