### PR TITLE
Derive term loan addresses from margin user addresses

### DIFF
--- a/libraries/rust/margin/src/fixed_term/event_consumer.rs
+++ b/libraries/rust/margin/src/fixed_term/event_consumer.rs
@@ -464,7 +464,7 @@ impl MarketState {
                     .to_le_bytes()
                     .to_vec();
 
-                let loan_account = Some(self.builder.term_loan_key(&info.margin_account, seed));
+                let loan_account = Some(self.builder.term_loan_key(&info.margin_user, seed));
 
                 tracing::debug!(
                     owner = ?info.margin_account,

--- a/programs/fixed-term/src/orderbook/instructions/consume_events/queue_iterator.rs
+++ b/programs/fixed-term/src/orderbook/instructions/consume_events/queue_iterator.rs
@@ -94,12 +94,7 @@ impl<'a, 'info> EventIterator<'a, 'info> {
                     Some(TermAccount::Loan(self.accounts.init_next::<TermLoan>(
                         self.payer.to_account_info(),
                         self.system_program.to_account_info(),
-                        &[
-                            crate::seeds::TERM_LOAN,
-                            self.market.as_ref(),
-                            info.margin_account.as_ref(),
-                            &seed,
-                        ],
+                        &TermLoan::seeds(self.market.as_ref(), info.margin_user.as_ref(), &seed),
                     )?))
                 } else {
                     None


### PR DESCRIPTION
Change the consume_events instruction and crank to use the margin user address as when deriving the term loan address, to be consistent with other code.

Currently we have on mainnet a mix of term loans derived based on either the margin account or the margin user. This is because of an inconsistency within the program, it uses a different standard in different places. This is not a security issue, but it introduces unnecessary complexity into clients when they are looking for term loans.

The root cause is that the margin borrow instruction creates term loans with a pda derived from the margin user, and the consume events instruction creates term loans with a pda derived from the margin account. All the libraries and most of the client code is written to use a margin user for this derivation, so it's a more straightforward code change if we consider that the "correct" standard and to converge on it as the sole approach.

current outstanding term loans:

- 30 day market DLeHf5H681zaJRTBx5anwXn3FNg8tLKnuHLgKKFjU3xZ
  - 1 derived from margin user
  - 1 derived from margin account
- 30 day market 7eESDQVJVJS5jddr7wnUo5tjTWDidQqDWJvPvJNgHHrd
  - 1 derived from margin user
- 1 day market 8uTjgPj2Y399J9kQQ1D7E3jVe54R228E8wJEHeimQpmw
  - 2 derived from margin account
