### PR TITLE
stop using min_context_slot in SolanaRpc::get_multiple_accounts

### DIFF
--- a/libraries/rust/solana-client/src/rpc/native.rs
+++ b/libraries/rust/solana-client/src/rpc/native.rs
@@ -109,13 +109,11 @@ impl SolanaRpc for RpcConnection {
         &self,
         pubkeys: &[Pubkey],
     ) -> ClientResult<Vec<Option<Account>>> {
-        let slot = self.get_slot().await?;
-
         self.rpc
             .get_multiple_accounts_with_config(
                 pubkeys,
                 RpcAccountInfoConfig {
-                    min_context_slot: Some(slot),
+                    min_context_slot: None,
                     commitment: Some(CommitmentConfig::processed()),
                     ..Default::default()
                 },


### PR DESCRIPTION
This fixes a source of frequent errors (at least 1 per minute) in the liquidator. There is nothing I can do in the liquidator code to avoid these errors, short of replacing the RPC client implementation.

```
solana client error: RPC response error -32016: Minimum context slot has not been reached 
```

For all the other get requests, we're using None here. It's just get_multiple_accounts where we're setting this. I don't see any reason why this request should get special treatment

I also can't imagine any scenario where there is an advantage to setting the minimum slot to whatever the same RPC node just told us was the latest slot. If we're trusting them for the first slot response, why not trust them for the second? For a basic RPC node, this constraint should actually have no effect whatsoever, because the slot will never go backwards.

However, RPC nodes may be implemented with load balancing to multiple RPC nodes behind the scenes. Depending on how they balance the requests, the first request may go to some node X that is slightly ahead of the node Y that received the second request. Then we're trusting X to represent what the latest slot is, so we reject the response from node Y. But if the first request happened to go to Y, then our client would assume everything is perfectly fine. So this restriction is just causing requests to fail at random with errors that are completely outside our control.