### PR TITLE
allow a constant amount of equity loss in a liquidation

### DIFF
--- a/libraries/rust/program-common/src/number_128.rs
+++ b/libraries/rust/program-common/src/number_128.rs
@@ -90,19 +90,29 @@ impl Number128 {
 
     /// Convert another integer
     pub fn from_decimal(value: impl Into<i128>, exponent: impl Into<i32>) -> Self {
-        let extra_precision = PRECISION + exponent.into();
+        Self::const_from_decimal(value.into(), exponent.into())
+    }
+
+    /// Convert another integer at compile-time
+    pub const fn const_from_decimal(value: i128, exponent: i32) -> Self {
+        let extra_precision = PRECISION + exponent;
         let prec_value = POWERS_OF_TEN[extra_precision.unsigned_abs() as usize];
 
         if extra_precision < 0 {
-            Self(value.into() / prec_value)
+            Self(value / prec_value)
         } else {
-            Self(value.into() * prec_value)
+            Self(value * prec_value)
         }
     }
 
     /// Convert from basis points
     pub fn from_bps(basis_points: u16) -> Self {
-        Self::from_decimal(basis_points, crate::BPS_EXPONENT)
+        Self::const_from_bps(basis_points.into())
+    }
+
+    /// Convert from basis points at compile-time
+    pub const fn const_from_bps(basis_points: i128) -> Self {
+        Self::const_from_decimal(basis_points, crate::BPS_EXPONENT)
     }
 
     /// Get the underlying 128-bit representation in bytes.

--- a/programs/margin/src/instructions/liquidate_begin.rs
+++ b/programs/margin/src/instructions/liquidate_begin.rs
@@ -22,8 +22,8 @@ use jet_program_common::Number128;
 use crate::{
     events,
     syscall::{sys, Sys},
-    ErrorCode, Liquidation, LiquidationState, MarginAccount, Permissions, Permit,
-    LIQUIDATION_MAX_EQUITY_LOSS_CONSTANT, LIQUIDATION_MAX_EQUITY_LOSS_PROPORTION_BPS, Valuation,
+    ErrorCode, Liquidation, LiquidationState, MarginAccount, Permissions, Permit, Valuation,
+    LIQUIDATION_MAX_EQUITY_LOSS_CONSTANT, LIQUIDATION_MAX_EQUITY_LOSS_PROPORTION_BPS,
 };
 
 #[derive(Accounts)]
@@ -113,7 +113,8 @@ pub fn liquidate_begin_handler(ctx: Context<LiquidateBegin>) -> Result<()> {
 }
 
 pub fn max_equity_loss(valuation: &Valuation) -> Number128 {
-    const M: Number128 = Number128::const_from_bps(LIQUIDATION_MAX_EQUITY_LOSS_PROPORTION_BPS as i128);
+    const M: Number128 =
+        Number128::const_from_bps(LIQUIDATION_MAX_EQUITY_LOSS_PROPORTION_BPS as i128);
     const B: Number128 =
         Number128::const_from_decimal(LIQUIDATION_MAX_EQUITY_LOSS_CONSTANT as i128, 0);
     M * valuation.liabilities + B

--- a/programs/margin/src/lib.rs
+++ b/programs/margin/src/lib.rs
@@ -58,9 +58,18 @@ pub const MAX_ORACLE_STALENESS: i64 = 30;
 #[constant]
 pub const MAX_PRICE_QUOTE_AGE: u64 = 30;
 
-/// The maximum amount of equity that can be deducted from an account during liquidation
-/// as a fraction of the account's entire liabilities value
-pub const LIQUIDATION_MAX_TOTAL_EQUITY_LOSS_BPS: u16 = 4_00;
+/// The maximum amount of equity that can be deducted from an account during
+/// liquidation as a proportion of the account's entire liabilities value. This
+/// is the degree-1 coefficient (slope) in the linear equation defining max
+/// equity loss.
+#[constant]
+pub const LIQUIDATION_MAX_EQUITY_LOSS_PROPORTION_BPS: u16 = 4_00;
+
+/// The constant dollar value that is always allowed to be lost during
+/// liquidation. This is the constant term in the linear equation defining max
+/// equity loss.
+#[constant]
+pub const LIQUIDATION_MAX_EQUITY_LOSS_CONSTANT: u64 = 1;
 
 /// The maximum duration in seconds of a liquidation before another user may cancel it
 #[constant]


### PR DESCRIPTION
Currently, the max equity loss is calculated as a proportion of the size of the liabilities, as in

`max_equity_loss = equity_loss_ratio * liabilities`

This change adds a positive constant term to that linear formula, and sets the constant to $1

`max_equity_loss = equity_loss_ratio * liabilities + $1`

With the current approach, as the size of the liabilities approaches zero, so does the max equity loss. This makes it difficult to clean up dust. Once positions are below some threshold, the liquidator should bring them all the way down to zero and repay as much debt as possible, rather than leaving pointless amounts of dust that can cause the account to become unhealthy again.

It's unnecessary to require a liquidator to go to great lengths being careful about how to move individual pennies around. The loss of up to $1 should be well within the bounds of a reasonable fee applied to the margin account for imposing liquidity risk to the margin system and effort on the liquidator. Plus, allowing the liquidator some flexibility here will reduce the burden on the liquidator to liquidate low-valued accounts.

This change allows the liquidator to mindlessly round-up transactions, or eliminate entire dust positions, so there is no possibility of an account's health constantly tripping over a dust position.
