### PR TITLE
fix(ui): don't prevent withdrawing 0 collateral tokens

### DIFF
--- a/apps/react-app/src/utils/risk.ts
+++ b/apps/react-app/src/utils/risk.ts
@@ -39,17 +39,21 @@ export function useProjectedRisk(
   const defaultActionProjection = account?.riskIndicator ?? 0;
 
   if (max && amount.gt(max)) {
+    // If the account has no liabilities, then the risk is 0
+    if ((marginAccount?.valuation.liabilities ?? 0) == 0) {
+      return 0;
+    }
     return Infinity;
   }
   const projectedRiskIndicator = canProjectAfterAction
     ? pool.projectAfterAction(
-        account,
-        amount.tokens,
-        action,
-        minAmountOut && minAmountOut.tokens,
-        outputToken,
-        swapRepayWithProceeds
-      ).riskIndicator
+      account,
+      amount.tokens,
+      action,
+      minAmountOut && minAmountOut.tokens,
+      outputToken,
+      swapRepayWithProceeds
+    ).riskIndicator
     : defaultActionProjection;
 
   return projectedRiskIndicator;

--- a/packages/margin/src/margin/marginAccount.ts
+++ b/packages/margin/src/margin/marginAccount.ts
@@ -671,6 +671,10 @@ export class MarginAccount {
       this.valuation.availableSetupCollateral / depositNoteValueModifier / tokenPrice,
       decimals
     )
+    // A user could have tokens that do not count as collateral, they should be able to withdraw them
+    if (pool.depositNoteMetadata.valueModifier === 0) {
+      withdraw = TokenAmount.max(withdraw, depositBalance);
+    }
     withdraw = TokenAmount.min(withdraw, depositBalance)
     withdraw = TokenAmount.min(withdraw, pool.vault)
     withdraw = TokenAmount.max(withdraw, zero)


### PR DESCRIPTION
We were determining the withdrawable amount of a user based on the influence of their token balance on their remaining available collateral.
There is however an edge case where a user might not have any collateral due to having tokens that don't count as such.
Users with just those tokens were unable to withdraw after depositing. This fixes that.